### PR TITLE
feat(citation): make citation plugin datastore-independent

### DIFF
--- a/addon/plugins/citation-plugin/index.ts
+++ b/addon/plugins/citation-plugin/index.ts
@@ -5,20 +5,17 @@ import {
   EditorStateConfig,
   InlineDecorationSpec,
   MarkSpec,
+  NodeType,
   PNode,
   ProsePlugin,
   Schema,
   WidgetSpec,
 } from '@lblod/ember-rdfa-editor';
-import {
-  datastoreKey,
-  ProseStore,
-} from '@lblod/ember-rdfa-editor/plugins/datastore';
 import processMatch, {
   RegexpMatchArrayWithIndices,
 } from './utils/process-match';
-import { expect } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { citation } from './marks/citation';
+import { changedDescendants } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/changed-descendants';
 
 const BASIC_MULTIPLANE_CHARACTER = '\u0021-\uFFFF'; // most of the characters used around the world
 
@@ -60,117 +57,12 @@ export interface CitationDecoration extends Decoration {
   spec: CitationDecorationSpec;
 }
 
-function calculateDecorations(
-  schema: CitationSchema,
-  doc: PNode,
-  activeRanges: [number, number][]
-) {
-  const decorations: Decoration[] = [];
-
-  for (const [start, end] of activeRanges) {
-    doc.nodesBetween(start, end, (node: PNode, pos: number): boolean => {
-      if (
-        node.isText &&
-        node.text &&
-        !schema.marks.citation.isInSet(node.marks)
-      ) {
-        for (const match of node.text.matchAll(CITATION_REGEX)) {
-          const processedMatch = processMatch(
-            match as RegexpMatchArrayWithIndices
-          );
-
-          if (processedMatch) {
-            const { text, legislationTypeUri, searchTextMatch } =
-              processedMatch;
-            const { start: matchStart, end: matchEnd } = searchTextMatch;
-            const decorationStart = pos + matchStart;
-            const decorationEnd = pos + matchEnd;
-            decorations.push(
-              Decoration.inline(
-                decorationStart,
-                decorationEnd,
-
-                {
-                  'data-editor-highlight': 'true',
-                },
-                {
-                  searchText: text,
-                  legislationTypeUri,
-                }
-              )
-            );
-          }
-        }
-      }
-      return true;
-    });
-  }
-  return DecorationSet.create(doc, decorations);
-}
-
 interface CitationPluginState {
   highlights: DecorationSet;
   activeRanges: [number, number][];
 }
 
 export type CitationPlugin = ProsePlugin<CitationPluginState>;
-
-function citationPlugin({
-  activeIn = defaultActiveIn,
-}: CitationPluginConfig): CitationPlugin {
-  const citation: CitationPlugin = new ProsePlugin({
-    state: {
-      init(stateConfig: EditorStateConfig, state: EditorState) {
-        const { doc, schema } = state;
-        const activeRanges = activeIn(
-          state,
-          expect(
-            'the datastore plugin is required for this plugin',
-            datastoreKey.getState(state)
-          )()
-        );
-        return {
-          highlights: calculateDecorations(schema, doc, activeRanges),
-          activeRanges,
-        };
-      },
-      apply(tr, set, oldState, newState) {
-        const { doc, schema } = newState;
-        const activeRanges = activeIn(
-          newState,
-          expect(
-            'the datastore plugin is required for this plugin',
-            datastoreKey.getState(newState)
-          )()
-        );
-        return {
-          highlights: calculateDecorations(schema, doc, activeRanges),
-          activeRanges,
-        };
-      },
-    },
-    props: {
-      decorations(state): DecorationSet | undefined {
-        return citation.getState(state)?.highlights;
-      },
-    },
-  });
-  return citation;
-}
-
-function defaultActiveIn(
-  state: EditorState,
-  datastore: ProseStore
-): [number, number][] {
-  const result: [number, number][] = [];
-  for (const { from, to } of datastore
-    .match(null, 'besluit:motivering')
-    .asPredicateNodeMapping()
-    .nodes()) {
-    result.push([from, to]);
-  }
-  return result;
-}
 
 export interface CitationPluginBundle {
   plugin: ProsePlugin<CitationPluginState>;
@@ -183,12 +75,31 @@ export interface CitationPluginBundle {
   };
 }
 
