### PR TITLE
Add the __rdfaId when manually creating decisions titles, decision articles or citations

### DIFF
--- a/addon/plugins/besluit-plugin/commands/insert-title.ts
+++ b/addon/plugins/besluit-plugin/commands/insert-title.ts
@@ -1,6 +1,7 @@
 import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 import { Command, NodeSelection } from '@lblod/ember-rdfa-editor';
 import IntlService from 'ember-intl/services/intl';
+import { v4 as uuid } from 'uuid';
 
 export default function insertTitle(intl: IntlService): Command {
   return function (state, dispatch) {
@@ -19,7 +20,7 @@ export default function insertTitle(intl: IntlService): Command {
         besluit.pos + 1,
         schema.node(
           'title',
-          null,
+          { __rdfaId: uuid() },
           schema.node(
             'paragraph',
             null,

--- a/addon/plugins/citation-plugin/utils/cited-text.ts
+++ b/addon/plugins/citation-plugin/utils/cited-text.ts
@@ -1,6 +1,7 @@
 import { PNode } from '@lblod/ember-rdfa-editor';
 import { CitationSchema } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { v4 as uuid } from 'uuid';
 
 export function citedText(
   schema: CitationSchema,
@@ -12,6 +13,7 @@ export function citedText(
       href: uri,
       property: 'eli:cites',
       typeof: 'eli:LegalExpression',
+      __rdfaId: uuid(),
     }),
   ]);
 }

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -187,12 +187,18 @@ export const besluitArticleStructure: StructureSpec = {
     const numberConverted = number?.toString() ?? '1';
     const node = schema.node(
       `besluit_article`,
-      { resource: `http://data.lblod.info/articles/${uuid()}` },
+      {
+        resource: `http://data.lblod.info/articles/${uuid()}`,
+        __rdfaId: uuid(),
+      },
       [
-        schema.node('besluit_article_header', { number: numberConverted }),
+        schema.node('besluit_article_header', {
+          number: numberConverted,
+          __rdfaId: uuid(),
+        }),
         schema.node(
           `besluit_article_content`,
-          {},
+          { __rdfaId: uuid() },
           content ??
             schema.node(
               'paragraph',


### PR DESCRIPTION
This PR ensures that an __rdfaId is already added to title and article nodes as well as citation marks when creating them manually and to ensure these are not added after a reload. Solves https://binnenland.atlassian.net/browse/GN-4008?atlOrigin=eyJpIjoiODk1NmFlYmJjOGZhNDlmMTk3ODk5NDA1ZTE3ZWNjZmQiLCJwIjoiaiJ9.

Note: this is a temporary solution, ideally we should be able to add default generation functions to attributes such as __rdfaId. 