### PR TITLE
Add besluit-type plugin

### DIFF
--- a/ember-rdfa-editor-lblod-plugins/config/environment.js
+++ b/ember-rdfa-editor-lblod-plugins/config/environment.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = function (/* environment, appConfig */) {
+  return {
+    besluitTypePlugin: {
+      endpoint: 'https://centrale-vindplaats.lblod.info/sparql',
+    },
+  };
+};

--- a/ember-rdfa-editor-lblod-plugins/package.json
+++ b/ember-rdfa-editor-lblod-plugins/package.json
@@ -34,7 +34,10 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0",
-    "ember-cli-string-helpers": "^6.1.0"
+    "buffer": "^6.0.3",
+    "ember-cli-string-helpers": "^6.1.0",
+    "fetch-sparql-endpoint": "^3.0.0",
+    "process": "0.11.10"
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",
@@ -44,6 +47,7 @@
     "@babel/plugin-syntax-decorators": "^7.17.0",
     "@embroider/addon-dev": "^2.0.0",
     "@rollup/plugin-babel": "^5.3.0",
+    "@rollup/plugin-inject": "^4.0.3",
     "concurrently": "^7.2.1",
     "ember-concurrency": "^2.2.0",
     "ember-intl": "^5.7.2",
@@ -70,6 +74,8 @@
     "type": "addon",
     "main": "addon-main.js",
     "app-js": {
+      "./components/besluit-type-plugin/besluit-type-select.js": "./dist/_app_/components/besluit-type-plugin/besluit-type-select.js",
+      "./components/besluit-type-plugin/toolbar-dropdown.js": "./dist/_app_/components/besluit-type-plugin/toolbar-dropdown.js",
       "./components/citaten-plugin/citaat-card.js": "./dist/_app_/components/citaten-plugin/citaat-card.js",
       "./components/citaten-plugin/citaat-insert.js": "./dist/_app_/components/citaten-plugin/citaat-insert.js",
       "./components/citaten-plugin/citations/article-list.js": "./dist/_app_/components/citaten-plugin/citations/article-list.js",

--- a/ember-rdfa-editor-lblod-plugins/rollup.config.js
+++ b/ember-rdfa-editor-lblod-plugins/rollup.config.js
@@ -1,6 +1,7 @@
 import babel from '@rollup/plugin-babel';
 import copy from 'rollup-plugin-copy';
 import { Addon } from '@embroider/addon-dev/rollup';
+import inject from '@rollup/plugin-inject';
 
 const addon = new Addon({
   srcDir: 'src',
@@ -21,6 +22,7 @@ export default {
       'initializers/**/*.js',
       'services/**/*.js',
       'models/**/*.js',
+      'config/**/*.js',
     ]),
 
     // These are the modules that should get reexported into the traditional
@@ -31,6 +33,7 @@ export default {
       'initializers/**/*.js',
       'services/**/*.js',
       'models/**/*.js',
+      'config/**/*.js',
     ]),
 
     // This babel config should *not* apply presets or compile away ES modules.
@@ -64,6 +67,11 @@ export default {
         { src: '../README.md', dest: '.' },
         { src: '../LICENSE.md', dest: '.' },
       ],
+    }),
+    inject({
+      Buffer: ['buffer', 'Buffer'],
+      process: 'process/browser',
+      include: '../**/node_modules/**/*.js',
     }),
   ],
 };

