### PR TITLE
Rework table of contents plugin

### DIFF
--- a/addon/components/table-of-contents-plugin/card.ts
+++ b/addon/components/table-of-contents-plugin/card.ts
@@ -1,16 +1,9 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import {
-  TableOfContentsConfig,
-  TABLE_OF_CONTENTS_DEFAULT_CONFIG,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/utils/constants';
 import { ProseController } from '@lblod/ember-rdfa-editor/core/prosemirror';
 
 type Args = {
   controller: ProseController;
-  widgetArgs: {
-    config: TableOfContentsConfig;
-  };
 };
 
 export default class TableOfContentsCardComponent extends Component<Args> {
@@ -33,10 +26,6 @@ export default class TableOfContentsCardComponent extends Component<Args> {
     return result;
   }
 
-  get config() {
-    return this.args.widgetArgs.config ?? TABLE_OF_CONTENTS_DEFAULT_CONFIG;
-  }
-
   @action
   toggle() {
     if (this.tableOfContentsRange) {
@@ -47,13 +36,7 @@ export default class TableOfContentsCardComponent extends Component<Args> {
     } else {
       const { schema } = this.controller;
       this.controller.withTransaction((tr) => {
-        return tr.replaceRangeWith(
-          0,
-          0,
-          schema.node('table_of_contents', {
-            config: this.config,
-          })
-        );
+        return tr.replaceRangeWith(0, 0, schema.node('table_of_contents'));
       });
     }
   }

--- a/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
+++ b/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
@@ -3,9 +3,8 @@ import Component from '@glimmer/component';
 import { PNode } from '@lblod/ember-rdfa-editor';
 import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
 import { Selection } from '@lblod/ember-rdfa-editor';
-import { getRdfaAttribute } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
-import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
-import { TableOfContentsConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/utils/constants';
+import { NodeWithPos } from '@curvenote/prosemirror-utils';
+import { TableOfContentsConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin';
 type OutlineEntry = {
   content: string;
   pos: number;
@@ -33,34 +32,33 @@ export default class TableOfContentsComponent extends Component<EmberNodeArgs> {
   extractOutline({ node, pos }: { node: PNode; pos: number }): OutlineEntry[] {
     let result: OutlineEntry[] = [];
     let parent: OutlineEntry | undefined;
-    const properties = getRdfaAttribute(node, 'property').pop();
-    const resource = getRdfaAttribute(node, 'resource').pop();
-    if (properties && resource) {
-      for (const tocConfigEntry of this.config) {
-        if (
-          tocConfigEntry.sectionPredicate.some((pred) =>
-            properties.includes(pred)
-          )
-        ) {
-          if (typeof tocConfigEntry.value === 'string') {
-            parent = { content: tocConfigEntry.value, pos };
-            break;
-          } else {
-            const range = [
-              ...this.args.controller.datastore
-                .match(`>${resource}`, `>${tocConfigEntry.value.predicate}`)
-                .asPredicateNodeMapping()
-                .nodes(),
-            ][0];
-            if (range) {
-              const node = unwrap(this.controller.state.doc.nodeAt(range.from));
-              parent = {
-                content: node.textContent,
-                pos: range.from,
-              };
-              break;
+    for (const option of this.config) {
+      const { path } = option;
+      if (RegExp(`^${path[0]}$`).exec(node.type.name)) {
+        let i = 1;
+        let currentNode: NodeWithPos | undefined = { node, pos };
+        while (currentNode && i < path.length) {
+          let newCurrentNode: NodeWithPos | undefined;
+          currentNode.node.forEach((child, offset) => {
+            if (RegExp(`^${path[i]}$`).exec(child.type.name)) {
+              console.log(child.type.name);
+              newCurrentNode = { pos: pos + offset, node: child };
+              return;
             }
-          }
+          });
+          currentNode = newCurrentNode;
+          i++;
+        }
+        if (currentNode) {
+          const outlineText = currentNode.node.type.spec.outlineText as
+            | ((node: PNode) => string)
+            | undefined;
+          const content =
+            outlineText?.(currentNode.node) ?? currentNode.node.textContent;
+          parent = {
+            pos: currentNode.pos,
+            content,
+          };
         }
       }
     }

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -1,4 +1,4 @@
-import { NodeSpec } from '@lblod/ember-rdfa-editor';
+import { NodeSpec, PNode } from '@lblod/ember-rdfa-editor';
 import { StructureSpec } from '..';
 import {
   constructStructureBodyNodeSpec,
@@ -87,6 +87,10 @@ export const article_header: NodeSpec = {
     property: {
       default: SAY('heading').prefixed,
     },
+  },
+  outlineText: (node: PNode) => {
+    const { number } = node.attrs;
+    return `Artikel ${number as string}: ${node.textContent}`;
   },
   toDOM(node) {
     return [

--- a/addon/plugins/article-structure-plugin/structures/structure-header.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header.ts
@@ -1,4 +1,4 @@
-import { NodeSpec } from '@lblod/ember-rdfa-editor';
+import { NodeSpec, PNode } from '@lblod/ember-rdfa-editor';
 import { ELI, EXT, SAY, XSD } from '../constants';
 import { getStructureHeaderAttrs } from '../utils/structure';
 
@@ -19,13 +19,16 @@ export const structure_header: NodeSpec = {
     property: {
       default: SAY('heading').prefixed,
     },
-
     number: {
       default: '1',
     },
     level: {
       default: 1,
     },
+  },
+  outlineText: (node: PNode) => {
+    const { number } = node.attrs;
+    return `${number as string}. ${node.textContent}`;
   },
   toDOM(node) {
     return [

--- a/addon/plugins/table-of-contents-plugin/index.ts
+++ b/addon/plugins/table-of-contents-plugin/index.ts
@@ -1,14 +1,10 @@
 import { WidgetSpec } from '@lblod/ember-rdfa-editor';
-import { TableOfContentsConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/utils/constants';
 
-export function tableOfContentsWidget(
-  config?: TableOfContentsConfig
-): WidgetSpec {
-  return {
-    componentName: 'table-of-contents-plugin/card',
-    desiredLocation: 'sidebar',
-    widgetArgs: {
-      config,
-    },
-  };
-}
+export type TableOfContentsConfig = {
+  path: string[];
+}[];
+
+export const tableOfContentsWidget: WidgetSpec = {
+  componentName: 'table-of-contents-plugin/card',
+  desiredLocation: 'sidebar',
+};

--- a/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
+++ b/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
@@ -1,53 +1,47 @@
-import { optionMapOr } from '@lblod/ember-rdfa-editor/utils/option';
 import {
   createEmberNodeSpec,
   createEmberNodeView,
   EmberNodeConfig,
 } from '@lblod/ember-rdfa-editor/utils/ember-node';
-import {
-  TableOfContentsConfig,
-  TABLE_OF_CONTENTS_DEFAULT_CONFIG,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/utils/constants';
+import { TABLE_OF_CONTENTS_DEFAULT_CONFIG } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/utils/constants';
+import { TableOfContentsConfig } from '..';
 
-export const emberNodeConfig: EmberNodeConfig = {
-  name: 'table-of-contents',
-  componentPath: 'table-of-contents-plugin/ember-nodes/table-of-contents',
-  inline: false,
-  group: 'table_of_contents',
-  atom: true,
-  attrs: {
-    config: {
-      default: TABLE_OF_CONTENTS_DEFAULT_CONFIG,
-      serialize: (node) => {
-        return JSON.stringify(node.attrs['config']);
+export const emberNodeConfig: (
+  config?: TableOfContentsConfig
+) => EmberNodeConfig = (config) => {
+  return {
+    name: 'table-of-contents',
+    componentPath: 'table-of-contents-plugin/ember-nodes/table-of-contents',
+    inline: false,
+    group: 'table_of_contents',
+    atom: true,
+    attrs: {
+      config: {
+        default: config ?? TABLE_OF_CONTENTS_DEFAULT_CONFIG,
       },
     },
-  },
-  parseDOM: [
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        if (
-          element.dataset['emberNode'] === 'table-of-contents' ||
-          // Ensure backwards compatibility
-          element.dataset['inlineComponent'] ===
-            'inline-components/table-of-contents' ||
-          (element.classList.contains('inline-component') &&
-            element.classList.contains('inline-components/table-of-contents'))
-        ) {
-          return {
-            config: optionMapOr(
-              TABLE_OF_CONTENTS_DEFAULT_CONFIG,
-              JSON.parse,
-              element.getAttribute('config')
-            ) as TableOfContentsConfig,
-          };
-        }
-        return false;
+    parseDOM: [
+      {
+        tag: 'div',
+        getAttrs(element: HTMLElement) {
+          if (
+            element.dataset['emberNode'] === 'table-of-contents' ||
+            // Ensure backwards compatibility
+            element.dataset['inlineComponent'] ===
+              'inline-components/table-of-contents' ||
+            (element.classList.contains('inline-component') &&
+              element.classList.contains('inline-components/table-of-contents'))
+          ) {
+            return {};
+          }
+          return false;
+        },
       },
-    },
-  ],
+    ],
+  };
 };
 
-export const table_of_contents = createEmberNodeSpec(emberNodeConfig);
-export const tableOfContentsView = createEmberNodeView(emberNodeConfig);
+export const table_of_contents = (config?: TableOfContentsConfig) =>
+  createEmberNodeSpec(emberNodeConfig(config));
+export const tableOfContentsView = (config?: TableOfContentsConfig) =>
+  createEmberNodeView(emberNodeConfig(config));

--- a/addon/plugins/table-of-contents-plugin/utils/constants.ts
+++ b/addon/plugins/table-of-contents-plugin/utils/constants.ts
@@ -1,17 +1,10 @@
-export type TableOfContentsConfig = {
-  sectionPredicate: string[];
-  value:
-    | string
-    | {
-        predicate: string;
-      };
-}[];
+import { TableOfContentsConfig } from '..';
 
 export const TABLE_OF_CONTENTS_DEFAULT_CONFIG: TableOfContentsConfig = [
   {
-    sectionPredicate: ['https://say.data.gift/ns/hasPart', 'say:hasPart'],
-    value: {
-      predicate: 'https://say.data.gift/ns/heading',
-    },
+    path: [
+      'title|chapter|section|subsection|article',
+      'structure_header|article_header',
+    ],
   },
 ];

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -87,7 +87,7 @@ const nodes = {
 
   hard_break,
   block_rdfa,
-  table_of_contents,
+  table_of_contents: table_of_contents(),
   invisible_rdfa,
 };
 const marks = {
@@ -157,7 +157,7 @@ export default class RegulatoryStatementSampleController extends Controller {
     controller: ProseController
   ) => Record<string, NodeViewConstructor> = (controller) => {
     return {
-      table_of_contents: tableOfContentsView(controller),
+      table_of_contents: tableOfContentsView()(controller),
     };
   };
   @tracked plugins: Plugin[] = [tablePlugin, citation.plugin];
@@ -165,7 +165,7 @@ export default class RegulatoryStatementSampleController extends Controller {
     tableMenu,
     rdfaDateCardWidget,
     rdfaDateInsertWidget,
-    tableOfContentsWidget(),
+    tableOfContentsWidget,
     insertVariableWidget(this.insertVariableWidgetOptions),
     templateVariableWidget,
     articleStructureInsertWidget(),


### PR DESCRIPTION
This PR includes several changes for the table-of-contents plugin:
- Configs are no longer RDF-based, but are now prosemirror-nodetype based. For each node/structure that needs to be shown in the table of contents, it needs to be included in the config.
- Configs are no longer serialized, this seemed to be no longer necessary, instead you can configure the node-spec and node-view in the schema with a specific configuration.
- By default, the plugin uses the `textContent` property of a node in order to represent it in the table of contents. If you want to override this behaviour, you may specify a `outlineText` property on the node-specs that need to be picked up. `outlineText` has the type `(node: PNode) => string`.