### PR TITLE
Roadsign regulation plugin rework

### DIFF
--- a/addon/components/roadsign-regulation-plugin/roadsign-regulation-card.ts
+++ b/addon/components/roadsign-regulation-plugin/roadsign-regulation-card.ts
@@ -1,3 +1,4 @@
+import { findParentNode } from '@curvenote/prosemirror-utils';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -11,13 +12,13 @@ import { ProseController } from '@lblod/ember-rdfa-editor/core/prosemirror';
  * @extends Ember.Component
  */
 const acceptedTypes = [
-  '>https://data.vlaanderen.be/id/concept/BesluitType/4d8f678a-6fa4-4d5f-a2a1-80974e43bf34',
-  '>https://data.vlaanderen.be/id/concept/BesluitType/7d95fd2e-3cc9-4a4c-a58e-0fbc408c2f9b',
-  '>https://data.vlaanderen.be/id/concept/BesluitType/3bba9f10-faff-49a6-acaa-85af7f2199a3',
-  '>https://data.vlaanderen.be/id/concept/BesluitType/0d1278af-b69e-4152-a418-ec5cfd1c7d0b',
-  '>https://data.vlaanderen.be/id/concept/BesluitType/e8afe7c5-9640-4db8-8f74-3f023bec3241',
-  '>https://data.vlaanderen.be/id/concept/BesluitType/256bd04a-b74b-4f2a-8f5d-14dda4765af9',
-  '>https://data.vlaanderen.be/id/concept/BesluitType/67378dd0-5413-474b-8996-d992ef81637a',
+  'https://data.vlaanderen.be/id/concept/BesluitType/4d8f678a-6fa4-4d5f-a2a1-80974e43bf34',
+  'https://data.vlaanderen.be/id/concept/BesluitType/7d95fd2e-3cc9-4a4c-a58e-0fbc408c2f9b',
+  'https://data.vlaanderen.be/id/concept/BesluitType/3bba9f10-faff-49a6-acaa-85af7f2199a3',
+  'https://data.vlaanderen.be/id/concept/BesluitType/0d1278af-b69e-4152-a418-ec5cfd1c7d0b',
+  'https://data.vlaanderen.be/id/concept/BesluitType/e8afe7c5-9640-4db8-8f74-3f023bec3241',
+  'https://data.vlaanderen.be/id/concept/BesluitType/256bd04a-b74b-4f2a-8f5d-14dda4765af9',
+  'https://data.vlaanderen.be/id/concept/BesluitType/67378dd0-5413-474b-8996-d992ef81637a',
 ];
 
 type Args = {
@@ -36,25 +37,23 @@ export default class RoadsignRegulationCard extends Component<Args> {
     return this.args.controller;
   }
 
+  get schema() {
+    return this.args.controller.schema;
+  }
+
   get showCard() {
     const selection = this.controller.state.selection;
-    const limitedDatastore = this.controller.datastore.limitToRange(
-      this.controller.state,
-      selection.from,
-      selection.to
-    );
-    const besluit = [
-      ...limitedDatastore
-        .match(undefined, 'a')
-        .transformDataset((dataset, termConverter) => {
-          return dataset.filter((quad) =>
-            acceptedTypes
-              .map((type) => termConverter(type).value)
-              .includes(quad.object.value)
-          );
-        })
-        .asQuadResultSet(),
-    ][0];
-    return !!besluit;
+    const besluitNode = findParentNode((node) => {
+      if (node.type === this.schema.nodes['besluit']) {
+        const rdfTypes = (node.attrs['typeof'] as string | undefined)?.split(
+          ' '
+        );
+        if (rdfTypes?.some((t) => acceptedTypes.includes(t))) {
+          return true;
+        }
+      }
+      return false;
+    })(selection);
+    return !!besluitNode;
   }
 }

--- a/addon/components/roadsign-regulation-plugin/roadsigns-modal.ts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-modal.ts
@@ -16,7 +16,10 @@ import { assert } from '@ember/debug';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
 import Measure from '@lblod/ember-rdfa-editor-lblod-plugins/models/measure';
 import { ProseController } from '@lblod/ember-rdfa-editor/core/prosemirror';
-import { insertArticle } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-plugin/commands';
+import { insertStructure } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/commands';
+import { besluitArticleStructure } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/standard-template-plugin/utils/nodes';
+import IntlService from 'ember-intl/services/intl';
+import { ProseParser } from '@lblod/ember-rdfa-editor';
 
 const PAGE_SIZE = 10;
 const SIGN_TYPE_URI =
@@ -47,6 +50,7 @@ export default class RoadsignRegulationCard extends Component<Args> {
 
   pageSize = PAGE_SIZE;
   @service declare roadsignRegistry: RoadsignRegistryService;
+  @service declare intl: IntlService;
 
   @tracked typeSelected?: TypeOption;
 
@@ -285,9 +289,16 @@ export default class RoadsignRegulationCard extends Component<Args> {
       </div>
     </div>
   `;
+    const domParser = new DOMParser();
+    const htmlNode = domParser.parseFromString(regulationHTML, 'text/html');
+    const contentFragment = ProseParser.fromSchema(
+      this.args.controller.schema
+    ).parseSlice(htmlNode, {
+      preserveWhitespace: false,
+    }).content;
 
     this.args.controller.doCommand(
-      insertArticle(this.args.controller, regulationHTML)
+      insertStructure(besluitArticleStructure, this.intl, contentFragment)
     );
     this.args.closeModal();
   }

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -1,5 +1,6 @@
 import {
   Command,
+  Fragment,
   NodeSelection,
   NodeType,
   PNode,
@@ -16,7 +17,8 @@ import { containsOnlyPlaceholder } from '../utils/structure';
 
 const insertStructure = (
   structureSpec: StructureSpec,
-  intl: IntlService
+  intl: IntlService,
+  content?: Fragment
 ): Command => {
   return (state, dispatch) => {
     const { schema, selection, doc } = state;
@@ -31,7 +33,7 @@ const insertStructure = (
     }
     if (dispatch) {
       const { node: newStructureNode, selectionConfig } =
-        structureSpec.constructor({ schema, intl });
+        structureSpec.constructor({ schema, intl, content });
       const transaction = state.tr;
 
       transaction.replaceWith(

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -354,7 +354,7 @@ export const besluit_article_header: NodeSpec = {
 // };
 
 export const besluit_article_content: NodeSpec = {
-  content: 'paragraph+',
+  content: 'block+',
   inline: false,
   attrs: {
     property: {


### PR DESCRIPTION
This PR does two things:
- it uses the new decision articles and the insert-structure command from the article-structure plugin
- it drops the dependency from the datastore.