### PR TITLE
fix(template): improve template insertion behavior

### DIFF
--- a/addon/components/standard-template-plugin/template-provider.ts
+++ b/addon/components/standard-template-plugin/template-provider.ts
@@ -98,10 +98,17 @@ export default class TemplateProviderComponent extends Component<Args> {
     const selection = this.controller.state.selection;
     let insertRange: { from: number; to: number } = selection;
     const { $from, $to } = selection;
-    if (
+    const isInPlaceholder =
       $from.parent.type === this.controller.schema.nodes['placeholder'] &&
-      $from.sameParent($to)
-    ) {
+      $from.sameParent($to);
+    // if we would be completely replacing the contents of a simple paragraph node,
+    // replace the entire node instead
+    const isInSimpleParagraph =
+      $from.parent.type === this.controller.schema.nodes.paragraph &&
+      $from.sameParent($to) &&
+      $from.pos === $from.start() &&
+      $to.pos === $to.end();
+    if (isInPlaceholder || isInSimpleParagraph) {
       insertRange = {
         from: $from.start($from.depth - 1),
         to: $from.end($from.depth - 1),


### PR DESCRIPTION
Make inserting standard templates less awkward by replacing the paragraph you're in (if you're in one) instead of inserting it after (which leaves you with a newline where you don't expect it)