### PR TITLE
Enable word-break as break-all on variable contenteditable

### DIFF
--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -47,6 +47,7 @@
   .variable {
     [contenteditable] {
       white-space: pre-wrap;
+      word-break: break-all;
       word-wrap: break-word;
       outline: 0px;
     }


### PR DESCRIPTION
This PR ensures that words are broken up when they are about to overflow a variable container.