### PR TITLE
Improve behavior of decision nodes

### DIFF
--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -33,7 +33,7 @@ export const title: NodeSpec = {
   },
   parseDOM: [
     {
-      tag: 'h4',
+      tag: 'h1,h2,h3,h4,h5',
       getAttrs(element: HTMLElement) {
         if (hasRDFaAttribute(element, 'property', ELI('title'))) {
           return getRdfaAttrs(element);

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -19,6 +19,7 @@ import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 export const title: NodeSpec = {
   content: 'paragraph+',
   inline: false,
+  defining: true,
   attrs: {
     ...rdfaAttrs,
     property: {
@@ -298,6 +299,7 @@ export const besluit: NodeSpec = {
   group: 'block',
   content: 'block*title?block*description?block*motivering?block*',
   inline: false,
+  defining: true,
   attrs: {
     ...rdfaAttrs,
     property: {


### PR DESCRIPTION
- make the important nodes defining
- make other heading levels also parse as a title, which means the classic decision template works as expected (it has an h5 instead of an h4)

I didn't change the toDom (so in the end it will always be an h4) because the insert-title command would insert an h4 anyway. We can address this more seriously when we add the heading selector feature.