--- a/ember-rdfa-editor-lblod-plugins/src/components/besluit-type-plugin/besluit-type-select.hbs
+++ b/ember-rdfa-editor-lblod-plugins/src/components/besluit-type-plugin/besluit-type-select.hbs
@@ -1,0 +1,28 @@
+<div ...attributes>
+  <PowerSelect
+    @renderInPlace={{true}}
+    @searchEnabled={{true}}
+    @searchMessage={{t "besluit-type-plugin.search-message"}}
+    @noMatchesMessage={{t "besluit-type-plugin.no-matches-message"}}
+    @search={{this.search}}
+    @options={{this.besluitTypes}}
+    @selected={{@selected}}
+    @onChange={{@onchange}} as |besluitType|>
+    {{besluitType.label}}
+  </PowerSelect>
+  <p class='au-u-muted au-u-margin-tiny au-u-margin-bottom-small'>
+    {{@selected.definition}}
+  </p>
+  {{#if @showWarningWhenEmpty}}
+    {{#unless @selected}}
+      <AuAlert
+        @icon="alert-triangle"
+        @title={{t "besluit-type-plugin.alert-title"}}
+        @skin="warning"
+        @size="small"
+        class="au-u-margin-bottom-none au-u-margin-top-small">
+      <p>{{t "besluit-type-plugin.alert-body"}}</p>
+      </AuAlert>
+    {{/unless}}
+  {{/if}}
+</div>

--- a/ember-rdfa-editor-lblod-plugins/src/components/besluit-type-plugin/besluit-type-select.js
+++ b/ember-rdfa-editor-lblod-plugins/src/components/besluit-type-plugin/besluit-type-select.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class BesluitTypePluginBesluitTypeSelectComponent extends Component {
+  @tracked besluitTypes;
+  constructor() {
+    super(...arguments);
+    this.besluitTypes = this.args.besluitTypes.sort((a, b) =>
+      a.label > b.label ? 1 : -1
+    );
+  }
+
+  @action
+  search(term) {
+    const lowerTerm = term.toLowerCase();
+    return this.args.besluitTypes.filter((besluitType) =>
+      besluitType.label.toLowerCase().includes(lowerTerm)
+    );
+  }
+}

--- a/ember-rdfa-editor-lblod-plugins/src/components/besluit-type-plugin/toolbar-dropdown.hbs
+++ b/ember-rdfa-editor-lblod-plugins/src/components/besluit-type-plugin/toolbar-dropdown.hbs
@@ -1,0 +1,83 @@
+{{#if this.showCard}}
+  {{#if this.loadDataTaskInstance.isError}}
+    <AuPill
+      @skin="error"
+      @icon="circle-x"
+      @iconAlignment="left"
+      class="au-c-pill--link"
+      {{on "click" this.toggleCard}}>
+      {{t "besluit-type-plugin.error-short"}}
+    </AuPill>
+  {{else}}
+    {{#if this.besluit.label}}
+      <AuPill
+        @skin="link"
+        {{on "click" this.toggleCard}}>
+        {{t "besluit-type-plugin.dt"}}: {{this.besluit.label}}
+      </AuPill>
+    {{else}}
+      <AuPill
+        @icon="alert-triangle"
+        @iconAlignment="left"
+        @skin="link"
+        {{on "click" this.toggleCard}}>
+        {{t "besluit-type-plugin.insert-dt"}}
+      </AuPill>
+    {{/if}}
+  {{/if}}
+{{/if}}
+{{#if this.cardExpanded}}
+  <AuModal
+    @title={{t "besluit-type-plugin.insert-dt"}}
+    @closeModal={{this.toggleCard}}
+    @modalOpen={{true}}
+    @size='default'
+    class="au-c-modal--overflow"
+    as |Modal|>
+    <Modal.Body>
+      {{#if this.loadDataTaskInstance.isError}}
+        <AuAlert
+          @title={{t "besluit-type-plugin.error-title"}}
+          @skin="error"
+          @icon="cross">
+          <p>
+            {{t "besluit-type-plugin.error-first-body"}}
+{{!-- template-lint-disable no-bare-strings  --}}
+            <AuLinkExternal
+              href="mailto:gelinktnotuleren@vlaanderen.be"
+              @icon="mail"
+              @iconAlignment="left">
+              GelinktNotuleren@vlaanderen.be
+            </AuLinkExternal>
+{{!-- template-lint-enable no-bare-strings  --}}
+            {{t "besluit-type-plugin.error-rest-body"}}
+          </p>
+        </AuAlert>
+      {{else}}
+        <BesluitTypePlugin::BesluitTypeSelect
+          @besluitTypes={{this.types}}
+          @onchange={{this.updateBesluitType}}
+          @selected={{this.besluit}}
+          @showWarningWhenEmpty={{false}}/>
+        {{#if this.besluit.subTypes.length}}
+          <AuHr @size="large"/>
+          <BesluitTypePlugin::BesluitTypeSelect
+            @besluitTypes={{this.besluit.subTypes}}
+            @onchange={{this.updateBesluitSubType}}
+            @selected={{this.subBesluit}}
+            @showWarningWhenEmpty={{true}}
+            class="au-u-padding-left au-u-padding-right"/>
+        {{/if}}
+        {{#if this.subBesluit.subTypes.length}}
+          <AuHr @size="large"/>
+          <BesluitTypePlugin::BesluitTypeSelect
+            @besluitTypes={{this.subBesluit.subTypes}}
+            @onchange={{this.updateBesluitSubSubType}}
+            @selected={{this.subSubBesluit}}
+            @showWarningWhenEmpty={{true}}
+            class="au-u-padding-left au-u-padding-right"/>
+        {{/if}}
+      {{/if}}
+    </Modal.Body>
+  </AuModal>
+{{/if}}

--- a/ember-rdfa-editor-lblod-plugins/src/components/besluit-type-plugin/toolbar-dropdown.js
+++ b/ember-rdfa-editor-lblod-plugins/src/components/besluit-type-plugin/toolbar-dropdown.js
@@ -1,0 +1,188 @@
+import { tracked } from '@glimmer/tracking';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
+import { getOwner } from '@ember/application';
+import fetchBesluitTypes from '../../utils/fetchBesluitTypes';
+import { inject as service } from '@ember/service';
+
+export default class BesluitTypePluginToolbarDropdownComponent extends Component {
+  @service currentSession;
+
+  /**
+   * Actual besluit type selected
+   * @property besluitType
+   * @type BesluitType
+   * @private
+   */
+  @tracked besluitType;
+  @tracked previousBesluitType;
+  @tracked types = [];
+
+  //used to update selections since the other vars dont seem to work in octane
+  @tracked besluit;
+  @tracked subBesluit;
+  @tracked subSubBesluit;
+
+  @tracked cardExpanded = false;
+  @tracked showCard = false;
+
+  @tracked loadDataTaskInstance;
+
+  constructor(...args) {
+    super(...args);
+    this.loadDataTaskInstance = this.loadData.perform();
+    this.args.controller.onEvent('selectionChanged', this.getBesluitType);
+  }
+
+  @task
+  *loadData() {
+    const bestuurseenheid = yield this.currentSession.get('group');
+    const classificatie = yield bestuurseenheid.get('classificatie');
+    const ENV = getOwner(this).resolveRegistration('config:environment');
+    const types = yield fetchBesluitTypes(classificatie.uri, ENV);
+    this.types = types;
+  }
+
+  @action
+  getBesluitType() {
+    const selectedRange = this.args.controller.selection.lastRange;
+    if (!selectedRange) {
+      return;
+    }
+    const limitedDatastore = this.args.controller.datastore.limitToRange(
+      selectedRange,
+      'rangeIsInside'
+    );
+    const besluit = limitedDatastore
+      .match(null, 'a', '>http://data.vlaanderen.be/ns/besluit#Besluit')
+      .asQuads()
+      .next().value;
+    if (!besluit) {
+      this.showCard = false;
+      return;
+    }
+    this.showCard = true;
+    const besluitUri = besluit.subject.value;
+    const besluitTypes = limitedDatastore
+      .match(`>${besluitUri}`, 'a', null)
+      .asQuads();
+    const besluitTypesUris = [...besluitTypes].map((quad) => quad.object.value);
+    const besluitTypeRelevant = besluitTypesUris.find((type) =>
+      type.includes('https://data.vlaanderen.be/id/concept/BesluitType/')
+    );
+    this.besluitNode = [
+      ...limitedDatastore
+        .match(`>${besluitUri}`, 'a', null)
+        .asSubjectNodes()
+        .next().value.nodes,
+    ][0];
+    if (besluitTypeRelevant) {
+      this.previousBesluitType = besluitTypeRelevant;
+      const besluitType = this.findBesluitTypeByURI(besluitTypeRelevant);
+
+      const firstAncestor = this.findBesluitTypeParent(besluitType);
+      const secondAncestor = this.findBesluitTypeParent(firstAncestor);
+      if (firstAncestor && secondAncestor) {
+        this.besluit = secondAncestor;
+        this.subBesluit = firstAncestor;
+        this.subSubBesluit = besluitType;
+      } else if (firstAncestor) {
+        this.besluit = firstAncestor;
+        this.subBesluit = besluitType;
+        this.subSubBesluit = undefined;
+      } else {
+        this.besluit = besluitType;
+        this.subBesluit = undefined;
+        this.subSubBesluit = undefined;
+      }
+      this.cardExpanded = false;
+    } else {
+      this.cardExpanded = true;
+      this.besluit = undefined;
+      this.subBesluit = undefined;
+      this.subSubBesluit = undefined;
+    }
+  }
+
+  @action
+  updateBesluitType(selected) {
+    this.besluit = selected;
+    this.besluitType = selected;
+    this.subBesluit = null;
+    this.subSubBesluit = null;
+    if (!selected.subTypes || !selected.subTypes.length) this.insert();
+  }
+
+  @action
+  updateBesluitSubType(selected) {
+    this.subBesluit = selected;
+    this.besluitType = selected;
+    this.subSubBesluit = null;
+    if (!selected.subTypes || !selected.subTypes.length) this.insert();
+  }
+
+  @action
+  updateBesluitSubSubType(selected) {
+    this.subSubBesluit = selected;
+    this.besluitType = selected;
+    if (!selected.subTypes || !selected.subTypes.length) this.insert();
+  }
+
+  findBesluitTypeParent(besluitType, array = this.types, parent = null) {
+    if (!besluitType || !array) {
+      return null;
+    }
+    for (let i = 0; i < array.length; i++) {
+      if (array[i] == besluitType) {
+        return parent;
+      } else if (array[i].subTypes && array[i].subTypes.length) {
+        parent = array[i];
+        return this.findBesluitTypeParent(
+          besluitType,
+          array[i].subTypes,
+          parent
+        );
+      }
+    }
+    return null;
+  }
+
+  findBesluitTypeByURI(uri, types = this.types) {
+    if (uri) {
+      for (const besluitType of types) {
+        if (besluitType.uri === uri) {
+          return besluitType;
+        } else if (besluitType.subTypes && besluitType.subTypes.length) {
+          const subType = this.findBesluitTypeByURI(uri, besluitType.subTypes);
+          if (subType) {
+            return subType;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  insert() {
+    this.cardExpanded = false;
+    if (this.previousBesluitType) {
+      this.besluitNode = this.args.controller.executeCommand(
+        'remove-type',
+        this.previousBesluitType,
+        this.besluitNode
+      );
+    }
+
+    this.args.controller.executeCommand(
+      'add-type',
+      this.besluitType.uri,
+      this.besluitNode
+    );
+  }
+
+  @action
+  toggleCard() {
+    this.cardExpanded = !this.cardExpanded;
+  }
+}

--- a/ember-rdfa-editor-lblod-plugins/src/initializers/plugin-initializer.js
+++ b/ember-rdfa-editor-lblod-plugins/src/initializers/plugin-initializer.js
@@ -1,3 +1,4 @@
+import BesluitTypePlugin from '../plugins/besluit-type-plugin';
 import CitatenPlugin from '../plugins/citaten-plugin';
 
 function pluginFactory(plugin) {
@@ -11,9 +12,14 @@ function pluginFactory(plugin) {
 }
 
 export function initialize(application) {
-  application.register('plugin:citaten-plugin', pluginFactory(CitatenPlugin), {
+  application.register('plugin:citaten', pluginFactory(CitatenPlugin), {
     singleton: false,
   });
+  application.register(
+    'plugin:besluit-type',
+    pluginFactory(BesluitTypePlugin),
+    { singleton: false }
+  );
 }
 
 export default {

--- a/ember-rdfa-editor-lblod-plugins/src/plugins/besluit-type-plugin.js
+++ b/ember-rdfa-editor-lblod-plugins/src/plugins/besluit-type-plugin.js
@@ -1,0 +1,16 @@
+export default class BesluitTypePlugin {
+  controller;
+
+  get name() {
+    return 'besluit-type';
+  }
+
+  initialize(controller) {
+    this.controller = controller;
+    controller.registerWidget({
+      componentName: 'besluit-type-plugin/toolbar-dropdown',
+      identifier: 'besluit-type-plugin/dropdown',
+      desiredLocation: 'toolbar',
+    });
+  }
+}

--- a/ember-rdfa-editor-lblod-plugins/src/plugins/citaten-plugin.js
+++ b/ember-rdfa-editor-lblod-plugins/src/plugins/citaten-plugin.js
@@ -3,14 +3,14 @@ export default class CitatenPlugin {
   controller;
 
   get name() {
-    return 'citaten-plugin';
+    return 'citaten';
   }
   async initialize(controller) {
     this.controller = controller;
     controller.registerWidget({
       desiredLocation: 'sidebar',
       componentName: 'citaten-plugin/citaat-card',
-      identifier: 'citaten-plugincitaat-card',
+      identifier: 'citaten-plugin/citaat-card',
     });
     controller.registerWidget({
       desiredLocation: 'insertSidebar',

--- a/ember-rdfa-editor-lblod-plugins/src/utils/fetchBesluitTypes.js
+++ b/ember-rdfa-editor-lblod-plugins/src/utils/fetchBesluitTypes.js
@@ -1,0 +1,90 @@
+import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
+
+export default async function fetchBesluitTypes(classificationUri, ENV) {
+  const query = `
+    PREFIX                    conceptscheme: <https://data.vlaanderen.be/id/conceptscheme/>
+    PREFIX                      BesluitType: <https://data.vlaanderen.be/id/concept/BesluitType/>
+    PREFIX              BesluitDocumentType: <https://data.vlaanderen.be/id/concept/BesluitDocumentType/>
+    PREFIX                             skos: <http://www.w3.org/2004/02/skos/core#>
+    PREFIX                              xsd: <http://www.w3.org/2001/XMLSchema#>
+    PREFIX                              rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX                             core: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX                          besluit: <http://lblod.data.gift/vocabularies/besluit/>
+    PREFIX BestuurseenheidClassificatieCode: <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/>
+    PREFIX                              sch: <http://schema.org/>
+    PREFIX                             rule: <http://lblod.data.gift/vocabularies/notification/>
+    PREFIX                        lblodRule: <http://data.lblod.info/id/notification-rule/>
+
+    SELECT ?s ?p ?o WHERE {
+      ?s skos:inScheme conceptscheme:BesluitType ;
+         besluit:notificationRule ?rule .
+      ?rule besluit:decidableBy <${classificationUri}> .
+      OPTIONAL { ?rule sch:validFrom ?validFrom . }
+      OPTIONAL { ?rule sch:validThrough ?validThrough . }
+      BIND(now() AS ?currentTime) .
+      BIND(STRLEN(STR(?validFrom)) > 0 AS ?validFromExists) .
+      BIND(STRLEN(STR(?validThrough)) > 0 AS ?validThroughExists) .
+      FILTER(
+        ((?validFromExists && ?validThroughExists) && (?currentTime < ?validThrough && ?currentTime >= ?validFrom)) ||
+        ((!?validFromExists && ?validThroughExists) && (?currentTime < ?validThrough)) ||
+        ((?validFromExists && !?validThroughExists) && (?currentTime >= ?validFrom))
+      ) .
+      ?s ?p ?o .
+      VALUES ?p {
+        skos:prefLabel
+        skos:definition
+        skos:broader
+      }
+    }
+  `;
+  const typeFetcher = new SparqlEndpointFetcher({
+    method: 'POST',
+  });
+  const endpoint = ENV.besluitTypePlugin.endpoint;
+  const bindingStream = await typeFetcher.fetchBindings(endpoint, query);
+  const validBesluitTriples = [];
+  bindingStream.on('data', (triple) => {
+    validBesluitTriples.push(triple);
+  });
+  return new Promise((resolve, reject) => {
+    bindingStream.on('error', reject);
+    bindingStream.on('end', () => {
+      resolve(validBesluitTriples);
+    });
+  }).then(quadsToBesluitTypeObjects);
+}
+
+function quadsToBesluitTypeObjects(triples) {
+  const besluitTypes = new Map();
+  triples.forEach((triple) => {
+    const existing = besluitTypes.get(triple.s.value) || {
+      uri: triple.s.value,
+    };
+    switch (triple.p.value) {
+      case 'http://www.w3.org/2004/02/skos/core#definition':
+        existing.definition = triple.o.value;
+        break;
+      case 'http://www.w3.org/2004/02/skos/core#prefLabel':
+        existing.label = triple.o.value;
+        break;
+      case 'http://www.w3.org/2004/02/skos/core#broader':
+        existing.broader = triple.o.value;
+        break;
+    }
+    besluitTypes.set(triple.s.value, existing);
+  });
+  return createBesluitTypeObjectsHierarchy([...besluitTypes.values()]);
+}
+
+function createBesluitTypeObjectsHierarchy(allBesluitTypes) {
+  const besluitTypes = allBesluitTypes.filter((bst) => !bst.broader);
+  const subTypes = allBesluitTypes.filter((bst) => !!bst.broader);
+  subTypes.forEach((subtype) => {
+    //Use allBesluitTypes to find the parent. This means no tree recursive search process, but we can still create trees of multiple levels deep.
+    const parent = allBesluitTypes.find((type) => type.uri === subtype.broader);
+    if (parent)
+      if (parent.subTypes) parent.subTypes.push(subtype);
+      else parent.subTypes = [subtype];
+  });
+  return besluitTypes;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,10 @@
       "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.0.0",
-        "ember-cli-string-helpers": "^6.1.0"
+        "buffer": "^6.0.3",
+        "ember-cli-string-helpers": "^6.1.0",
+        "fetch-sparql-endpoint": "^3.0.0",
+        "process": "0.11.10"
       },
       "devDependencies": {
         "@babel/core": "^7.17.0",
@@ -35,6 +38,7 @@
         "@babel/plugin-syntax-decorators": "^7.17.0",
         "@embroider/addon-dev": "^2.0.0",
         "@rollup/plugin-babel": "^5.3.0",
+        "@rollup/plugin-inject": "^4.0.3",
         "concurrently": "^7.2.1",
         "ember-concurrency": "^2.2.0",
         "ember-intl": "^5.7.2",
@@ -5140,6 +5144,58 @@
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
+    "node_modules/@rollup/plugin-inject": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.4.tgz",
+      "integrity": "sha512-4pbcU4J/nS+zuHk+c+OL3WtmEQhqxlZ9uqfjQMQDOHOPld7PsCd8k5LWs8h5wjwJN7MgnAn768F2sDxEP4eNFQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "estree-walker": "^2.0.1",
+        "magic-string": "^0.25.7"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-inject/node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-inject/node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-inject/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-inject/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -5413,6 +5469,20 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
+    "node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/@types/rimraf": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.5.tgz",
@@ -5430,6 +5500,14 @@
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/sparqljs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.3.tgz",
+      "integrity": "sha512-nmFgmR6ns4i8sg9fYu+293H+PMLKmDOZy34sgwgAeUEEiIqSs4guj5aCZRt3gq1g0yuKXkqrxLDq/684g7pGtQ==",
+      "dependencies": {
+        "rdf-js": "^4.0.2"
       }
     },
     "node_modules/@types/symlink-or-copy": {
@@ -5716,6 +5794,17 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.5",
@@ -9947,7 +10036,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11783,6 +11871,33 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
       "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -20501,7 +20616,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -21332,6 +21446,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -21968,6 +22090,30 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-sparql-endpoint": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-3.1.1.tgz",
+      "integrity": "sha512-SWb/d70+VTQmS+7th1ZgT05Kx6RMCsBoLv//oO29SObqDfzU0amxJ0EdMvoIKRgxWsbpZX423aS/NWHK1VhAIg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.11",
+        "@types/sparqljs": "^3.1.3",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.0.6",
+        "is-stream": "^2.0.0",
+        "minimist": "^1.2.0",
+        "n3": "^1.6.3",
+        "rdf-string": "^1.6.0",
+        "readable-web-to-node-stream": "^3.0.2",
+        "sparqljs": "^3.1.2",
+        "sparqljson-parse": "^2.1.0",
+        "sparqlxml-parse": "^2.0.0",
+        "stream-to-string": "^1.1.0"
+      },
+      "bin": {
+        "fetch-sparql-endpoint": "bin/fetch-sparql-endpoint.js"
       }
     },
     "node_modules/figgy-pudding": {
@@ -23622,7 +23768,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -24902,6 +25047,14 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "engines": [
+        "node >= 0.2.0"
+      ]
     },
     "node_modules/keyv": {
       "version": "4.5.2",
@@ -26777,6 +26930,32 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/n3": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.3.tgz",
+      "integrity": "sha512-9caLSZuMW1kdlPxEN4ka6E4E8a5QKoZ2emxpW+zHMofI+Bo92nJhN//wNub15S5T9I4c6saEqdGEu+YXJqMZVA==",
+      "dependencies": {
+        "queue-microtask": "^1.1.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/n3/node_modules/readable-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
@@ -28541,6 +28720,11 @@
         "rsvp": "^3.0.14"
       }
     },
+    "node_modules/promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha512-7rrONfyLkDEc7OJ5QBkqa4KI4EBhCd340xRuIUPGCfu13znS+vx+VDdrT9ODAJHlXm7w4lbxN3DRjyv58EuzDg=="
+    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -28795,7 +28979,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -28980,6 +29163,23 @@
         "@rdfjs/types": "*"
       }
     },
+    "node_modules/rdf-js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
+      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.1.tgz",
+      "integrity": "sha512-EDNVQs9jDgm4hkY8TZLhQI3rYUduecMRxLu3szldAdS2CHEo8aFqlHcZDFgBcaJN2XJWoRJU8YQT85wmb8gPEA==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -29017,6 +29217,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/readdirp": {
@@ -30821,6 +31036,85 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/sparqljs": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.6.1.tgz",
+      "integrity": "sha512-4QoI3cMywOio8mtTLa3Rl85XI7UBvQRm1CbzbHEQ7C6AN6ldBFsSS96vkhcKCQKPl0eDTmCXsi+50234+1cOpA==",
+      "dependencies": {
+        "rdf-data-factory": "^1.1.1"
+      },
+      "bin": {
+        "sparqljs": "bin/sparql-to-json"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/sparqljson-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-2.1.2.tgz",
+      "integrity": "sha512-RqPeyy+RYQMeqgEsKPTY+ME5ZNXcgXJzg1v0o+tROiTntS9CwUW8mAY3wsx6seSvW3LVyNDEtsqOxnAokoGXOA==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "jsonparse": "^1.3.1",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/sparqljson-parse/node_modules/readable-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/sparqlxml-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-2.0.2.tgz",
+      "integrity": "sha512-Iqso0WSTCSuMUYoX2pOEJxteCq9U+7AkOqwlFcvFG1S1aM87xWrp28njQOIiyIrL7Y8CkVXBZG1ec+DhZYUNXA==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0",
+        "saxes": "^6.0.0"
+      }
+    },
+    "node_modules/sparqlxml-parse/node_modules/readable-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/sparqlxml-parse/node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/spawn-args": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/spawn-args/-/spawn-args-0.2.0.tgz",
@@ -31108,6 +31402,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "node_modules/stream-to-string": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.0.tgz",
+      "integrity": "sha512-8drZlFIKBHSMdX9GCWv8V9AAWnQcTqw0iAI6/GC7UJ0H0SwKeFKjOoZfGY1tOU00GGU7FYZQoJ/ZCUEoXhD7yQ==",
+      "dependencies": {
+        "promise-polyfill": "^1.1.6"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -32105,8 +32407,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tracked-built-ins": {
       "version": "3.1.0",
@@ -33334,8 +33635,7 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
       "version": "5.75.0",
@@ -33473,7 +33773,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -33813,8 +34112,7 @@
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "node_modules/xregexp": {
       "version": "2.0.0",
@@ -38028,6 +38326,53 @@
         }
       }
     },
+    "@rollup/plugin-inject": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.4.tgz",
+      "integrity": "sha512-4pbcU4J/nS+zuHk+c+OL3WtmEQhqxlZ9uqfjQMQDOHOPld7PsCd8k5LWs8h5wjwJN7MgnAn768F2sDxEP4eNFQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "estree-walker": "^2.0.1",
+        "magic-string": "^0.25.7"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          },
+          "dependencies": {
+            "estree-walker": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+              "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+              "dev": true
+            }
+          }
+        },
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.25.9",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+          "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.8"
+          }
+        }
+      }
+    },
     "@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -38278,6 +38623,22 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
+    "@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "requires": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "@types/rimraf": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.5.tgz",
@@ -38295,6 +38656,14 @@
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/sparqljs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.3.tgz",
+      "integrity": "sha512-nmFgmR6ns4i8sg9fYu+293H+PMLKmDOZy34sgwgAeUEEiIqSs4guj5aCZRt3gq1g0yuKXkqrxLDq/684g7pGtQ==",
+      "requires": {
+        "rdf-js": "^4.0.2"
       }
     },
     "@types/symlink-or-copy": {
@@ -38581,6 +38950,14 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "abortcontroller-polyfill": {
       "version": "1.7.5",
@@ -42197,7 +42574,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -43660,6 +44036,24 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
       "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+    },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "requires": {
+        "node-fetch": "2.6.7"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -49891,6 +50285,8 @@
         "@embroider/addon-dev": "^2.0.0",
         "@embroider/addon-shim": "^1.0.0",
         "@rollup/plugin-babel": "^5.3.0",
+        "@rollup/plugin-inject": "^4.0.3",
+        "buffer": "^6.0.3",
         "concurrently": "^7.2.1",
         "ember-cli-string-helpers": "^6.1.0",
         "ember-concurrency": "^2.2.0",
@@ -49903,7 +50299,9 @@
         "eslint-plugin-ember": "^10.5.8",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.0.0",
+        "fetch-sparql-endpoint": "^3.0.0",
         "prettier": "^2.5.1",
+        "process": "0.11.10",
         "rollup": "^2.67.0",
         "rollup-plugin-copy": "^3.4.0"
       },
@@ -51017,7 +51415,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
@@ -51609,6 +52006,11 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -52134,6 +52536,27 @@
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "fetch-sparql-endpoint": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-3.1.1.tgz",
+      "integrity": "sha512-SWb/d70+VTQmS+7th1ZgT05Kx6RMCsBoLv//oO29SObqDfzU0amxJ0EdMvoIKRgxWsbpZX423aS/NWHK1VhAIg==",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.11",
+        "@types/sparqljs": "^3.1.3",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.0.6",
+        "is-stream": "^2.0.0",
+        "minimist": "^1.2.0",
+        "n3": "^1.6.3",
+        "rdf-string": "^1.6.0",
+        "readable-web-to-node-stream": "^3.0.2",
+        "sparqljs": "^3.1.2",
+        "sparqljson-parse": "^2.1.0",
+        "sparqlxml-parse": "^2.0.0",
+        "stream-to-string": "^1.1.0"
       }
     },
     "figgy-pudding": {
@@ -53478,7 +53901,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -54403,6 +54825,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
       "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
     },
     "keyv": {
       "version": "4.5.2",
@@ -55849,6 +56276,28 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "n3": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.3.tgz",
+      "integrity": "sha512-9caLSZuMW1kdlPxEN4ka6E4E8a5QKoZ2emxpW+zHMofI+Bo92nJhN//wNub15S5T9I4c6saEqdGEu+YXJqMZVA==",
+      "requires": {
+        "queue-microtask": "^1.1.2",
+        "readable-stream": "^4.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10"
+          }
+        }
+      }
+    },
     "nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
@@ -57189,6 +57638,11 @@
         "rsvp": "^3.0.14"
       }
     },
+    "promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha512-7rrONfyLkDEc7OJ5QBkqa4KI4EBhCd340xRuIUPGCfu13znS+vx+VDdrT9ODAJHlXm7w4lbxN3DRjyv58EuzDg=="
+    },
     "promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -57405,8 +57859,7 @@
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "quick-lru": {
       "version": "5.1.1",
@@ -57551,6 +58004,23 @@
         "@rdfjs/types": "*"
       }
     },
+    "rdf-js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
+      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+      "requires": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "rdf-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.1.tgz",
+      "integrity": "sha512-EDNVQs9jDgm4hkY8TZLhQI3rYUduecMRxLu3szldAdS2CHEo8aFqlHcZDFgBcaJN2XJWoRJU8YQT85wmb8gPEA==",
+      "requires": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -57581,6 +58051,14 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      }
+    },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
       }
     },
     "readdirp": {
@@ -58967,6 +59445,74 @@
         }
       }
     },
+    "sparqljs": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.6.1.tgz",
+      "integrity": "sha512-4QoI3cMywOio8mtTLa3Rl85XI7UBvQRm1CbzbHEQ7C6AN6ldBFsSS96vkhcKCQKPl0eDTmCXsi+50234+1cOpA==",
+      "requires": {
+        "rdf-data-factory": "^1.1.1"
+      }
+    },
+    "sparqljson-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-2.1.2.tgz",
+      "integrity": "sha512-RqPeyy+RYQMeqgEsKPTY+ME5ZNXcgXJzg1v0o+tROiTntS9CwUW8mAY3wsx6seSvW3LVyNDEtsqOxnAokoGXOA==",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "jsonparse": "^1.3.1",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10"
+          }
+        }
+      }
+    },
+    "sparqlxml-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-2.0.2.tgz",
+      "integrity": "sha512-Iqso0WSTCSuMUYoX2pOEJxteCq9U+7AkOqwlFcvFG1S1aM87xWrp28njQOIiyIrL7Y8CkVXBZG1ec+DhZYUNXA==",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0",
+        "saxes": "^6.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10"
+          }
+        },
+        "saxes": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+          "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+          "requires": {
+            "xmlchars": "^2.2.0"
+          }
+        }
+      }
+    },
     "spawn-args": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/spawn-args/-/spawn-args-0.2.0.tgz",
