### PR TITLE
Remove redundant context from article-structure plugin

### DIFF
--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -1,11 +1,12 @@
 import {
   Command,
   NodeSelection,
+  NodeType,
+  Selection,
   TextSelection,
 } from '@lblod/ember-rdfa-editor';
 import recalculateStructureNumbers from './recalculate-structure-numbers';
 import { StructureSpec } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
-import { findAncestorOfType } from '../utils/structure';
 import wrapStructureContent from './wrap-structure-content';
 import IntlService from 'ember-intl/services/intl';
 
@@ -15,23 +16,12 @@ const insertStructure = (
 ): Command => {
   return (state, dispatch) => {
     const { schema, selection } = state;
-    const contextNodeTypes = structureSpec.context
-      .map((nodeType) => schema.nodes[nodeType])
-      .filter((nodeSpec) => !!nodeSpec);
-    const parent = findAncestorOfType(selection, ...contextNodeTypes);
-    if (!parent) {
-      return false;
-    }
-    const { depth } = parent;
-    const index = selection.$from.index(depth);
-    if (
-      !parent.node.canReplaceWith(
-        index + 1,
-        index + 1,
-        schema.nodes[structureSpec.name]
-      )
-    ) {
-      return wrapStructureContent(structureSpec, parent, intl)(state, dispatch);
+    const container = findInsertionContainer(
+      selection,
+      schema.nodes[structureSpec.name]
+    );
+    if (!container) {
+      return wrapStructureContent(structureSpec, intl)(state, dispatch);
     }
     if (dispatch) {
       const { node: newStructureNode, selectionConfig } =
@@ -39,18 +29,19 @@ const insertStructure = (
       const transaction = state.tr;
       let insertRange: { from: number; to: number };
       if (
-        parent.node.childCount === 1 &&
-        parent.node.firstChild?.type === schema.nodes['paragraph'] &&
-        parent.node.firstChild.firstChild?.type === schema.nodes['placeholder']
+        container.node.childCount === 1 &&
+        container.node.firstChild?.type === schema.nodes['paragraph'] &&
+        container.node.firstChild.firstChild?.type ===
+          schema.nodes['placeholder']
       ) {
         insertRange = {
-          from: parent.pos + 1,
-          to: parent.pos + parent.node.nodeSize - 1,
+          from: container.pos + 1,
+          to: container.pos + container.node.nodeSize - 1,
         };
       } else {
         insertRange = {
-          from: selection.$from.after(depth + 1),
-          to: selection.$from.after(depth + 1),
+          from: selection.$from.after(container.depth + 1),
+          to: selection.$from.after(container.depth + 1),
         };
       }
 
@@ -76,5 +67,18 @@ const insertStructure = (
     return true;
   };
 };
+
+function findInsertionContainer(selection: Selection, nodeType: NodeType) {
+  const { $from } = selection;
+  for (let currentDepth = $from.depth; currentDepth >= 0; currentDepth--) {
+    const currentAncestor = $from.node(currentDepth);
+    const index = $from.index(currentDepth);
+    const pos = currentDepth > 0 ? $from.before(currentDepth) : -1;
+    if (currentAncestor.canReplaceWith(index, index, nodeType)) {
+      return { node: currentAncestor, depth: currentDepth, pos };
+    }
+  }
+  return null;
+}
 
 export default insertStructure;

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -61,6 +61,7 @@ const insertStructure = (
               insertRange.from + selectionConfig.relativePos
             );
       transaction.setSelection(newSelection);
+      transaction.scrollIntoView();
       recalculateStructureNumbers(transaction, structureSpec);
       dispatch(transaction);
     }

--- a/addon/plugins/article-structure-plugin/commands/move-selected-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/move-selected-structure.ts
@@ -67,6 +67,7 @@ const moveSelectedStructure = (
         ? NodeSelection.create(transaction.doc, newSelectionPos)
         : TextSelection.create(transaction.doc, newSelectionPos);
       transaction.setSelection(newSelection);
+      transaction.scrollIntoView();
       recalculateStructureNumbers(transaction, currentStructureSpec);
       dispatch(transaction);
     }

--- a/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
+++ b/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
@@ -66,6 +66,7 @@ const wrapStructureContent = (
               container.pos + 1 + selectionConfig.relativePos
             );
       transaction.setSelection(newSelection);
+      transaction.scrollIntoView();
       recalculateStructureNumbers(transaction, structureSpec);
       dispatch(transaction);
     }

--- a/addon/plugins/article-structure-plugin/index.ts
+++ b/addon/plugins/article-structure-plugin/index.ts
@@ -13,7 +13,7 @@ export type SpecName = string;
 
 export type StructureSpec = {
   name: SpecName;
-  context: SpecName[];
+  // context: SpecName[];
   translations: {
     insert: string;
     move: {

--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -10,7 +10,6 @@ const PLACEHOLDERS = {
 
 export const articleParagraphSpec: StructureSpec = {
   name: 'article_paragraph',
-  context: ['article_body'],
   translations: {
     insert: 'article-structure-plugin.insert.paragraph',
     move: {

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -15,7 +15,6 @@ const PLACEHOLDERS = {
 };
 export const articleSpec: StructureSpec = {
   name: 'article',
-  context: ['title_body', 'chapter_body', 'section_body', 'subsection_body'],
   translations: {
     insert: 'article-structure-plugin.insert.article',
     move: {

--- a/addon/plugins/article-structure-plugin/structures/chapter.ts
+++ b/addon/plugins/article-structure-plugin/structures/chapter.ts
@@ -14,7 +14,6 @@ const PLACEHOLDERS = {
 };
 export const chapterSpec: StructureSpec = {
   name: 'chapter',
-  context: ['doc', 'block', 'title_body'],
   continuous: false,
   translations: {
     insert: 'article-structure-plugin.insert.chapter',

--- a/addon/plugins/article-structure-plugin/structures/section.ts
+++ b/addon/plugins/article-structure-plugin/structures/section.ts
@@ -14,7 +14,6 @@ const PLACEHOLDERS = {
 };
 export const sectionSpec: StructureSpec = {
   name: 'section',
-  context: ['chapter_body'],
   continuous: false,
   translations: {
     insert: 'article-structure-plugin.insert.section',

--- a/addon/plugins/article-structure-plugin/structures/subsection.ts
+++ b/addon/plugins/article-structure-plugin/structures/subsection.ts
@@ -15,7 +15,6 @@ const PLACEHOLDERS = {
 
 export const subsectionSpec: StructureSpec = {
   name: 'subsection',
-  context: ['section_body'],
   continuous: false,
   translations: {
     insert: 'article-structure-plugin.insert.subsection',

--- a/addon/plugins/article-structure-plugin/structures/title.ts
+++ b/addon/plugins/article-structure-plugin/structures/title.ts
@@ -14,7 +14,6 @@ const PLACEHOLDERS = {
 };
 export const titleSpec: StructureSpec = {
   name: 'title',
-  context: ['doc', 'block'],
   continuous: false,
   translations: {
     insert: 'article-structure-plugin.insert.title',


### PR DESCRIPTION
Until now, each structure-spec had a context property which determined in which node-types it could be inserted. This context property is not really necessary as this check can also be completely performed using the prosemirror `canReplaceWith` method. This PR removes the redundant context property.