### PR TITLE
Update insert-structure command so it looks forward for the next best position to insert

### DIFF
--- a/addon/plugins/article-structure-plugin/structures/structure-header.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header.ts
@@ -14,7 +14,6 @@ const TAG_TO_LEVEL = new Map([
   ['h4', 4],
   ['h5', 5],
   ['h6', 6],
-  ['span', 6],
 ]);
 
 export const structure_header: NodeSpec = {

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -1,4 +1,10 @@
-import { NodeSpec, NodeType, Selection } from '@lblod/ember-rdfa-editor';
+import {
+  NodeSpec,
+  NodeType,
+  PNode,
+  Schema,
+  Selection,
+} from '@lblod/ember-rdfa-editor';
 import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 import {
   ELI,
@@ -166,4 +172,12 @@ export function romanize(num: number) {
     }
   }
   return Array(+digits.join('') + 1).join('M') + roman;
+}
+
+export function containsOnlyPlaceholder(schema: Schema, node: PNode) {
+  return (
+    node.childCount === 1 &&
+    node.firstChild?.type === schema.nodes['paragraph'] &&
+    node.firstChild.firstChild?.type === schema.nodes['placeholder']
+  );
 }


### PR DESCRIPTION
When inserting a structure and it cant be inserted into the current container, the insert-command now looks forward into the document to find a container it can be inserted in and inserts it at the end of this container.