### PR TITLE
Replace paragraphs by block in content specifiers and fix roadsign-regulation parsing rule

### DIFF
--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -134,5 +134,5 @@ export const article_header: NodeSpec = {
 };
 
 export const article_body = constructStructureBodyNodeSpec({
-  content: '(paragraph|article_paragraph)+',
+  content: '(block|article_paragraph)+',
 });

--- a/addon/plugins/article-structure-plugin/structures/chapter.ts
+++ b/addon/plugins/article-structure-plugin/structures/chapter.ts
@@ -74,7 +74,6 @@ export const chapterSpec: StructureSpec = {
 export const chapter = constructStructureNodeSpec({
   type: SAY('Chapter'),
   content: 'structure_header chapter_body',
-  group: 'block',
 });
 
 export const chapter_body = constructStructureBodyNodeSpec({

--- a/addon/plugins/article-structure-plugin/structures/chapter.ts
+++ b/addon/plugins/article-structure-plugin/structures/chapter.ts
@@ -78,5 +78,5 @@ export const chapter = constructStructureNodeSpec({
 });
 
 export const chapter_body = constructStructureBodyNodeSpec({
-  content: '(section|paragraph)+|(article|paragraph)+',
+  content: '(section|block)+|(article|block)+',
 });

--- a/addon/plugins/article-structure-plugin/structures/section.ts
+++ b/addon/plugins/article-structure-plugin/structures/section.ts
@@ -77,5 +77,5 @@ export const section = constructStructureNodeSpec({
 });
 
 export const section_body = constructStructureBodyNodeSpec({
-  content: '(subsection|paragraph)+|(article|paragraph)+',
+  content: '(subsection|block)+|(article|block)+',
 });

--- a/addon/plugins/article-structure-plugin/structures/subsection.ts
+++ b/addon/plugins/article-structure-plugin/structures/subsection.ts
@@ -78,5 +78,5 @@ export const subsection = constructStructureNodeSpec({
 });
 
 export const subsection_body = constructStructureBodyNodeSpec({
-  content: '(article|paragraph)+',
+  content: '(article|block)+',
 });

--- a/addon/plugins/article-structure-plugin/structures/title.ts
+++ b/addon/plugins/article-structure-plugin/structures/title.ts
@@ -78,5 +78,5 @@ export const title = constructStructureNodeSpec({
 });
 
 export const title_body = constructStructureBodyNodeSpec({
-  content: '(chapter|paragraph)+|(article|paragraph)+',
+  content: '(chapter|block)+|(article|block)+',
 });

--- a/addon/plugins/article-structure-plugin/structures/title.ts
+++ b/addon/plugins/article-structure-plugin/structures/title.ts
@@ -74,7 +74,6 @@ export const titleSpec: StructureSpec = {
 export const title = constructStructureNodeSpec({
   type: SAY('Title'),
   content: 'structure_header title_body',
-  group: 'block',
 });
 
 export const title_body = constructStructureBodyNodeSpec({

--- a/addon/plugins/roadsign-regulation-plugin/nodes.ts
+++ b/addon/plugins/roadsign-regulation-plugin/nodes.ts
@@ -7,6 +7,9 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { hasRDFaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 
+const CONTENT_SELECTOR = `div[property~='${
+  DCT('description').full
+}'],div[property~='${DCT('description').prefixed}']`;
 export const roadsign_regulation: NodeSpec = {
   content: 'block+',
   group: 'block',
@@ -15,7 +18,9 @@ export const roadsign_regulation: NodeSpec = {
     resourceUri: {},
     measureUri: {},
     zonality: {},
-    temporal: {},
+    temporal: {
+      default: false,
+    },
   },
   toDOM(node) {
     const { resourceUri, measureUri, zonality, temporal } = node.attrs;
@@ -45,9 +50,8 @@ export const roadsign_regulation: NodeSpec = {
       [
         'span',
         {
-          style: 'display:none;',
           property: EXT('temporal'),
-          resource: (temporal as string | false).toString(),
+          resource: (temporal as string) ?? false,
         },
       ],
       ['div', { property: DCT('description') }, 0],
@@ -58,7 +62,12 @@ export const roadsign_regulation: NodeSpec = {
       tag: 'div',
       getAttrs(node: HTMLElement) {
         if (
-          hasRDFaAttribute(node, 'typeof', MOBILITEIT('Mobiliteitsmaatregel'))
+          hasRDFaAttribute(
+            node,
+            'typeof',
+            MOBILITEIT('Mobiliteitsmaatregel')
+          ) &&
+          node.querySelector(CONTENT_SELECTOR)
         ) {
           const resourceUri = node.getAttribute('resource');
           const measureUri = node
@@ -73,6 +82,9 @@ export const roadsign_regulation: NodeSpec = {
            span[property~='${EXT('zonality').full}']`
             )
             ?.getAttribute('resource');
+          if (!resourceUri || !measureUri || !zonality) {
+            return false;
+          }
           const temporal = node
             .querySelector(
               `span[property~='${EXT('temporal').prefixed}'],
@@ -89,6 +101,7 @@ export const roadsign_regulation: NodeSpec = {
         }
         return false;
       },
+      contentElement: CONTENT_SELECTOR,
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -104,7 +104,7 @@ export const motivering: NodeSpec = {
 
 export const article_container: NodeSpec = {
   group: 'block',
-  content: '(paragraph|besluit_article)+',
+  content: '(block|besluit_article)+',
   inline: false,
   attrs: {
     ...rdfaAttrs,

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -175,7 +175,8 @@ export default class BesluitSampleController extends Controller {
         'https://dev.kleinbord.lblod.info/snippets/example-opstellingen.html',
       mock: 'true',
     });
-    const presetContent = sampleData.DecisionTemplate;
+    const presetContent =
+      localStorage.getItem('EDITOR_CONTENT') ?? sampleData.DecisionTemplate;
     controller.setHtmlContent(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -88,7 +88,7 @@ export default class RegulatoryStatementSampleController extends Controller {
     return new Schema({
       nodes: {
         doc: {
-          content: 'table_of_contents? block+',
+          content: 'table_of_contents? (chapter|block)+|(title|block)+',
         },
         paragraph,
 

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -88,7 +88,7 @@ export default class RegulatoryStatementSampleController extends Controller {
     return new Schema({
       nodes: {
         doc: {
-          content: 'table_of_contents? (chapter|block)+|(title|block)+',
+          content: 'table_of_contents? ((chapter|block)+|(title|block)+)',
         },
         paragraph,
 


### PR DESCRIPTION
This PR does the following three things:
- Replace `paragraph` by `block` in content specifiers of node-specs, so they allow for more diverse content
- Remove `block` group from chapter and title nodes, and add chapter and title as possible nodes to content of `doc` in regulatory-statement-sample.
- Add a missing `contentElement` specifier to the `roadsign_regulation` node parsing rule.