@@ -59225,6 +59771,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "stream-to-string": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.0.tgz",
+      "integrity": "sha512-8drZlFIKBHSMdX9GCWv8V9AAWnQcTqw0iAI6/GC7UJ0H0SwKeFKjOoZfGY1tOU00GGU7FYZQoJ/ZCUEoXhD7yQ==",
+      "requires": {
+        "promise-polyfill": "^1.1.6"
+      }
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -60239,8 +60793,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tracked-built-ins": {
       "version": "3.1.0",
@@ -61235,8 +61788,7 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
       "version": "5.75.0",
@@ -61344,7 +61896,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -61607,8 +62158,7 @@
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "xregexp": {
       "version": "2.0.0",

--- a/test-app/app/controllers/application.js
+++ b/test-app/app/controllers/application.js
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 
 export default class ApplicationController extends Controller {
-  plugins = ['citaten-plugin'];
+  plugins = ['citaten', 'besluit-type'];
 
   @action
   rdfaEditorInit(controller) {

--- a/test-app/app/services/current-session.js
+++ b/test-app/app/services/current-session.js
@@ -1,0 +1,12 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class CurrentSessionService extends Service {
+  @tracked group = {
+    get() {
+      return {
+        uri: 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001',
+      };
+    },
+  };
+}


### PR DESCRIPTION
This PR adds the besluit-type plugin. Currently, the plugin fails to function as the `Buffer` polyfill does not work yet. This PR tries to load the `Buffer` polyfill using the `@rollup/plugin-inject` and `buffer` packages.

- [ ] Get `Buffer` polyfill working.