-export interface CitationPluginConfig {
-  activeIn?(state: EditorState, datastore: ProseStore): [number, number][];
+export interface CitationPluginNodeConfig {
+  type: 'nodes';
+  regex?: RegExp;
+
+  activeInNodeTypes(schema: Schema, state: EditorState): Set<NodeType>;
 }
 
+export interface CitationPluginRangeConfig {
+  type: 'ranges';
+  regex?: RegExp;
+
+  activeInRanges(state: EditorState): [number, number][];
+}
+
+export type CitationPluginConfig =
+  | CitationPluginNodeConfig
+  | CitationPluginRangeConfig;
+
 export function setupCitationPlugin(
-  config: CitationPluginConfig = {}
+  config: CitationPluginConfig = {
+    type: 'nodes',
+    activeInNodeTypes(schema): Set<NodeType> {
+      return new Set([schema.nodes.doc]);
+    },
+  }
 ): CitationPluginBundle {
   const plugin = citationPlugin(config);
   return {
@@ -212,5 +123,166 @@ export function setupCitationPlugin(
     marks: {
       citation,
     },
+  };
+}
+
+function citationPlugin(config: CitationPluginConfig): CitationPlugin {
+  const citation: CitationPlugin = new ProsePlugin({
+    state: {
+      init(stateConfig: EditorStateConfig, state: EditorState) {
+        return calculateCitationPluginState(state, config);
+      },
+      apply(tr, set, oldState, newState) {
+        return calculateCitationPluginState(newState, config, oldState);
+      },
+    },
+    props: {
+      decorations(state): DecorationSet | undefined {
+        return citation.getState(state)?.highlights;
+      },
+    },
+  });
+  return citation;
+}
+
+function calculateCitationPluginState(
+  state: EditorState,
+  config: CitationPluginConfig,
+  oldState?: EditorState
+) {
+  const { doc, schema } = state;
+  let activeRanges;
+  let highlights;
+  if (config.type === 'ranges') {
+    activeRanges = config.activeInRanges(state);
+    const calculatedDecs = calculateDecorationsInRanges(
+      config,
+      schema,
+      doc,
+      activeRanges
+    );
+    highlights = calculatedDecs.decorations;
+  } else {
+    const nodes = config.activeInNodeTypes(schema, state);
+    const calculatedDecs = calculateDecorationsInNodes(
+      config,
+      schema,
+      nodes,
+      doc,
+      oldState?.doc
+    );
+    activeRanges = calculatedDecs.activeRanges;
+    highlights = calculatedDecs.decorations;
+  }
+  return {
+    highlights,
+    activeRanges,
+  };
+}
+
+function calculateDecorationsInNodes(
+  config: CitationPluginConfig,
+  schema: CitationSchema,
+  nodes: Set<NodeType>,
+  newDoc: PNode,
+  oldDoc?: PNode
+): { decorations: DecorationSet; activeRanges: [number, number][] } {
+  const activeRanges: [number, number][] = [];
+  const decorations: Decoration[] = [];
+  const collector = collectDecorations(decorations, schema, config.regex);
+  if (nodes.has(newDoc.type)) {
+    oldDoc
+      ? changedDescendants(oldDoc, newDoc, 0, collector)
+      : newDoc.descendants(collector);
+    activeRanges.push([0, newDoc.nodeSize]);
+  } else {
+    oldDoc
+      ? changedDescendants(
+          oldDoc,
+          newDoc,
+          0,
+
+          (node, pos) => {
+            if (nodes.has(node.type)) {
+              node.nodesBetween(0, node.nodeSize - 2, collector, pos + 1);
+              activeRanges.push([pos, pos + node.nodeSize]);
+              return false;
+            }
+            return true;
+          }
+        )
+      : newDoc.descendants((node, pos) => {
+          if (nodes.has(node.type)) {
+            node.nodesBetween(0, node.nodeSize - 2, collector, pos + 1);
+            activeRanges.push([pos, pos + node.nodeSize]);
+            return false;
+          }
+          return true;
+        });
+  }
+  return {
+    decorations: DecorationSet.create(newDoc, decorations),
+    activeRanges,
+  };
+}
+
+function calculateDecorationsInRanges(
+  config: CitationPluginConfig,
+  schema: CitationSchema,
+  doc: PNode,
+  activeRanges: [number, number][]
+): { decorations: DecorationSet; activeRanges: [number, number][] } {
+  const decorations: Decoration[] = [];
+  const collector = collectDecorations(decorations, schema, config.regex);
+
+  for (const [start, end] of activeRanges) {
+    doc.nodesBetween(start, end, collector);
+  }
+  return {
+    decorations: DecorationSet.create(doc, decorations),
+    activeRanges: activeRanges,
+  };
+}
+
+function collectDecorations(
+  decorations: Decoration[],
+  schema: CitationSchema,
+  regex: RegExp = CITATION_REGEX
+) {
+  return function (node: PNode, pos: number): boolean {
+    console.log('collecting from pos', pos);
+    if (
+      node.isText &&
+      node.text &&
+      !schema.marks.citation.isInSet(node.marks)
+    ) {
+      for (const match of node.text.matchAll(regex)) {
+        const processedMatch = processMatch(
+          match as RegexpMatchArrayWithIndices
+        );
+
+        if (processedMatch) {
+          const { text, legislationTypeUri, searchTextMatch } = processedMatch;
+          const { start: matchStart, end: matchEnd } = searchTextMatch;
+          const decorationStart = pos + matchStart;
+          const decorationEnd = pos + matchEnd;
+          decorations.push(
+            Decoration.inline(
+              decorationStart,
+              decorationEnd,
+
+              {
+                'data-editor-highlight': 'true',
+              },
+              {
+                searchText: text,
+                legislationTypeUri,
+              }
+            )
+          );
+        }
+      }
+    }
+    return true;
   };
 }

--- a/addon/plugins/citation-plugin/index.ts
+++ b/addon/plugins/citation-plugin/index.ts
@@ -250,7 +250,6 @@ function collectDecorations(
   regex: RegExp = CITATION_REGEX
 ) {
   return function (node: PNode, pos: number): boolean {
-    console.log('collecting from pos', pos);
     if (
       node.isText &&
       node.text &&

--- a/addon/plugins/citation-plugin/nodes/motivation.ts
+++ b/addon/plugins/citation-plugin/nodes/motivation.ts
@@ -1,0 +1,35 @@
+import {
+  getRdfaAttrs,
+  NodeSpec,
+  PNode,
+  rdfaAttrs,
+} from '@lblod/ember-rdfa-editor';
+import { hasRDFaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import { BESLUIT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+
+export const motivation: NodeSpec = {
+  content: 'block*',
+  group: 'block',
+  attrs: {
+    ...rdfaAttrs,
+  },
+
+  parseDOM: [
+    {
+      tag: 'div',
+      getAttrs(node: HTMLElement) {
+        const rdfaAttrs = getRdfaAttrs(node);
+        if (
+          rdfaAttrs &&
+          hasRDFaAttribute(node, 'property', BESLUIT('motivering'))
+        ) {
+          return rdfaAttrs;
+        }
+        return false;
+      },
+    },
+  ],
+  toDOM(node: PNode) {
+    return ['div', node.attrs, 0];
+  },
+};

--- a/addon/utils/changed-descendants.ts
+++ b/addon/utils/changed-descendants.ts
@@ -1,0 +1,29 @@
+import { PNode } from '@lblod/ember-rdfa-editor';
+
+// from https://github.com/ProseMirror/prosemirror-tables/blob/8ec1e96ae994c1585b07b1ca9dc3292f63e868e0/src/fixtables.ts#L24
+export function changedDescendants(
+  old: PNode,
+  cur: PNode,
+  offset: number,
+  f: (node: PNode, pos: number) => void
+): void {
+  const oldSize = old.childCount;
+  const curSize = cur.childCount;
+  outer: for (let i = 0, j = 0; i < curSize; i++) {
+    const child = cur.child(i);
+    for (let scan = j, e = Math.min(oldSize, i + 3); scan < e; scan++) {
+      if (old.child(scan) === child) {
+        j = scan + 1;
+        offset += child.nodeSize;
+        continue outer;
+      }
+    }
+    f(child, offset);
+    if (j < oldSize && old.child(j).sameMarkup(child)) {
+      changedDescendants(old.child(j), child, offset + 1, f);
+    } else {
+      child.nodesBetween(0, child.content.size, f, offset + 1);
+    }
+    offset += child.nodeSize;
+  }
+}

--- a/addon/utils/constants.ts
+++ b/addon/utils/constants.ts
@@ -9,3 +9,8 @@ export const RDF = namespace(
 export const ELI = namespace('http://data.europa.eu/eli/ontology#', 'eli');
 export const XSD = namespace('http://www.w3.org/2001/XMLSchema#', 'xsd');
 export const EXT = namespace('http://mu.semte.ch/vocabularies/ext/', 'ext');
+
+export const BESLUIT = namespace(
+  'http://data.vlaanderen.be/ns/besluit#',
+  'besluit'
+);

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -29,9 +29,9 @@ import {
   list_item,
   ordered_list,
   paragraph,
+  placeholder,
   repaired_block,
   text,
-  placeholder,
 } from '@lblod/ember-rdfa-editor/nodes';
 import {
   tableMenu,
@@ -42,8 +42,8 @@ import { service } from '@ember/service';
 import importRdfaSnippet from '@lblod/ember-rdfa-editor-lblod-plugins/services/import-rdfa-snippet';
 import { besluitTypeWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-type-plugin';
 import {
-  besluitPluginCardWidget,
   besluitContextCardWidget,
+  besluitPluginCardWidget,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-plugin';
 import { importSnippetWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/import-snippet-plugin';
 import {
@@ -54,11 +54,18 @@ import { standardTemplateWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/p
 import { roadSignRegulationWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin';
 import { templateVariableWidget } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-variable-plugin';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
-import { NodeViewConstructor } from '@lblod/ember-rdfa-editor';
+import { NodeType, NodeViewConstructor } from '@lblod/ember-rdfa-editor';
 import { setupCitationPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
 import { invisible_rdfa } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
 import sampleData from '@lblod/ember-rdfa-editor/config/sample-data';
-const citation = setupCitationPlugin();
+import { motivation } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin/nodes/motivation';
+
+const citation = setupCitationPlugin({
+  type: 'nodes',
+  activeInNodeTypes(schema): Set<NodeType> {
+    return new Set<NodeType>([schema.nodes.motivation]);
+  },
+});
 const nodes = {
   doc,
   paragraph,
@@ -69,6 +76,7 @@ const nodes = {
   ordered_list,
   bullet_list,
   placeholder,
+  motivation,
   ...tableNodes({ tableGroup: 'block', cellContent: 'inline*' }),
   heading,
   blockquote,


### PR DESCRIPTION
Adds a new way of configuring the citation plugin activation ranges, by specifiying a function that returns a set of nodetypes in which the plugin should trigger. This calculation is efficient thanks to the use of a `changedDescendants` utility as demonstrated in the [prosemirror tables plugin](https://github.com/ProseMirror/prosemirror-tables/blob/8ec1e96ae994c1585b07b1ca9dc3292f63e868e0/src/fixtables.ts#L24), found [in this discussion thread](https://discuss.prosemirror.net/t/efficiently-finding-changed-nodes/4280)

The old way of directly specifying the ranges is still supported, but no longer provides the datastore as a second argument, which is the reason for the `breaking` label. This is actually just a more sensible design anyway, removing the implicit dependency of the citation plugin on the datastore. Now the host app can simply calculate the required ranges itself, and can choose to do that using the datastore or not.

With this, the option of specifying nodetypes is actually simply a convenience wrapper, since the same behavior could also be implemented in the host app by calculating the relevant ranges.

In addition, there is now a `motivation` nodespec included for our current usecase, and the dummy app is setup to trigger the citation inside any motivation blocks.

