### PR TITLE
Add backwards compatible parsing rule to article_paragraph

### DIFF
--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -127,7 +127,8 @@ export const article_header: NodeSpec = {
         }
         return false;
       },
-      contentElement: `span[property~='${EXT('title').prefixed}']`,
+      contentElement: `span[property~='${EXT('title').prefixed}'],
+                       span[property~='${EXT('title').full}']`,
     },
   ],
 };

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -115,12 +115,11 @@ export function findAncestorOfType(selection: Selection, ...types: NodeType[]) {
 }
 
 export function getStructureHeaderAttrs(element: HTMLElement) {
-  const numberNode = element.children[0];
-  if (
-    hasRDFaAttribute(element, 'property', SAY('heading')) &&
-    numberNode &&
-    hasRDFaAttribute(numberNode, 'property', ELI('number'))
-  ) {
+  const numberNode = element.querySelector(
+    `[property~="${ELI('number').prefixed}"],
+     [property~="${ELI('number').full}"]`
+  );
+  if (hasRDFaAttribute(element, 'property', SAY('heading')) && numberNode) {
     return {
       number: numberNode.textContent,
     };


### PR DESCRIPTION
This PR ensures that article paragraphs following the old format are also parsed correctly and converted to the new format.