### PR TITLE
Article-structure-plugin: structure insertion improvements

### DIFF
--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -31,6 +31,7 @@ const insertStructure = (
       selection,
       nodeType: schema.nodes[structureSpec.name],
       schema,
+      limitTo: structureSpec.limitTo,
     });
     if (!insertionRange) {
       return false;
@@ -86,10 +87,14 @@ function findInsertionRange(args: {
     }
   }
   const limitContainer = limitTo
-    ? findParentNodeOfType(schema.nodes['limitTo'])(selection)
+    ? findParentNodeOfType(schema.nodes[limitTo])(selection)
     : null;
+
   const limitContainerRange = limitContainer
-    ? { from: limitContainer.pos, to: limitContainer.node.nodeSize }
+    ? {
+        from: limitContainer.pos,
+        to: limitContainer.pos + limitContainer.node.nodeSize,
+      }
     : { from: 0, to: doc.nodeSize };
   const filterFunction = ({ from, to }: { from: number; to: number }) => {
     if (from >= limitContainerRange.from && to <= limitContainerRange.to) {

--- a/addon/plugins/article-structure-plugin/index.ts
+++ b/addon/plugins/article-structure-plugin/index.ts
@@ -13,7 +13,6 @@ export type SpecName = string;
 
 export type StructureSpec = {
   name: SpecName;
-  // context: SpecName[];
   translations: {
     insert: string;
     move: {
@@ -41,6 +40,7 @@ export type StructureSpec = {
   }) => Transaction;
   content?: (args: { pos: number; state: EditorState }) => Fragment;
   continuous: boolean;
+  limitTo?: string;
 };
 
 export type ArticleStructurePluginOptions = StructureSpec[];

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -177,6 +177,7 @@ export const besluitArticleStructure: StructureSpec = {
     },
     remove: 'article-structure-plugin.remove.article',
   },
+  limitTo: 'besluit',
   constructor: ({ schema, number, content, intl }) => {
     const numberConverted = number?.toString() ?? '1';
     const node = schema.node(


### PR DESCRIPTION
This PR includes two changes:
- the insert-structure command now also looks backwards for a container to insert into if no other insertion containers are found
- addition of the optional `limitTo` property to a structure-spec: this property defines whether the insertion range of a structure type should be constrained to another node-type. E.g. the insertion of `besluit-article` nodes should be constrained to the current besluit. You don't want the possibility to occur that when inserting a `besluit-article` it is inserted in another besluit than the current one.