### PR TITLE
Use new range-based datastore API

### DIFF
--- a/addon/commands/article-structure-plugin/insert-article-structure.ts
+++ b/addon/commands/article-structure-plugin/insert-article-structure.ts
@@ -8,7 +8,7 @@ import { findNodes } from '@lblod/ember-rdfa-editor/utils/position-utils';
 import { insertHtml } from '@lblod/ember-rdfa-editor/commands/insert-html-command';
 import recalculateStructureNumbers from './recalculate-structure-numbers';
 import { ResolvedArticleStructurePluginOptions } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
-import { getRdfaAttributes } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
+import { getRdfaAttribute } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 
 export default function insertArticleStructureV2(
   controller: ProseController,
@@ -32,7 +32,7 @@ export default function insertArticleStructureV2(
     const { selection } = controller.state;
     const filterFunction = ({ from }: { from: number }) => {
       const node = unwrap(controller.state.doc.nodeAt(from));
-      const nodeUri = getRdfaAttributes(node)?.resource;
+      const nodeUri = getRdfaAttribute(node, 'resource').pop();
       if (nodeUri && !urisNotAllowedToInsert.includes(nodeUri)) {
         return true;
       }
@@ -60,9 +60,10 @@ export default function insertArticleStructureV2(
       controller.state.doc.nodeAt(structureContainerRange.from)
     );
     if (structureTypeToAdd.insertPredicate) {
-      const structureContainerUri = getRdfaAttributes(
-        structureContainerNode
-      )?.resource;
+      const structureContainerUri = getRdfaAttribute(
+        structureContainerNode,
+        'resource'
+      ).pop();
       if (!structureContainerUri) {
         return false;
       }
@@ -113,6 +114,7 @@ export default function insertArticleStructureV2(
         from: structureContainerRange.from,
         to: structureContainerRange.from + containerNode.nodeSize,
       };
+
       controller.doCommand(
         recalculateStructureNumbers(
           controller,

--- a/addon/commands/article-structure-plugin/move-structure.ts
+++ b/addon/commands/article-structure-plugin/move-structure.ts
@@ -12,7 +12,7 @@ import {
 import recalculateStructureNumbers from './recalculate-structure-numbers';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
 import { ResolvedArticleStructurePluginOptions } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
-import { getRdfaAttributes } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
+import { getRdfaAttribute } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 export default function moveStructure(
   controller: ProseController,
   structureURI: string,
@@ -117,10 +117,10 @@ export default function moveStructure(
       const urisNotAllowedToInsert = report.results.map(
         (result) => result.focusNode?.value
       );
-      const structureContainerURI = (getRdfaAttributes(structureContainer)?.resource) ?? (getRdfaAttributes(resolvedStructurePos.node(resolvedStructurePos.depth - 1))?.resource);
+      const structureContainerURI = (getRdfaAttribute(structureContainer, 'resource').pop()) ?? (getRdfaAttribute(resolvedStructurePos.node(resolvedStructurePos.depth - 1), 'resource').pop());
       const filterFunction = ({ from }: { from: number }) => {
         const node = unwrap(controller.state.doc.nodeAt(from));
-        const nodeUri = getRdfaAttributes(node)?.resource;
+        const nodeUri = getRdfaAttribute(node, 'resource').pop();
         if(structureContainerURI === nodeUri) {
           return false;
         }
@@ -139,10 +139,10 @@ export default function moveStructure(
       }
       const newStructureContainerNode = unwrap(controller.state.doc.nodeAt(newStructureContainerRange.from));
 
-      const newStructureContainerURI = getRdfaAttributes(newStructureContainerNode)?.resource;
+      const newStructureContainerURI = getRdfaAttribute(newStructureContainerNode, 'resource').pop();
       // Check if there is a specific predicate container we need to insert inside
       if (currentStructureSpec.insertPredicate) {
-        newStructureContainerRange = findChildren(controller.state.doc, newStructureContainerRange.from, false, false, ({ from }) => getRdfaAttributes(unwrap(controller.state.doc.nodeAt(from)))?.property === currentStructureSpec.insertPredicate?.short).next().value;
+        newStructureContainerRange = findChildren(controller.state.doc, newStructureContainerRange.from, false, false, ({ from }) => getRdfaAttribute(unwrap(controller.state.doc.nodeAt(from)), 'property').pop() === currentStructureSpec.insertPredicate?.short).next().value;
       }
       if(!newStructureContainerRange){
         return false;

--- a/addon/commands/article-structure-plugin/move-structure.ts
+++ b/addon/commands/article-structure-plugin/move-structure.ts
@@ -174,8 +174,6 @@ export default function moveStructure(
           return tr;
         });
         
-        console.log('ORIGINAL URI: ', structureContainerURI);
-        console.log('NEW URI: ', newStructureContainerURI);
         const originalContainerRange = unwrap([...controller.datastore.match(`>${structureContainerURI as string}`).asSubjectNodeMapping().nodes()][0]);
         const newContainerRange = unwrap([...controller.datastore.match(`>${newStructureContainerURI as string}`).asSubjectNodeMapping().nodes()][0]);
         controller.doCommand(

--- a/addon/commands/article-structure-plugin/recalculate-structure-numbers.ts
+++ b/addon/commands/article-structure-plugin/recalculate-structure-numbers.ts
@@ -2,12 +2,11 @@ import { ProseController } from '@lblod/ember-rdfa-editor';
 import defaults from '@lblod/ember-rdfa-editor-lblod-plugins/utils/article-structure-plugin/defaults';
 import { Command } from 'prosemirror-state';
 import { ProseStore } from '@lblod/ember-rdfa-editor/utils/datastore/prose-store';
-import { expect, unwrap } from '@lblod/ember-rdfa-editor/utils/option';
+import { expect } from '@lblod/ember-rdfa-editor/utils/option';
 import {
   ResolvedArticleStructurePluginOptions,
   StructureSpec,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
-import { getRdfaAttribute } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 
 export default function recalculateStructureNumbers(
   controller: ProseController,
@@ -22,12 +21,13 @@ export default function recalculateStructureNumbers(
         datastore = controller.datastore.limitToRange(
           controller.state,
           containerRange.from,
-          containerRange.to
+          containerRange.to,
+          'rangeContains'
         );
       } else {
         datastore = controller.datastore;
       }
-      const structures = [
+      const structureMatch = [
         ...datastore
           .match(null, 'a', `>${structureType.type}`)
           .transformDataset((dataset) => {
@@ -35,17 +35,17 @@ export default function recalculateStructureNumbers(
               return options.structureTypes.includes(quad.object.value);
             });
           })
-          .asPredicateNodeMapping()
-          .nodes(),
+          .asSubjectNodeMapping(),
       ];
-      if (!structures) return true;
-      // Temporary workaround: for some reason structures contains each structure twice.
-      const structuresFiltered = structures.filter(
-        (node, index) => index === structures.indexOf(node)
-      );
-      for (let i = 0; i < structuresFiltered.length; i++) {
-        const structure = unwrap(structuresFiltered[i]);
-        replaceNumberIfNeeded(controller, structure, i, structureType);
+      const structures = structureMatch.map((match) => {
+        return {
+          uri: match.term.value,
+          range: match.nodes[0],
+        };
+      });
+      if (!structures.length) return true;
+      for (let i = 0; i < structures.length; i++) {
+        replaceNumberIfNeeded(controller, structures[i], i, structureType);
       }
     }
     return true;
@@ -54,28 +54,22 @@ export default function recalculateStructureNumbers(
 
 function replaceNumberIfNeeded(
   controller: ProseController,
-  structure: { from: number; to: number },
+  structure: { range: { from: number; to: number }; uri: string },
   index: number,
   structureType: StructureSpec
 ) {
   const numberPredicate =
     structureType.numberPredicate || defaults.numberPredicate;
-  const resource = unwrap(
-    getRdfaAttribute(
-      unwrap(controller.state.doc.nodeAt(structure.from)),
-      'resource'
-    ).pop()
-  );
   let structureNumberObjectNode = controller.datastore
-    .match(`>${resource}`, `>${numberPredicate}`)
+    .match(`>${structure.uri}`, `>${numberPredicate}`)
     .asObjectNodeMapping()
     .single();
   structureNumberObjectNode = expect(
-    `${resource} expected to have the predicate ${numberPredicate}`,
+    `${structure.uri} expected to have the predicate ${numberPredicate}`,
     structureNumberObjectNode
   );
   const structureNumber = structureNumberObjectNode.term.value;
-  const structureNumberElement = [...structureNumberObjectNode.nodes][0];
+  const structureNumberElement = structureNumberObjectNode.nodes[0];
   if (!structureNumberElement) {
     throw new Error('Could not find object node');
   }
@@ -87,13 +81,8 @@ function replaceNumberIfNeeded(
   }
   if (structureNumber !== structureNumberExpected) {
     const { from, to } = structureNumberElement;
-    const insertRange = { from: from + 1, to: to - 1 };
     controller.withTransaction((tr) => {
-      return tr.insertText(
-        String(structureNumberExpected),
-        insertRange.from,
-        insertRange.to
-      );
+      return tr.insertText(String(structureNumberExpected), from, to);
     });
   }
 }

--- a/addon/commands/article-structure-plugin/recalculate-structure-numbers.ts
+++ b/addon/commands/article-structure-plugin/recalculate-structure-numbers.ts
@@ -1,15 +1,13 @@
 import { ProseController } from '@lblod/ember-rdfa-editor';
 import defaults from '@lblod/ember-rdfa-editor-lblod-plugins/utils/article-structure-plugin/defaults';
 import { Command } from 'prosemirror-state';
-import {
-  ProseStore,
-  ResolvedPNode,
-} from '@lblod/ember-rdfa-editor/utils/datastore/prose-store';
+import { ProseStore } from '@lblod/ember-rdfa-editor/utils/datastore/prose-store';
 import { expect, unwrap } from '@lblod/ember-rdfa-editor/utils/option';
 import {
   ResolvedArticleStructurePluginOptions,
   StructureSpec,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
+import { getRdfaAttributes } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 
 export default function recalculateStructureNumbers(
   controller: ProseController,
@@ -56,13 +54,16 @@ export default function recalculateStructureNumbers(
 
 function replaceNumberIfNeeded(
   controller: ProseController,
-  structure: ResolvedPNode,
+  structure: { from: number; to: number },
   index: number,
   structureType: StructureSpec
 ) {
   const numberPredicate =
     structureType.numberPredicate || defaults.numberPredicate;
-  const resource = structure.node.attrs['resource'] as string;
+  const resource = unwrap(
+    getRdfaAttributes(unwrap(controller.state.doc.nodeAt(structure.from)))
+      ?.resource
+  );
   let structureNumberObjectNode = controller.datastore
     .match(`>${resource}`, `>${numberPredicate}`)
     .asObjectNodeMapping()
@@ -83,8 +84,8 @@ function replaceNumberIfNeeded(
     structureNumberExpected = (index + 1).toString();
   }
   if (structureNumber !== structureNumberExpected) {
-    const { pos, node } = structureNumberElement;
-    const insertRange = { from: pos + 1, to: pos + node.nodeSize - 1 };
+    const { from, to } = structureNumberElement;
+    const insertRange = { from: from + 1, to: to - 1 };
     controller.withTransaction((tr) => {
       return tr.insertText(
         String(structureNumberExpected),

--- a/addon/commands/article-structure-plugin/recalculate-structure-numbers.ts
+++ b/addon/commands/article-structure-plugin/recalculate-structure-numbers.ts
@@ -7,7 +7,7 @@ import {
   ResolvedArticleStructurePluginOptions,
   StructureSpec,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
-import { getRdfaAttributes } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
+import { getRdfaAttribute } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 
 export default function recalculateStructureNumbers(
   controller: ProseController,
@@ -61,8 +61,10 @@ function replaceNumberIfNeeded(
   const numberPredicate =
     structureType.numberPredicate || defaults.numberPredicate;
   const resource = unwrap(
-    getRdfaAttributes(unwrap(controller.state.doc.nodeAt(structure.from)))
-      ?.resource
+    getRdfaAttribute(
+      unwrap(controller.state.doc.nodeAt(structure.from)),
+      'resource'
+    ).pop()
   );
   let structureNumberObjectNode = controller.datastore
     .match(`>${resource}`, `>${numberPredicate}`)

--- a/addon/commands/besluit-plugin/get-article-nodes-for-besluit.ts
+++ b/addon/commands/besluit-plugin/get-article-nodes-for-besluit.ts
@@ -5,7 +5,6 @@ export default function getArticleNodesForBesluit(
   controller: ProseController,
   besluitUri?: string
 ) {
-  let besluitRange: { from: number; to: number } | undefined;
   if (!besluitUri) {
     const selection = controller.state.selection;
     besluitUri = controller.datastore
@@ -17,7 +16,6 @@ export default function getArticleNodesForBesluit(
   if (!besluitUri) {
     return;
   }
-  console.log('RANGE: ', besluitRange);
   const articles = controller.datastore
     .match(`>${besluitUri}`, 'eli:has_part')
     .asObjectNodeMapping();

--- a/addon/commands/besluit-plugin/get-article-nodes-for-besluit.ts
+++ b/addon/commands/besluit-plugin/get-article-nodes-for-besluit.ts
@@ -5,9 +5,9 @@ export default function getArticleNodesForBesluit(
   controller: ProseController,
   besluitUri?: string
 ) {
-  let besluitNode: ResolvedPNode | undefined;
+  let besluitRange: ResolvedPNode | undefined;
   if (besluitUri) {
-    besluitNode = [
+    besluitRange = [
       ...controller.datastore
         .match(`>${besluitUri}`)
         .asSubjectNodeMapping()
@@ -15,7 +15,7 @@ export default function getArticleNodesForBesluit(
     ][0];
   } else {
     const selection = controller.state.selection;
-    besluitNode = [
+    besluitRange = [
       ...controller.datastore
         .limitToRange(controller.state, selection.from, selection.to)
         .match(null, 'a', 'besluit:Besluit')
@@ -23,13 +23,9 @@ export default function getArticleNodesForBesluit(
         .nodes(),
     ][0];
   }
-  if (!besluitNode) {
+  if (!besluitRange) {
     return;
   }
-  const besluitRange = {
-    from: besluitNode.pos,
-    to: besluitNode.pos + besluitNode.node.nodeSize,
-  };
   return [
     ...controller.datastore
       .limitToRange(controller.state, besluitRange.from, besluitRange.to)

--- a/addon/commands/besluit-plugin/get-article-nodes-for-besluit.ts
+++ b/addon/commands/besluit-plugin/get-article-nodes-for-besluit.ts
@@ -6,30 +6,21 @@ export default function getArticleNodesForBesluit(
   besluitUri?: string
 ) {
   let besluitRange: { from: number; to: number } | undefined;
-  if (besluitUri) {
-    besluitRange = [
-      ...controller.datastore
-        .match(`>${besluitUri}`)
-        .asSubjectNodeMapping()
-        .nodes(),
-    ][0];
-  } else {
+  if (!besluitUri) {
     const selection = controller.state.selection;
-    besluitRange = [
-      ...controller.datastore
-        .limitToRange(controller.state, selection.from, selection.to)
-        .match(null, 'a', 'besluit:Besluit')
-        .asSubjectNodeMapping()
-        .nodes(),
-    ][0];
+    besluitUri = controller.datastore
+      .limitToRange(controller.state, selection.from, selection.to)
+      .match(null, 'a', 'besluit:Besluit')
+      .asQuadResultSet()
+      .first()?.subject.value;
   }
-  if (!besluitRange) {
+  if (!besluitUri) {
     return;
   }
+  console.log('RANGE: ', besluitRange);
   const articles = controller.datastore
-    .limitToRange(controller.state, besluitRange.from, besluitRange.to)
-    .match(null, 'a', 'besluit:Artikel')
-    .asSubjectNodeMapping();
+    .match(`>${besluitUri}`, 'eli:has_part')
+    .asObjectNodeMapping();
   return [
     ...articles.map((article) => {
       return {

--- a/addon/commands/besluit-plugin/insert-article.ts
+++ b/addon/commands/besluit-plugin/insert-article.ts
@@ -19,17 +19,24 @@ export default function insertArticle(
       .match(null, 'a', '>http://data.vlaanderen.be/ns/besluit#Besluit')
       .asQuadResultSet()
       .first()?.subject;
+    console.log('BESLUIT SUBJECT: ', besluitSubject);
 
     if (!besluitSubject) {
       return false;
     }
-
+    const container = [
+      ...controller.datastore
+        .match(besluitSubject, 'prov:value')
+        .asPredicateNodeMapping(),
+    ][0];
+    console.log('CONTAINER: ', container);
     const containerRange = [
       ...controller.datastore
         .match(besluitSubject, 'prov:value')
-        .asPredicateNodeMapping()
-        .nodes(),
-    ][0];
+        .asPredicateNodeMapping(),
+    ][0].nodes[0];
+
+    console.log('CONTAINER RANGE: ', containerRange);
 
     if (!containerRange) {
       return false;

--- a/addon/commands/besluit-plugin/insert-article.ts
+++ b/addon/commands/besluit-plugin/insert-article.ts
@@ -8,7 +8,7 @@ export default function insertArticle(
   articleContent: string,
   articleNumber: string
 ): Command {
-  return function (state, dispatch) {
+  return function (_state, dispatch) {
     const selection = controller.state.selection;
     const limitedDatastore = controller.datastore.limitToRange(
       controller.state,
@@ -24,20 +24,20 @@ export default function insertArticle(
       return false;
     }
 
-    const containerNode = [
+    const containerRange = [
       ...controller.datastore
         .match(besluitSubject, 'prov:value')
         .asPredicateNodeMapping()
         .nodes(),
     ][0];
 
-    if (!containerNode) {
+    if (!containerRange) {
       return false;
     }
     if (dispatch) {
       const range = {
-        from: containerNode.pos + containerNode.node.nodeSize - 1,
-        to: containerNode.pos + containerNode.node.nodeSize - 1,
+        from: containerRange.to - 1,
+        to: containerRange.to - 1,
       };
       const articleUri = `http://data.lblod.info/artikels/${uuid()}`;
       const articleHtml = `

--- a/addon/commands/besluit-plugin/insert-article.ts
+++ b/addon/commands/besluit-plugin/insert-article.ts
@@ -19,24 +19,16 @@ export default function insertArticle(
       .match(null, 'a', '>http://data.vlaanderen.be/ns/besluit#Besluit')
       .asQuadResultSet()
       .first()?.subject;
-    console.log('BESLUIT SUBJECT: ', besluitSubject);
 
     if (!besluitSubject) {
       return false;
     }
-    const container = [
-      ...controller.datastore
-        .match(besluitSubject, 'prov:value')
-        .asPredicateNodeMapping(),
-    ][0];
-    console.log('CONTAINER: ', container);
     const containerRange = [
       ...controller.datastore
         .match(besluitSubject, 'prov:value')
         .asPredicateNodeMapping(),
     ][0].nodes[0];
 
-    console.log('CONTAINER RANGE: ', containerRange);
 
     if (!containerRange) {
       return false;

--- a/addon/commands/besluit-plugin/insert-article.ts
+++ b/addon/commands/besluit-plugin/insert-article.ts
@@ -29,7 +29,6 @@ export default function insertArticle(
         .asPredicateNodeMapping(),
     ][0].nodes[0];
 
-
     if (!containerRange) {
       return false;
     }

--- a/addon/commands/besluit-plugin/insert-title.ts
+++ b/addon/commands/besluit-plugin/insert-title.ts
@@ -23,7 +23,7 @@ export default function insertTitle(
         .asSubjectNodeMapping(),
     ][0];
 
-    const besluitRange = besluit.nodes[0];
+    const besluitRange = besluit?.nodes[0];
 
     if (!besluit || !besluitRange) {
       return false;

--- a/addon/commands/besluit-plugin/insert-title.ts
+++ b/addon/commands/besluit-plugin/insert-title.ts
@@ -16,19 +16,22 @@ export default function insertTitle(
       selection.from,
       selection.to
     );
-    const besluitNode = [
+
+    const besluit = [
       ...limitedDatastore
         .match(null, 'a', 'besluit:Besluit')
-        .asSubjectNodeMapping()
-        .nodes(),
+        .asSubjectNodeMapping(),
     ][0];
 
-    if (!besluitNode) {
+    const besluitRange = besluit.nodes[0];
+
+    if (!besluit || !besluitRange) {
       return false;
     }
+
     const titleQuad = controller.datastore
       .match(
-        `>${besluitNode.node.attrs['resource'] as string}`,
+        `>${besluit.term.value}`,
         '>http://data.europa.eu/eli/ontology#title'
       )
       .asQuadResultSet()
@@ -39,8 +42,8 @@ export default function insertTitle(
 
     if (dispatch) {
       const range = {
-        from: besluitNode.pos + 1,
-        to: besluitNode.pos + 1,
+        from: besluitRange.from + 1,
+        to: besluitRange.from + 1,
       };
       const articleHtml = `
       <h4 class="h4" property="eli:title" datatype="xsd:string">${

--- a/addon/commands/besluit-plugin/move-article.ts
+++ b/addon/commands/besluit-plugin/move-article.ts
@@ -17,6 +17,7 @@ export default function moveArticleCommand(
 ): Command {
   return (_state, dispatch) => {
     const articles = getArticleNodesForBesluit(controller, besluitUri);
+    console.log('ARTICLES: ', articles);
     if (!articles) {
       return false;
     }

--- a/addon/commands/besluit-plugin/move-article.ts
+++ b/addon/commands/besluit-plugin/move-article.ts
@@ -20,10 +20,7 @@ export default function moveArticleCommand(
     if (!articles) {
       return false;
     }
-    const articleIndex = articles.findIndex(
-      ({ from }) =>
-        controller.state.doc.nodeAt(from)?.attrs['resource'] === articleUri
-    );
+    const articleIndex = articles.findIndex(({ uri }) => uri === articleUri);
 
     if (
       articleIndex === -1 ||
@@ -38,11 +35,11 @@ export default function moveArticleCommand(
       let articleB: ResolvedPNode;
 
       if (moveUp) {
-        articleA = unwrap(articles[articleIndex - 1]);
-        articleB = unwrap(articles[articleIndex]);
+        articleA = unwrap(articles[articleIndex - 1]).range;
+        articleB = unwrap(articles[articleIndex]).range;
       } else {
-        articleA = unwrap(articles[articleIndex]);
-        articleB = unwrap(articles[articleIndex + 1]);
+        articleA = unwrap(articles[articleIndex]).range;
+        articleB = unwrap(articles[articleIndex + 1]).range;
       }
       const articleBNode = unwrap(controller.state.doc.nodeAt(articleB.from));
       controller.withTransaction((tr) => {

--- a/addon/commands/besluit-plugin/move-article.ts
+++ b/addon/commands/besluit-plugin/move-article.ts
@@ -17,7 +17,6 @@ export default function moveArticleCommand(
 ): Command {
   return (_state, dispatch) => {
     const articles = getArticleNodesForBesluit(controller, besluitUri);
-    console.log('ARTICLES: ', articles);
     if (!articles) {
       return false;
     }

--- a/addon/commands/besluit-plugin/recalculate-article-numbers.ts
+++ b/addon/commands/besluit-plugin/recalculate-article-numbers.ts
@@ -1,5 +1,4 @@
 import { ProseController } from '@lblod/ember-rdfa-editor';
-import { ResolvedPNode } from '@lblod/ember-rdfa-editor/addon/plugins/datastore';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
 import getArticleNodesForBesluit from './get-article-nodes-for-besluit';
 
@@ -18,20 +17,12 @@ export default function recalculateArticleNumbers(
 
 function replaceNumberIfNeeded(
   controller: ProseController,
-  article: ResolvedPNode,
+  article: { uri: string; range: { from: number; to: number } },
   index: number
 ) {
-  const articleURI = controller.state.doc.nodeAt(article.from)?.attrs[
-    'resource'
-  ] as string | undefined;
-  if (!articleURI) {
-    throw new Error(
-      `Article URI not found for range { from: ${article.from}, to: ${article.to} }`
-    );
-  }
   const articleNumberObject = [
     ...controller.datastore
-      .match(`>${articleURI}`, '>http://data.europa.eu/eli/ontology#number')
+      .match(`>${article.uri}`, '>http://data.europa.eu/eli/ontology#number')
       .asObjectNodeMapping(),
   ][0];
   if (!articleNumberObject) {

--- a/addon/commands/besluit-plugin/recalculate-article-numbers.ts
+++ b/addon/commands/besluit-plugin/recalculate-article-numbers.ts
@@ -36,8 +36,8 @@ function replaceNumberIfNeeded(
     controller.withTransaction((tr) => {
       return tr.insertText(
         articleNumberExpected.toString(),
-        articleNumberRange.from + 1,
-        articleNumberRange.to - 1
+        articleNumberRange.from,
+        articleNumberRange.to
       );
     });
   }

--- a/addon/commands/modify-date-command.ts
+++ b/addon/commands/modify-date-command.ts
@@ -1,4 +1,5 @@
-import { Command } from '@lblod/ember-rdfa-editor';
+import { Command, Mark } from '@lblod/ember-rdfa-editor';
+import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
 
 function formatDate(date: Date, onlyDate: boolean) {
   const options: Intl.DateTimeFormatOptions = {
@@ -22,12 +23,25 @@ export default function modifyDate(
   return function (state, dispatch) {
     if (dispatch) {
       const transaction = state.tr;
-      transaction.setNodeAttribute(
-        from - 1,
-        'content',
-        dateValue.toISOString()
-      );
+      const node = unwrap(transaction.doc.nodeAt(from));
+      const currentRdfaMark = node.marks
+        .filter((mark) => mark.type.name === 'inline_rdfa')
+        .at(-1);
+      if (currentRdfaMark) {
+        transaction.removeMark(from, to, currentRdfaMark);
+      }
+
+      const newMark: Mark = currentRdfaMark
+        ? state.schema.mark('inline_rdfa', {
+            ...currentRdfaMark.attrs,
+            content: dateValue.toISOString(),
+          })
+        : state.schema.mark('inline_rdfa', {
+            content: dateValue.toISOString(),
+          });
+
       transaction.insertText(formatDate(dateValue, onlyDate), from, to);
+      transaction.addMark(from, to, newMark);
       dispatch(transaction);
     }
     return true;

--- a/addon/commands/modify-date-command.ts
+++ b/addon/commands/modify-date-command.ts
@@ -39,9 +39,8 @@ export default function modifyDate(
         : state.schema.mark('inline_rdfa', {
             content: dateValue.toISOString(),
           });
-
-      transaction.insertText(formatDate(dateValue, onlyDate), from, to);
       transaction.addMark(from, to, newMark);
+      transaction.insertText(formatDate(dateValue, onlyDate), from, to);
       dispatch(transaction);
     }
     return true;

--- a/addon/components/article-structure-plugin/article-structure-card.ts
+++ b/addon/components/article-structure-plugin/article-structure-card.ts
@@ -7,6 +7,8 @@ import IntlService from 'ember-intl/services/intl';
 import { trackedFunction } from 'ember-resources/util/function';
 import validateDatastore from '@lblod/ember-rdfa-editor-lblod-plugins/utils/article-structure-plugin/validate-datastore';
 import { ResolvedArticleStructurePluginOptions } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
+import { getRdfaAttributes } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
+import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
 
 type Args = {
   controller: ProseController;
@@ -82,9 +84,9 @@ export default class EditorPluginsArticleStructureCardComponent extends Componen
     ) {
       const structure = documentMatches.nodes.pop();
       if (structure) {
-        const uri = this.args.controller.state.doc.nodeAt(structure.from)
-          ?.attrs['resource'] as string | undefined;
-        return uri;
+        return getRdfaAttributes(
+          unwrap(this.args.controller.state.doc.nodeAt(structure.from))
+        )?.resource;
       }
     }
     return;

--- a/addon/components/article-structure-plugin/article-structure-card.ts
+++ b/addon/components/article-structure-plugin/article-structure-card.ts
@@ -82,7 +82,9 @@ export default class EditorPluginsArticleStructureCardComponent extends Componen
     ) {
       const structure = documentMatches.nodes.pop();
       if (structure) {
-        return structure.node.attrs['resource'] as string;
+        const uri = this.args.controller.state.doc.nodeAt(structure.from)
+          ?.attrs['resource'] as string | undefined;
+        return uri;
       }
     }
     return;

--- a/addon/components/article-structure-plugin/article-structure-card.ts
+++ b/addon/components/article-structure-plugin/article-structure-card.ts
@@ -7,8 +7,6 @@ import IntlService from 'ember-intl/services/intl';
 import { trackedFunction } from 'ember-resources/util/function';
 import validateDatastore from '@lblod/ember-rdfa-editor-lblod-plugins/utils/article-structure-plugin/validate-datastore';
 import { ResolvedArticleStructurePluginOptions } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
-import { getRdfaAttributes } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
-import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
 
 type Args = {
   controller: ProseController;
@@ -73,23 +71,10 @@ export default class EditorPluginsArticleStructureCardComponent extends Componen
       currentSelection.to
     );
 
-    const documentMatches = limitedDatastore
+    return limitedDatastore
       .match(null, 'a', '>https://say.data.gift/ns/DocumentSubdivision')
-      .asPredicateNodeMapping()
-      .single();
-    if (
-      documentMatches &&
-      documentMatches.nodes &&
-      documentMatches.nodes.length
-    ) {
-      const structure = documentMatches.nodes.pop();
-      if (structure) {
-        return getRdfaAttributes(
-          unwrap(this.args.controller.state.doc.nodeAt(structure.from))
-        )?.resource;
-      }
-    }
-    return;
+      .asQuadResultSet()
+      .first()?.subject.value;
   }
 
   get isOutsideStructure() {

--- a/addon/components/besluit-plugin/besluit-context-card.hbs
+++ b/addon/components/besluit-plugin/besluit-context-card.hbs
@@ -1,4 +1,4 @@
-{{#if this.activeArticleNode}}
+{{#if this.activeArticle}}
   <AuCard
     @shadow={{true}}
     @size="flush" as |c|>

--- a/addon/components/besluit-plugin/besluit-context-card.ts
+++ b/addon/components/besluit-plugin/besluit-context-card.ts
@@ -5,9 +5,11 @@ import {
   moveArticle,
   recalculateArticleNumbers,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/commands/besluit-plugin';
-import { ResolvedPNode } from '@lblod/ember-rdfa-editor/addon/plugins/datastore';
+import { ResolvedPNode } from '@lblod/ember-rdfa-editor/plugins/datastore';
 import { DecisionOptions } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-plugin';
 import { ProseController } from '@lblod/ember-rdfa-editor';
+import { getRdfaAttributes } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
+import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
 
 interface ContextCardWidgetArgs {
   options?: DecisionOptions;
@@ -27,6 +29,10 @@ export default class BesluitContextCardComponent extends Component<Args> {
 
   get controller() {
     return this.args.controller;
+  }
+
+  get doc() {
+    return this.controller.state.doc;
   }
   focus() {
     this.controller.focus();
@@ -135,9 +141,8 @@ export default class BesluitContextCardComponent extends Component<Args> {
 
   get activeArticleURI() {
     if (this.activeArticle) {
-      return this.controller.state.doc.nodeAt(this.activeArticle.from)?.attrs[
-        'resource'
-      ] as string;
+      return getRdfaAttributes(unwrap(this.doc.nodeAt(this.activeArticle.from)))
+        ?.resource;
     }
     return;
   }

--- a/addon/components/besluit-type-plugin/toolbar-dropdown.ts
+++ b/addon/components/besluit-type-plugin/toolbar-dropdown.ts
@@ -13,7 +13,7 @@ import { ProseController } from '@lblod/ember-rdfa-editor/core/prosemirror';
 import CurrentSessionService from '@lblod/frontend-gelinkt-notuleren/services/current-session';
 import { ResolvedPNode } from '@lblod/ember-rdfa-editor/plugins/datastore';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
-import { getRdfaAttributes } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
+import { getRdfaAttribute } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 declare module 'ember__owner' {
   export default interface Owner {
     resolveRegistration(name: string): unknown;
@@ -84,7 +84,7 @@ export default class EditorPluginsToolbarDropdownComponent extends Component<Arg
   get currentBesluitURI() {
     if (this.currentBesluitRange) {
       const node = unwrap(this.doc.nodeAt(this.currentBesluitRange.from));
-      return getRdfaAttributes(node)?.resource;
+      return getRdfaAttribute(node, 'resource').pop();
     }
     return;
   }

--- a/addon/components/besluit-type-plugin/toolbar-dropdown.ts
+++ b/addon/components/besluit-type-plugin/toolbar-dropdown.ts
@@ -11,7 +11,9 @@ import {
 } from '@lblod/ember-rdfa-editor/commands/type-commands';
 import { ProseController } from '@lblod/ember-rdfa-editor/core/prosemirror';
 import CurrentSessionService from '@lblod/frontend-gelinkt-notuleren/services/current-session';
-import { ResolvedPNode } from '@lblod/ember-rdfa-editor/addon/plugins/datastore';
+import { ResolvedPNode } from '@lblod/ember-rdfa-editor/plugins/datastore';
+import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
+import { getRdfaAttributes } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 declare module 'ember__owner' {
   export default interface Owner {
     resolveRegistration(name: string): unknown;
@@ -52,6 +54,10 @@ export default class EditorPluginsToolbarDropdownComponent extends Component<Arg
     return this.args.controller;
   }
 
+  get doc() {
+    return this.controller.state.doc;
+  }
+
   loadData = task(async () => {
     // eslint-disable-next-line @typescript-eslint/await-thenable
     const bestuurseenheid = await this.currentSession.get('group');
@@ -77,10 +83,8 @@ export default class EditorPluginsToolbarDropdownComponent extends Component<Arg
 
   get currentBesluitURI() {
     if (this.currentBesluitRange) {
-      const node = this.controller.state.doc.nodeAt(
-        this.currentBesluitRange.from
-      );
-      return node?.attrs['resource'] as string;
+      const node = unwrap(this.doc.nodeAt(this.currentBesluitRange.from));
+      return getRdfaAttributes(node)?.resource;
     }
     return;
   }

--- a/addon/components/import-snippet-plugin/card.ts
+++ b/addon/components/import-snippet-plugin/card.ts
@@ -22,17 +22,18 @@ export default class ImportSnippetPluginCard extends Component<Args> {
 
   get insertRange() {
     const selection = this.controller.state.selection;
-    const besluitNode = [
+    const besluitRange = [
       ...this.controller.datastore
         .limitToRange(this.controller.state, selection.from, selection.to)
         .match(null, 'a', '>http://data.vlaanderen.be/ns/besluit#Besluit')
-        .asSubjectNodeMapping(),
-    ][0]?.nodes[0];
-    if (besluitNode) {
-      const { node, pos } = besluitNode;
+        .asSubjectNodeMapping()
+        .nodes(),
+    ][0];
+    if (besluitRange) {
+      const { to } = besluitRange;
       return {
-        from: pos + node.nodeSize - 1,
-        to: pos + node.nodeSize - 1,
+        from: to - 1,
+        to: to - 1,
       };
     } else {
       return selection;

--- a/addon/components/insert-variable-plugin/insert-variable-card.ts
+++ b/addon/components/insert-variable-plugin/insert-variable-card.ts
@@ -125,7 +125,6 @@ export default class EditorPluginsInsertCodelistCardComponent extends Component<
       .match(null, 'a', 'ext:Mapping')
       .asQuadResultSet()
       .first();
-    console.log('QUAD: ', quad);
     if (quad) {
       this.showCard = false;
     } else {

--- a/addon/components/insert-variable-plugin/insert-variable-card.ts
+++ b/addon/components/insert-variable-plugin/insert-variable-card.ts
@@ -124,7 +124,8 @@ export default class EditorPluginsInsertCodelistCardComponent extends Component<
     const quad = limitedDatastore
       .match(null, 'a', 'ext:Mapping')
       .asQuadResultSet()
-      .single();
+      .first();
+    console.log('QUAD: ', quad);
     if (quad) {
       this.showCard = false;
     } else {

--- a/addon/components/rdfa-date-plugin/card.ts
+++ b/addon/components/rdfa-date-plugin/card.ts
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import modifyDate from '../../commands/modify-date-command';
 import { ProseController } from '@lblod/ember-rdfa-editor/core/prosemirror';
 import { getRdfaAttribute } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
+import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
 type Args = {
   controller: ProseController;
 };
@@ -42,25 +43,30 @@ export default class RdfaDatePluginCardComponent extends Component<Args> {
   onSelectionChanged() {
     const selection = this.controller.state.selection;
     const from = selection.$from;
-    const currentNode = from.parent.childBefore(from.parentOffset);
-    console.log('CURRENT NODE: ', currentNode);
-    const datatypes = getRdfaAttribute(currentNode, 'datatype');
-    if (!datatypes.length) {
+    const { node: currentNode } = unwrap(
+      from.parent.childBefore(from.parentOffset)
+    );
+    if (!currentNode) {
+      return;
+    }
+    const datatype = getRdfaAttribute(currentNode, 'datatype').pop();
+    if (!datatype) {
       this.showCard = false;
       this.dateRange = undefined;
       return;
     }
     // const { node: selectionParent, pos: parentPos } = ancestor;
 
-    if (datatypes.includes('xsd:dateTime') || datatypes.includes('xsd:date')) {
+    if (datatype === 'xsd:dateTime' || datatype === 'xsd:date') {
+      console.log('INCLUDES');
       this.dateRange = {
-        from: from.start(from.depth + 1),
-        to: from.end(from.depth + 1),
+        from: from.start(),
+        to: from.end(),
       };
       const dateContent = getRdfaAttribute(currentNode, 'content').pop();
       this.dateValue = dateContent ? new Date(dateContent) : new Date();
       this.dateInDocument = !!dateContent;
-      this.onlyDate = datatypes.includes('xsd:date');
+      this.onlyDate = datatype === 'xsd:date';
       this.showCard = true;
     } else {
       this.dateRange = undefined;

--- a/addon/components/rdfa-date-plugin/card.ts
+++ b/addon/components/rdfa-date-plugin/card.ts
@@ -59,10 +59,8 @@ export default class RdfaDatePluginCardComponent extends Component<Args> {
         from: from.pos - from.textOffset,
         to: from.pos - from.textOffset + currentNode.nodeSize,
       };
-      console.log('DATE RANGE: ', this.dateRange);
       const dateContent = getRdfaAttribute(currentNode, 'content').pop();
       this.dateValue = dateContent ? new Date(dateContent) : new Date();
-      console.log('DATE VALUE: ', this.dateValue);
       this.dateInDocument = !!dateContent;
       this.onlyDate = datatype === 'xsd:date';
       this.showCard = true;

--- a/addon/components/rdfa-date-plugin/card.ts
+++ b/addon/components/rdfa-date-plugin/card.ts
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 import modifyDate from '../../commands/modify-date-command';
 import { ProseController } from '@lblod/ember-rdfa-editor/core/prosemirror';
 import { getRdfaAttribute } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
-import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
 type Args = {
   controller: ProseController;
 };

--- a/addon/components/rdfa-date-plugin/card.ts
+++ b/addon/components/rdfa-date-plugin/card.ts
@@ -43,7 +43,7 @@ export default class RdfaDatePluginCardComponent extends Component<Args> {
   onSelectionChanged() {
     const selection = this.controller.state.selection;
     const from = selection.$from;
-    const currentNode = unwrap(from.parent.child(from.index()));
+    const currentNode = from.parent.maybeChild(from.index());
     if (!currentNode) {
       return;
     }

--- a/addon/components/rdfa-date-plugin/card.ts
+++ b/addon/components/rdfa-date-plugin/card.ts
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import modifyDate from '../../commands/modify-date-command';
 import { ProseController } from '@lblod/ember-rdfa-editor/core/prosemirror';
-import { findAncestors } from '@lblod/ember-rdfa-editor/utils/position-utils';
+import { getRdfaAttribute } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 type Args = {
   controller: ProseController;
 };
@@ -42,23 +42,25 @@ export default class RdfaDatePluginCardComponent extends Component<Args> {
   onSelectionChanged() {
     const selection = this.controller.state.selection;
     const from = selection.$from;
-    const ancestor = findAncestors(from, (node) => !!node.attrs['datatype'])[0];
-    if (!ancestor) {
+    const currentNode = from.parent.childBefore(from.parentOffset);
+    console.log('CURRENT NODE: ', currentNode);
+    const datatypes = getRdfaAttribute(currentNode, 'datatype');
+    if (!datatypes.length) {
       this.showCard = false;
       this.dateRange = undefined;
       return;
     }
-    const { node: selectionParent, pos: parentPos } = ancestor;
-    const datatype = selectionParent.attrs['datatype'] as string;
-    if (datatype === 'xsd:dateTime' || datatype === 'xsd:date') {
+    // const { node: selectionParent, pos: parentPos } = ancestor;
+
+    if (datatypes.includes('xsd:dateTime') || datatypes.includes('xsd:date')) {
       this.dateRange = {
-        from: parentPos + 1,
-        to: parentPos + selectionParent.nodeSize - 1,
+        from: from.start(from.depth + 1),
+        to: from.end(from.depth + 1),
       };
-      const dateContent = selectionParent.attrs['content'] as string;
+      const dateContent = getRdfaAttribute(currentNode, 'content').pop();
       this.dateValue = dateContent ? new Date(dateContent) : new Date();
       this.dateInDocument = !!dateContent;
-      this.onlyDate = datatype === 'xsd:date';
+      this.onlyDate = datatypes.includes('xsd:date');
       this.showCard = true;
     } else {
       this.dateRange = undefined;

--- a/addon/components/rdfa-date-plugin/card.ts
+++ b/addon/components/rdfa-date-plugin/card.ts
@@ -43,9 +43,7 @@ export default class RdfaDatePluginCardComponent extends Component<Args> {
   onSelectionChanged() {
     const selection = this.controller.state.selection;
     const from = selection.$from;
-    const { node: currentNode } = unwrap(
-      from.parent.childBefore(from.parentOffset)
-    );
+    const currentNode = unwrap(from.parent.child(from.index()));
     if (!currentNode) {
       return;
     }
@@ -58,13 +56,14 @@ export default class RdfaDatePluginCardComponent extends Component<Args> {
     // const { node: selectionParent, pos: parentPos } = ancestor;
 
     if (datatype === 'xsd:dateTime' || datatype === 'xsd:date') {
-      console.log('INCLUDES');
       this.dateRange = {
-        from: from.start(),
-        to: from.end(),
+        from: from.pos - from.textOffset,
+        to: from.pos - from.textOffset + currentNode.nodeSize,
       };
+      console.log('DATE RANGE: ', this.dateRange);
       const dateContent = getRdfaAttribute(currentNode, 'content').pop();
       this.dateValue = dateContent ? new Date(dateContent) : new Date();
+      console.log('DATE VALUE: ', this.dateValue);
       this.dateInDocument = !!dateContent;
       this.onlyDate = datatype === 'xsd:date';
       this.showCard = true;

--- a/addon/components/rdfa-date-plugin/insert.ts
+++ b/addon/components/rdfa-date-plugin/insert.ts
@@ -23,7 +23,6 @@ export default class RdfaDatePluginInsertComponent extends Component<Args> {
           property: 'ext:content',
         }),
       ]);
-      console.log('DATE NODE: ', dateNode);
       return tr.replaceSelectionWith(dateNode, false);
     });
   }

--- a/addon/components/rdfa-date-plugin/insert.ts
+++ b/addon/components/rdfa-date-plugin/insert.ts
@@ -10,19 +10,21 @@ export default class RdfaDatePluginInsertComponent extends Component<Args> {
   get controller() {
     return this.args.controller;
   }
+
+  get schema() {
+    return this.controller.schema;
+  }
   @action
   insertDate() {
     this.controller.withTransaction((tr) => {
-      return tr.replaceSelectionWith(
-        this.controller.schema.node(
-          'inline_rdfa',
-          {
-            datatype: 'xsd:date',
-            property: 'ext:content',
-          },
-          [this.controller.schema.text('${date}')]
-        )
-      );
+      const dateNode = this.schema.text('${date}', [
+        this.schema.mark('inline_rdfa', {
+          datatype: 'xsd:date',
+          property: 'ext:content',
+        }),
+      ]);
+      console.log('DATE NODE: ', dateNode);
+      return tr.replaceSelectionWith(dateNode, false);
     });
   }
 
@@ -30,14 +32,13 @@ export default class RdfaDatePluginInsertComponent extends Component<Args> {
   insertDateTime() {
     this.controller.withTransaction((tr) => {
       return tr.replaceSelectionWith(
-        this.controller.schema.node(
-          'inline_rdfa',
-          {
+        this.schema.text('${date and time}', [
+          this.schema.mark('inline_rdfa', {
             datatype: 'xsd:dateTime',
             property: 'ext:content',
-          },
-          [this.controller.schema.text('${date and time}')]
-        )
+          }),
+        ]),
+        false
       );
     });
   }

--- a/addon/components/table-of-contents-plugin/card.ts
+++ b/addon/components/table-of-contents-plugin/card.ts
@@ -24,9 +24,7 @@ export default class TableOfContentsCardComponent extends Component<Args> {
 
   get tableOfContentsRange() {
     let result: { from: number; to: number } | undefined;
-    console.log('DOC: ', this.controller.state.doc);
     this.controller.state.doc.descendants((node, pos) => {
-      console.log(node.type);
       if (node.type === this.controller.schema.nodes['tableOfContents']) {
         result = { from: pos, to: pos + node.nodeSize };
       }

--- a/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
+++ b/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
@@ -44,7 +44,7 @@ export default class TableOfContentsComponent extends Component<EmberNodeArgs> {
             parent = { content: tocConfigEntry.value, pos };
             break;
           } else {
-            const nodes = [
+            const { from } = [
               ...this.args.controller.datastore
                 .match(
                   `>${attributes['resource'] as string}`,
@@ -52,12 +52,12 @@ export default class TableOfContentsComponent extends Component<EmberNodeArgs> {
                 )
                 .asObjectNodeMapping()
                 .nodes(),
-            ];
-            const resolvedNode = nodes[0];
-            if (resolvedNode) {
+            ][0];
+            const node = this.controller.state.doc.nodeAt(from);
+            if (node) {
               parent = {
-                content: resolvedNode.node.textContent,
-                pos: resolvedNode.pos,
+                content: node.textContent,
+                pos: from,
               };
               break;
             }

--- a/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
+++ b/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
@@ -4,6 +4,7 @@ import { TableOfContentsConfig } from '../../../constants';
 import { PNode } from '@lblod/ember-rdfa-editor';
 import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
 import { Selection } from '@lblod/ember-rdfa-editor';
+import { getRdfaAttributes } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 type OutlineEntry = {
   content: string;
   pos: number;
@@ -31,8 +32,8 @@ export default class TableOfContentsComponent extends Component<EmberNodeArgs> {
   extractOutline({ node, pos }: { node: PNode; pos: number }): OutlineEntry[] {
     let result: OutlineEntry[] = [];
     let parent: OutlineEntry | undefined;
-    const attributes = node.attrs;
-    const properties = node.attrs['property'] as string | undefined;
+    const attributes = getRdfaAttributes(node);
+    const properties = attributes?.property;
     if (properties) {
       for (const tocConfigEntry of this.config) {
         if (

--- a/addon/components/template-variable-plugin/template-variable-card.ts
+++ b/addon/components/template-variable-plugin/template-variable-card.ts
@@ -13,6 +13,7 @@ import { ProseController } from '@lblod/ember-rdfa-editor/core/prosemirror';
 import { ProseStore } from '@lblod/ember-rdfa-editor/utils/datastore/prose-store';
 import { insertHtml } from '@lblod/ember-rdfa-editor/commands/insert-html-command';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
+import { getRdfaAttributes } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 
 type Args = {
   controller: ProseController;
@@ -75,7 +76,7 @@ export default class EditorPluginsTemplateVariableCardComponent extends Componen
       0,
       variableNode.nodeSize,
       (child, pos) => {
-        if (child.attrs['property'] === 'ext:content') {
+        if (getRdfaAttributes(child)?.property === 'ext:content') {
           insertRange = {
             from: pos + 1,
             to: pos + child.nodeSize - 1,

--- a/addon/components/template-variable-plugin/template-variable-card.ts
+++ b/addon/components/template-variable-plugin/template-variable-card.ts
@@ -67,18 +67,27 @@ export default class EditorPluginsTemplateVariableCardComponent extends Componen
     if (!mapping) {
       return;
     }
-    const { node: mappingNode, pos } = unwrap([[...mapping.nodes][0]][0]);
+    const { from } = unwrap([[...mapping.nodes][0]][0]);
+    const variableNode = this.controller.state.doc.nodeAt(from);
+
     let insertRange: { from: number; to: number } | undefined;
-    mappingNode.descendants((child, relativePos) => {
-      const absolutePos: number = pos + relativePos + 1;
-      if (child.attrs['property'] === 'ext:content') {
-        insertRange = {
-          from: absolutePos + 1,
-          to: absolutePos + child.nodeSize - 1,
-        };
-      }
-      return false;
-    });
+    variableNode?.nodesBetween(
+      0,
+      variableNode.nodeSize,
+      (child, pos) => {
+        if (child.attrs['property'] === 'ext:content') {
+          insertRange = {
+            from: pos + 1,
+            to: pos + child.nodeSize - 1,
+          };
+        }
+        return false;
+      },
+      from + 1
+    );
+    if (!insertRange) {
+      return;
+    }
     let htmlToInsert: string;
     if (Array.isArray(this.selectedVariable)) {
       htmlToInsert = this.selectedVariable

--- a/addon/plugins/citation-plugin/index.ts
+++ b/addon/plugins/citation-plugin/index.ts
@@ -163,11 +163,11 @@ function defaultActiveIn(
   datastore: ProseStore
 ): [number, number][] {
   const result: [number, number][] = [];
-  for (const { node, pos } of datastore
+  for (const { from, to } of datastore
     .match(null, 'besluit:motivering')
     .asPredicateNodeMapping()
     .nodes()) {
-    result.push([pos, pos + node.nodeSize]);
+    result.push([from, to]);
   }
   return result;
 }

--- a/addon/plugins/citation-plugin/utils/cited-text.ts
+++ b/addon/plugins/citation-plugin/utils/cited-text.ts
@@ -1,4 +1,4 @@
-import { PNode } from '@lblod/ember-rdfa-editor/addon';
+import { PNode } from '@lblod/ember-rdfa-editor';
 import { CitationSchema } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 

--- a/addon/services/import-rdfa-snippet.ts
+++ b/addon/services/import-rdfa-snippet.ts
@@ -1,8 +1,7 @@
 import Service from '@ember/service';
-import { A } from '@ember/array';
 import ContextScanner from '@lblod/marawa/rdfa-context-scanner';
 import RdfaBlock from '@lblod/marawa/rdfa-block';
-import NativeArray from '@ember/array/-private/native-array';
+import { tracked } from 'tracked-built-ins';
 
 type RequestParams = {
   source: string;
@@ -24,6 +23,10 @@ export class RdfaSnippet {
   ) {}
 }
 
+type Error = {
+  source: string;
+  details: string;
+};
 /**
  * Service responsible for fetching and storing a snippet
  *
@@ -37,17 +40,17 @@ export class RdfaSnippet {
  * @extends EmberService
  */
 export default class ImportRdfaSnippet extends Service {
-  errors;
+  @tracked errors: Error[];
 
-  snippets: NativeArray<RdfaSnippet>;
+  @tracked snippets: RdfaSnippet[];
 
   contextScanner: ContextScanner;
 
   constructor() {
     // eslint-disable-next-line prefer-rest-params
     super(...arguments);
-    this.snippets = A();
-    this.errors = A();
+    this.snippets = tracked([]);
+    this.errors = tracked([]);
     this.contextScanner = new ContextScanner();
   }
 
@@ -104,13 +107,13 @@ export default class ImportRdfaSnippet extends Service {
       });
 
       if (!data) {
-        this.errors.pushObject({
+        this.errors.push({
           source: params.source,
           details: `No data found for ${params.uri ?? ''}`,
         });
       }
     } catch (err) {
-      this.errors.pushObject({
+      this.errors.push({
         source: params.source,
         details: `Error fetching data ${params.uri ?? ''}: ${err as string}`,
       });
@@ -158,7 +161,7 @@ export default class ImportRdfaSnippet extends Service {
       const type = this.determineType(rdfaBlocks);
       this.storeSnippet(params.source, type, snippet, rdfaBlocks);
     } catch (err: unknown) {
-      this.errors.pushObject({
+      this.errors.push({
         source: params.source,
         details: `Error fetching data ${params.uri ?? ''}: ${err as string}`,
       });
@@ -192,6 +195,6 @@ export default class ImportRdfaSnippet extends Service {
     content: string,
     blocks: RdfaBlock[]
   ): void {
-    this.snippets.pushObject(new RdfaSnippet(source, type, content, blocks));
+    this.snippets.push(new RdfaSnippet(source, type, content, blocks));
   }
 }

--- a/tests/dummy/app/controllers/application.ts
+++ b/tests/dummy/app/controllers/application.ts
@@ -92,12 +92,12 @@ const nodes = {
   image,
 
   hard_break,
-  inline_rdfa,
   block_rdfa,
   tableOfContents,
 };
 const marks = {
   citation: citation.marks.citation,
+  inline_rdfa,
   link,
   em,
   strong,

--- a/tests/dummy/app/controllers/application.ts
+++ b/tests/dummy/app/controllers/application.ts
@@ -30,17 +30,13 @@ import {
   paragraph,
   repaired_block,
   text,
+  placeholder,
 } from '@lblod/ember-rdfa-editor/nodes';
 import {
   tableMenu,
   tableNodes,
   tablePlugin,
 } from '@lblod/ember-rdfa-editor/plugins/table';
-import {
-  placeholder,
-  placeholderEditing,
-  placeholderView,
-} from '@lblod/ember-rdfa-editor/plugins/placeholder';
 import { service } from '@ember/service';
 import importRdfaSnippet from 'dummy/services/import-rdfa-snippet';
 import { besluitTypeWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-type-plugin';
@@ -166,15 +162,10 @@ export default class IndexController extends Controller {
     controller: ProseController
   ) => Record<string, NodeViewConstructor> = (controller) => {
     return {
-      placeholder: placeholderView,
       tableOfContents: tableOfContentsView(controller),
     };
   };
-  @tracked plugins: Plugin[] = [
-    placeholderEditing(),
-    tablePlugin,
-    citation.plugin,
-  ];
+  @tracked plugins: Plugin[] = [tablePlugin, citation.plugin];
   @tracked widgets: WidgetSpec[] = [
     tableMenu,
     besluitTypeWidget,

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -57,7 +57,7 @@ import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { NodeViewConstructor } from '@lblod/ember-rdfa-editor';
 import { setupCitationPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
 import { invisible_rdfa } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
-
+import sampleData from '@lblod/ember-rdfa-editor/config/sample-data';
 const citation = setupCitationPlugin();
 const nodes = {
   doc,
@@ -150,7 +150,7 @@ export default class BesluitSampleController extends Controller {
         'https://dev.kleinbord.lblod.info/snippets/example-opstellingen.html',
       mock: 'true',
     });
-    const presetContent = `<div resource='http://localhost/test' typeof='say:DocumentContent'>Insert here</div>`;
+    const presetContent = sampleData.DecisionTemplate;
     controller.setHtmlContent(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -1,0 +1,163 @@
+import Controller from '@ember/controller';
+import applyDevTools from 'prosemirror-dev-tools';
+import { action } from '@ember/object';
+import { tracked } from 'tracked-built-ins';
+import {
+  ProseController,
+  WidgetSpec,
+} from '@lblod/ember-rdfa-editor/core/prosemirror';
+import { Plugin } from 'prosemirror-state';
+import { Schema } from 'prosemirror-model';
+import {
+  em,
+  link,
+  strikethrough,
+  strong,
+  underline,
+} from '@lblod/ember-rdfa-editor/marks';
+import {
+  block_rdfa,
+  blockquote,
+  bullet_list,
+  code_block,
+  doc,
+  hard_break,
+  heading,
+  horizontal_rule,
+  image,
+  inline_rdfa,
+  list_item,
+  ordered_list,
+  paragraph,
+  repaired_block,
+  text,
+  placeholder,
+} from '@lblod/ember-rdfa-editor/nodes';
+import {
+  tableMenu,
+  tableNodes,
+  tablePlugin,
+} from '@lblod/ember-rdfa-editor/plugins/table';
+import { service } from '@ember/service';
+import importRdfaSnippet from 'dummy/services/import-rdfa-snippet';
+import { besluitTypeWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-type-plugin';
+import {
+  besluitPluginCardWidget,
+  besluitContextCardWidget,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-plugin';
+import { importSnippetWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/import-snippet-plugin';
+import {
+  rdfaDateCardWidget,
+  rdfaDateInsertWidget,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/rdfa-date-plugin';
+import { standardTemplateWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/standard-template-plugin';
+import { roadSignRegulationWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin';
+import { templateVariableWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-variable-plugin';
+import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { NodeViewConstructor } from '@lblod/ember-rdfa-editor';
+import { setupCitationPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
+import { invisible_rdfa } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
+
+const citation = setupCitationPlugin();
+const nodes = {
+  doc,
+  paragraph,
+
+  repaired_block,
+
+  list_item,
+  ordered_list,
+  bullet_list,
+  placeholder,
+  ...tableNodes({ tableGroup: 'block', cellContent: 'inline*' }),
+  heading,
+  blockquote,
+
+  horizontal_rule,
+  code_block,
+
+  text,
+
+  image,
+
+  hard_break,
+  block_rdfa,
+  invisible_rdfa,
+};
+const marks = {
+  citation: citation.marks.citation,
+  inline_rdfa,
+  link,
+  em,
+  strong,
+  underline,
+  strikethrough,
+};
+const dummySchema = new Schema({ nodes, marks });
+
+export default class BesluitSampleController extends Controller {
+  @service declare importRdfaSnippet: importRdfaSnippet;
+  prefixes = {
+    ext: 'http://mu.semte.ch/vocabularies/ext/',
+    mobiliteit: 'https://data.vlaanderen.be/ns/mobiliteit#',
+    dct: 'http://purl.org/dc/terms/',
+    say: 'https://say.data.gift/ns/',
+  };
+
+  @tracked rdfaEditor?: ProseController;
+  @tracked nodeViews: (
+    controller: ProseController
+  ) => Record<string, NodeViewConstructor> = () => {
+    return {};
+  };
+  @tracked plugins: Plugin[] = [tablePlugin, citation.plugin];
+  @tracked widgets: WidgetSpec[] = [
+    tableMenu,
+    besluitTypeWidget,
+    besluitContextCardWidget(),
+    besluitPluginCardWidget(),
+    importSnippetWidget,
+    rdfaDateCardWidget,
+    rdfaDateInsertWidget,
+    standardTemplateWidget,
+    citation.widgets.citationCard,
+    citation.widgets.citationInsert,
+    roadSignRegulationWidget,
+    templateVariableWidget,
+  ];
+  schema: Schema = dummySchema;
+
+  @action
+  setPrefixes(element: HTMLElement) {
+    element.setAttribute('prefix', this.prefixToAttrString(this.prefixes));
+  }
+
+  prefixToAttrString(prefix: Record<string, string>) {
+    let attrString = '';
+    Object.keys(prefix).forEach((key) => {
+      const uri = unwrap(prefix[key]);
+      attrString += `${key}: ${uri} `;
+    });
+    return attrString;
+  }
+
+  @action
+  async rdfaEditorInit(controller: ProseController) {
+    applyDevTools(controller.view);
+    await this.importRdfaSnippet.downloadSnippet({
+      omitCredentials: 'true',
+      source:
+        'https://dev.kleinbord.lblod.info/snippets/example-opstellingen.html',
+      mock: 'true',
+    });
+    const presetContent = `<div resource='http://localhost/test' typeof='say:DocumentContent'>Insert here</div>`;
+    controller.setHtmlContent(presetContent);
+    const editorDone = new CustomEvent('editor-done');
+    window.dispatchEvent(editorDone);
+  }
+
+  @action
+  togglePlugin() {
+    console.warn('Live toggling plugins is currently not supported');
+  }
+}

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -39,23 +39,15 @@ import {
 } from '@lblod/ember-rdfa-editor/plugins/table';
 import { service } from '@ember/service';
 import importRdfaSnippet from 'dummy/services/import-rdfa-snippet';
-import { besluitTypeWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-type-plugin';
-import {
-  besluitPluginCardWidget,
-  besluitContextCardWidget,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-plugin';
-import { importSnippetWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/import-snippet-plugin';
 import {
   rdfaDateCardWidget,
   rdfaDateInsertWidget,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/rdfa-date-plugin';
-import { standardTemplateWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/standard-template-plugin';
 import {
   tableOfContentsView,
   tableOfContents,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/ember-nodes/table-of-contents';
 import { tableOfContentsWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin';
-import { roadSignRegulationWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin';
 import { CodeList } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/variable-plugins/fetch-data';
 import { insertVariableWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/insert-variable-plugin';
 import { templateVariableWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-variable-plugin';
@@ -108,7 +100,7 @@ const marks = {
 };
 const dummySchema = new Schema({ nodes, marks });
 
-export default class IndexController extends Controller {
+export default class RegulatoryStatementSampleController extends Controller {
   @service declare importRdfaSnippet: importRdfaSnippet;
   prefixes = {
     ext: 'http://mu.semte.ch/vocabularies/ext/',
@@ -170,17 +162,9 @@ export default class IndexController extends Controller {
   @tracked plugins: Plugin[] = [tablePlugin, citation.plugin];
   @tracked widgets: WidgetSpec[] = [
     tableMenu,
-    besluitTypeWidget,
-    besluitContextCardWidget(),
-    besluitPluginCardWidget(),
-    importSnippetWidget,
     rdfaDateCardWidget,
     rdfaDateInsertWidget,
-    standardTemplateWidget,
-    citation.widgets.citationCard,
-    citation.widgets.citationInsert,
     tableOfContentsWidget(),
-    roadSignRegulationWidget,
     insertVariableWidget(this.insertVariableWidgetOptions),
     templateVariableWidget,
     articleStructureInsertWidget(),

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,4 +6,7 @@ export default class Router extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-Router.map(function () {});
+Router.map(function () {
+  this.route('besluit-sample', { path: '/' });
+  this.route('regulatory-statement-sample');
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,28 +1,7 @@
-{{!-- template-lint-disable no-bare-strings  --}}
-{{page-title "Dummy"}}
-<div {{did-insert this.setPrefixes}}>
-  <RdfaEditorWithDebug
-    {{did-insert this.setPrefixes}}
-    @rdfaEditorInit={{this.rdfaEditorInit}}
-    @editorOptions={{hash
-      showToggleRdfaAnnotations="true"
-      showInsertButton=null
-      showRdfa="true"
-      showRdfaHighlight="true"
-      showRdfaHover="true"
-      showPaper="true"
-      showSidebar="true"
-      showToolbarBottom=null
-    }}
-    @toolbarOptions={{hash
-      showTextStyleButtons="true"
-      showListButtons="true"
-      showIndentButtons="true"
-    }}
-    @plugins={{this.plugins}}
-    @widgets={{this.widgets}}
-    @nodeViews={{this.nodeViews}}
-    @schema={{this.schema}}>
-    <h1>Dummy app - rdfa-editor-citaten-plugin</h1>
-  </RdfaEditorWithDebug>
-</div>
+{{page-title 'Dummy'}}
+
+<nav class='navbar'>
+  <LinkTo class='navigation-link' @route='besluit-sample'>Besluit Sample</LinkTo>
+  <LinkTo class='navigation-link' @route='regulatory-statement-sample'>Regulatory Statement Sample</LinkTo>
+</nav>
+{{outlet}}

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -1,0 +1,28 @@
+{{!-- template-lint-disable no-bare-strings  --}}
+{{page-title "Dummy"}}
+<div {{did-insert this.setPrefixes}}>
+  <RdfaEditorWithDebug
+    {{did-insert this.setPrefixes}}
+    @rdfaEditorInit={{this.rdfaEditorInit}}
+    @editorOptions={{hash
+      showToggleRdfaAnnotations="true"
+      showInsertButton=null
+      showRdfa="true"
+      showRdfaHighlight="true"
+      showRdfaHover="true"
+      showPaper="true"
+      showSidebar="true"
+      showToolbarBottom=null
+    }}
+    @toolbarOptions={{hash
+      showTextStyleButtons="true"
+      showListButtons="true"
+      showIndentButtons="true"
+    }}
+    @plugins={{this.plugins}}
+    @widgets={{this.widgets}}
+    @nodeViews={{this.nodeViews}}
+    @schema={{this.schema}}>
+    <h1>Dummy app - besluit sample</h1>
+  </RdfaEditorWithDebug>
+</div>

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -1,0 +1,28 @@
+{{!-- template-lint-disable no-bare-strings  --}}
+{{page-title "Dummy"}}
+<div {{did-insert this.setPrefixes}}>
+  <RdfaEditorWithDebug
+    {{did-insert this.setPrefixes}}
+    @rdfaEditorInit={{this.rdfaEditorInit}}
+    @editorOptions={{hash
+      showToggleRdfaAnnotations="true"
+      showInsertButton=null
+      showRdfa="true"
+      showRdfaHighlight="true"
+      showRdfaHover="true"
+      showPaper="true"
+      showSidebar="true"
+      showToolbarBottom=null
+    }}
+    @toolbarOptions={{hash
+      showTextStyleButtons="true"
+      showListButtons="true"
+      showIndentButtons="true"
+    }}
+    @plugins={{this.plugins}}
+    @widgets={{this.widgets}}
+    @nodeViews={{this.nodeViews}}
+    @schema={{this.schema}}>
+    <h1>Dummy app - regulatory-statement sample</h1>
+  </RdfaEditorWithDebug>
+</div>


### PR DESCRIPTION
This PR includes modifications to include support for the following:
- The new range-based datastore API: when requesting nodes from the datastore, it now returns ranges (from-to pairs)
- It takes into account the new RDFa marks.