### PR TITLE
Fix: correcltly set the date type as xsd:date or xsd:dateTime based on the date content

### DIFF
--- a/addon/components/rdfa-date-plugin/card.ts
+++ b/addon/components/rdfa-date-plugin/card.ts
@@ -5,6 +5,7 @@ import { ProseController } from '@lblod/ember-rdfa-editor/core/prosemirror';
 import { NodeSelection, PNode } from '@lblod/ember-rdfa-editor';
 import { DateFormat } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/rdfa-date-plugin';
 import {
+  formatContainsTime,
   validateDateFormat,
   ValidationError,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/rdfa-date-plugin/utils';
@@ -28,7 +29,6 @@ type Args = {
     };
   };
 };
-const TIME_CHAR_REGEX = new RegExp('[abBhHkKmsStTp]');
 const SECONDS_REGEX = new RegExp('[sStT]|p{2,}');
 export default class RdfaDatePluginCardComponent extends Component<Args> {
   @service
@@ -84,8 +84,7 @@ export default class RdfaDatePluginCardComponent extends Component<Args> {
     return optionMapOr(
       false,
       (node) => {
-        const format = node.attrs.format as string;
-        return !TIME_CHAR_REGEX.test(format);
+        return !formatContainsTime(node.attrs.format);
       },
       this.selectedDateNode
     );
@@ -96,7 +95,7 @@ export default class RdfaDatePluginCardComponent extends Component<Args> {
       false,
       (node) => {
         const format = node.attrs.format as string;
-        return SECONDS_REGEX.test(format);
+        return SECONDS_REGEX.test(format.replace(/'[^']*'|"[^"]*"/g, ''));
       },
       this.selectedDateNode
     );
@@ -209,7 +208,7 @@ export default class RdfaDatePluginCardComponent extends Component<Args> {
       return tr
         .setNodeAttribute(pos, 'format', dateFormat)
         .setNodeAttribute(pos, 'custom', custom)
-        .setNodeAttribute(pos, 'onlyDate', this.onlyDate);
+        .setNodeAttribute(pos, 'onlyDate', !formatContainsTime(dateFormat));
     }, true);
   }
 
@@ -243,7 +242,7 @@ export default class RdfaDatePluginCardComponent extends Component<Args> {
       this.controller.withTransaction((tr) => {
         return tr
           .setNodeAttribute(pos, 'format', format)
-          .setNodeAttribute(pos, 'onlyDate', this.onlyDate);
+          .setNodeAttribute(pos, 'onlyDate', !formatContainsTime(format));
       }, true);
     }
   }

--- a/addon/plugins/rdfa-date-plugin/utils.ts
+++ b/addon/plugins/rdfa-date-plugin/utils.ts
@@ -2,12 +2,18 @@ import { formatWithOptions } from 'date-fns/fp';
 import { nlBE } from 'date-fns/locale';
 import { RegexpMatchArrayWithIndices } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin/utils/process-match';
 
+const TIME_CHAR_REGEX = new RegExp('[abBhHkKmsStTp]');
+
 export function formatDate(date: Date, format: string) {
   try {
     return formatWithOptions({ locale: nlBE }, format)(date);
   } catch (e) {
     return '';
   }
+}
+
+export function formatContainsTime(format: string){
+  return TIME_CHAR_REGEX.test(format.replace(/'[^']*'|"[^"]*"/g, ''));
 }
 
 type ValidationErrorType =

--- a/addon/plugins/rdfa-date-plugin/utils.ts
+++ b/addon/plugins/rdfa-date-plugin/utils.ts
@@ -12,7 +12,7 @@ export function formatDate(date: Date, format: string) {
   }
 }
 
-export function formatContainsTime(format: string){
+export function formatContainsTime(format: string) {
   return TIME_CHAR_REGEX.test(format.replace(/'[^']*'|"[^"]*"/g, ''));
 }
 


### PR DESCRIPTION
This PR fixes two issues:
- The check whether a date-format contains time-related characters now ignores text between quotation marks
- When adding/removing time from a date, `xsd:date` is used when it does not contain a time and `xsd:dateTime` is used when it does contain a time and not the other way around.