### PR TITLE
Make headers and content nodes of structures isolating and defining

### DIFF
--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -49,6 +49,8 @@ const contentSelector = `span[property~='${SAY('body').prefixed}'],
 export const article_paragraph: NodeSpec = {
   content: 'inline*',
   inline: false,
+  isolating: true,
+  defining: true,
   attrs: {
     typeof: {
       default: SAY('Paragraph').prefixed,

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -85,6 +85,8 @@ export const article = constructStructureNodeSpec({
 export const article_header: NodeSpec = {
   content: 'text*|placeholder',
   inline: false,
+  isolating: true,
+  defining: true,
   attrs: {
     number: {
       default: '1',

--- a/addon/plugins/article-structure-plugin/structures/structure-header.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header.ts
@@ -19,6 +19,8 @@ const TAG_TO_LEVEL = new Map([
 export const structure_header: NodeSpec = {
   content: 'text*|placeholder',
   inline: false,
+  defining: true,
+  isolating: true,
   attrs: {
     property: {
       default: SAY('heading').prefixed,

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -71,6 +71,8 @@ export function constructStructureBodyNodeSpec(config: {
   return {
     content,
     inline: false,
+    defining: true,
+    isolating: true,
     toDOM() {
       return [
         'div',

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -226,6 +226,8 @@ export const besluitArticleStructure: StructureSpec = {
 
 export const besluit_article_header: NodeSpec = {
   inline: false,
+  isolating: true,
+  defining: true,
   attrs: {
     ...rdfaAttrs,
     number: {
@@ -270,6 +272,8 @@ export const besluit_article_header: NodeSpec = {
 export const besluit_article_content: NodeSpec = {
   content: 'block+',
   inline: false,
+  isolating: true,
+  defining: true,
   attrs: {
     ...rdfaAttrs,
     property: {

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -226,8 +226,6 @@ export const besluitArticleStructure: StructureSpec = {
 
 export const besluit_article_header: NodeSpec = {
   inline: false,
-  isolating: true,
-  defining: true,
   selectable: false,
   attrs: {
     ...rdfaAttrs,
@@ -273,8 +271,6 @@ export const besluit_article_header: NodeSpec = {
 export const besluit_article_content: NodeSpec = {
   content: 'block+',
   inline: false,
-  isolating: true,
-  defining: true,
   attrs: {
     ...rdfaAttrs,
     property: {

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -228,6 +228,7 @@ export const besluit_article_header: NodeSpec = {
   inline: false,
   isolating: true,
   defining: true,
+  selectable: false,
   attrs: {
     ...rdfaAttrs,
     number: {


### PR DESCRIPTION
This PR introduces the addition of the `defining` and `isolating` attributes on the content and headers of article-structures.
This ensures that you cant backspace out of these nodes and that they are preserved when pasting content inside of them. This solves a lot of weird backspace collapsing bugs, as seen in https://binnenland.atlassian.net/browse/GN-3994?atlOrigin=eyJpIjoiNzQ1ZDM4YThlZTE5NGQ0M2JkZjVjZGU2N2NkODY0NjciLCJwIjoiaiJ9.