### PR TITLE
We had a wrong format in the long datetime option

### DIFF
--- a/addon/plugins/rdfa-date-plugin/index.ts
+++ b/addon/plugins/rdfa-date-plugin/index.ts
@@ -11,7 +11,7 @@ export const defaultDateFormats: DateFormat[] = [
     label: 'Long Date',
     key: 'long',
     dateFormat: 'EEEE dd MMMM yyyy',
-    dateTimeFormat: 'EEEE dd MMMM yyyy \'at\' HH:mm',
+    dateTimeFormat: 'PPPPp',
   },
 ];
 


### PR DESCRIPTION
Small bug on the default formats that caused some problems on qa