### PR TITLE
Ensure that the citation type is preserved between the sidebar card and the modal

### DIFF
--- a/addon/components/citation-plugin/citation-card.hbs
+++ b/addon/components/citation-plugin/citation-card.hbs
@@ -106,13 +106,13 @@
     </c.footer>
   </AuCard>
 {{/if}}
-{{#if this.showModal}}
 <CitationPlugin::Citations::SearchModal
+  @open={{this.showModal}}
   @closeModal={{this.closeModal}}
   @insertDecisionCitation={{this.insertDecisionCitation}}
   @insertArticleCitation={{this.insertArticleCitation}}
   @selectedDecision={{this.decision}}
   @legislationTypeUri={{this.selectedLegislationTypeUri}}
+  @selectLegislationType={{this.selectLegislationType}}
   @text={{this.searchText}}
 />
-{{/if}}

--- a/addon/components/citation-plugin/citation-card.hbs
+++ b/addon/components/citation-plugin/citation-card.hbs
@@ -106,13 +106,13 @@
     </c.footer>
   </AuCard>
 {{/if}}
-
+{{#if this.showModal}}
 <CitationPlugin::Citations::SearchModal
-  @open={{this.showModal}}
   @closeModal={{this.closeModal}}
   @insertDecisionCitation={{this.insertDecisionCitation}}
   @insertArticleCitation={{this.insertArticleCitation}}
   @selectedDecision={{this.decision}}
-  @legislationTypeUri={{this.legislationTypeUri}}
+  @legislationTypeUri={{this.selectedLegislationTypeUri}}
   @text={{this.searchText}}
 />
+{{/if}}

--- a/addon/components/citation-plugin/citation-insert.hbs
+++ b/addon/components/citation-plugin/citation-insert.hbs
@@ -10,11 +10,12 @@
   </AuButton>
 </AuList::Item>
 
+{{#if this.showModal}}
 <CitationPlugin::Citations::SearchModal
-  @open={{this.showModal}}
   @closeModal={{this.closeModal}}
   @insertDecisionCitation={{this.insertDecisionCitation}}
   @insertArticleCitation={{this.insertArticleCitation}}
   @legislationTypeUri={{this.legislationTypeUri}}
   @text={{this.text}}
 />
+{{/if}}

--- a/addon/components/citation-plugin/citation-insert.hbs
+++ b/addon/components/citation-plugin/citation-insert.hbs
@@ -10,12 +10,13 @@
   </AuButton>
 </AuList::Item>
 
-{{#if this.showModal}}
 <CitationPlugin::Citations::SearchModal
+  @open={{this.showModal}}
   @closeModal={{this.closeModal}}
   @insertDecisionCitation={{this.insertDecisionCitation}}
   @insertArticleCitation={{this.insertArticleCitation}}
-  @legislationTypeUri={{this.legislationTypeUri}}
+  @legislationTypeUri={{this.selectedLegislationTypeUri}}
+
+  @selectLegislationType={{this.selectLegislationType}}
   @text={{this.text}}
 />
-{{/if}}

--- a/addon/components/citation-plugin/citation-insert.ts
+++ b/addon/components/citation-plugin/citation-insert.ts
@@ -13,7 +13,11 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin/utils/vlaamse-codex';
 import { citedText } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin/utils/cited-text';
 import { CitationPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
-import { LEGISLATION_TYPES } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin/utils/legislation-types';
+import {
+  LEGISLATION_TYPE_CONCEPTS,
+  LEGISLATION_TYPES,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin/utils/legislation-types';
+import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 
 interface Args {
   controller: ProseController;
@@ -24,6 +28,28 @@ export default class EditorPluginsCitationInsertComponent extends Component<Args
   @tracked showModal = false;
   @tracked legislationTypeUri = LEGISLATION_TYPES.decreet;
   @tracked text = '';
+  @tracked legislationType: string | null = null;
+
+  get selectedLegislationTypeUri(): string {
+    return this.selectedLegislationType.value;
+  }
+
+  get selectedLegislationType() {
+    const type = this.legislationType;
+    const found = LEGISLATION_TYPE_CONCEPTS.find((c) => c.value === type);
+    return found || unwrap(LEGISLATION_TYPE_CONCEPTS[0]);
+  }
+
+  @action
+  selectLegislationType(type: string) {
+    type = type.toLowerCase();
+    const found = LEGISLATION_TYPE_CONCEPTS.find(
+      (c) => c.label.toLowerCase() === type
+    );
+    this.legislationType = found
+      ? found.value
+      : unwrap(LEGISLATION_TYPE_CONCEPTS[0]).value;
+  }
 
   get disableInsert() {
     if (!this.activeRanges) {

--- a/addon/components/citation-plugin/citations/search-modal.hbs
+++ b/addon/components/citation-plugin/citations/search-modal.hbs
@@ -1,5 +1,5 @@
 <AuModal
-  @modalOpen={{true}}
+  @modalOpen={{@open}}
   @closeModal={{fn this.closeModal this.legislationTypeUri this.text}}
   @title={{t 'citaten-plugin.card.title'}}
   @size='large'
@@ -40,7 +40,7 @@
                 @searchMessage={{t 'citaten-plugin.search.placeholder'}}
                 @options={{this.legislationTypes}}
                 @selected={{this.legislationSelected}}
-                @onChange={{this.selectLegislationType}}
+                @onChange={{@selectLegislationType}}
                 as |type|
               >
                 {{type}}

--- a/addon/components/citation-plugin/citations/search-modal.hbs
+++ b/addon/components/citation-plugin/citations/search-modal.hbs
@@ -1,5 +1,5 @@
 <AuModal
-  @modalOpen={{@open}}
+  @modalOpen={{true}}
   @closeModal={{fn this.closeModal this.legislationTypeUri this.text}}
   @title={{t 'citaten-plugin.card.title'}}
   @size='large'

--- a/addon/components/citation-plugin/citations/search-modal.ts
+++ b/addon/components/citation-plugin/citations/search-modal.ts
@@ -47,13 +47,12 @@ export default class EditorPluginsCitationsSearchModalComponent extends Componen
   // Vlaamse Codex currently doesn't contain captions and content of decisions
   // @tracked isEnabledSearchCaption = false
   // @tracked isEnabledSearchContent = false
-  @tracked legislationTypeUri: string;
   @tracked pageNumber = 0;
   @tracked pageSize = 5;
   @tracked totalCount = 0;
   @tracked decisions = [];
   @tracked error: unknown;
-  @tracked selectedDecision: Decision | null;
+  @tracked selectedDecision: Decision | null = null;
   @tracked documentDateFrom: Date | null = null;
   @tracked documentDateTo: Date | null = null;
   @tracked publicationDateFrom: Date | null = null;
@@ -62,11 +61,8 @@ export default class EditorPluginsCitationsSearchModalComponent extends Componen
   minDate = new Date('1930-01-01T12:00:00');
   maxDate = new Date(`${new Date().getFullYear() + 10}-01-01T12:00:00`);
 
-  constructor(owner: unknown, args: Args) {
-    super(owner, args);
-    this.selectedDecision = this.args.selectedDecision;
-    this.legislationTypeUri =
-      this.args.legislationTypeUri || LEGISLATION_TYPES['decreet'];
+  get legislationTypeUri() {
+    return this.args.legislationTypeUri || LEGISLATION_TYPES['decreet'];
   }
 
   get datePickerLocalization() {
@@ -172,17 +168,6 @@ export default class EditorPluginsCitationsSearchModalComponent extends Componen
   @action
   setInputSearchText(event: InputEvent) {
     this.inputSearchText = (event.target as HTMLInputElement).value;
-  }
-
-  @action
-  selectLegislationType(type: string) {
-    type = type.toLowerCase();
-    const found = LEGISLATION_TYPE_CONCEPTS.find(
-      (c) => c.label.toLowerCase() === type
-    );
-    this.legislationTypeUri = found
-      ? found.value
-      : unwrap(LEGISLATION_TYPE_CONCEPTS[0]).value;
   }
 
   @action


### PR DESCRIPTION
The legislation type of the modal is initialized in its constructor. The issue is: this constructor is not called each time the modal component is opened, as the modal already exists, its just hidden.

I see two solutions:
- We recreate the modal each time it is opened (which is how this PR does it) => the constructor is run every time it is opened, the most simple solution
- We initialize the `legislationType` in a modifier, e.g. `did-insert`.

This PR solves https://binnenland.atlassian.net/browse/GN-3952?atlOrigin=eyJpIjoiYjE0NWMxMzQzM2ExNGExYzhjYzRhZDY5NzM1NDBkYmIiLCJwIjoiaiJ9.