### PR TITLE
fix citation highlights not triggering correctly in various situations

### DIFF
--- a/addon/plugins/citation-plugin/utils/process-match.ts
+++ b/addon/plugins/citation-plugin/utils/process-match.ts
@@ -5,7 +5,8 @@ import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 const STOP_WORDS = ['het', 'de', 'van', 'tot', 'dat'];
 const DATE_REGEX = new RegExp('(\\d{1,2})\\s(\\w+)\\s(\\d{2,4})', 'g');
 const INVISIBLE_SPACE = '\u200B';
-const SPACES_REGEX = new RegExp('[\\s${UNBREAKABLE_SPACE}]+');
+const UNBREAKABLE_SPACE = '\u00A0';
+const SPACES_REGEX = new RegExp(`[\\s${UNBREAKABLE_SPACE}]+`);
 export type RegexpMatchArrayWithIndices = RegExpMatchArray & {
   indices: Array<[number, number]> & {
     groups: { [key: string]: [number, number] };

--- a/addon/plugins/citation-plugin/utils/process-match.ts
+++ b/addon/plugins/citation-plugin/utils/process-match.ts
@@ -57,13 +57,13 @@ export default function processMatch(
       cleanedSearchTerms = `${type} ${cleanedSearchTerms}`;
     } else if (/wetboek/i.test(type)) {
       typeLabel = 'wetboek';
-    } else if (/geco[oö]rdineerde[^\S\n]wetten/i.test(type)) {
+    } else if (/geco[oö]rdineerde[^\S\n]wet(ten)?/i.test(type)) {
       typeLabel = 'gecoördineerde wetten';
     } else if (/grondwets?wijziging/i.test(type)) {
       typeLabel = 'grondwetswijziging';
     } else if (/grondwet/i.test(type)) {
       typeLabel = 'grondwet';
-    } else if (/bijzondere wet/i.test(type)) {
+    } else if (/bijzondere[^\S\n]wet/i.test(type)) {
       typeLabel = 'bijzondere wet';
     } else if (/\w+wet/i.test(type)) {
       typeLabel = 'wet';


### PR DESCRIPTION
- highlights were calculated only on changed sections, but the non-changed highlights were thrown away in the process
- "bijzondere wet" was not triggering correctly
- the regex to strip away spaces used quotes instead of backticks, meaning it matched literally on each of the characters in `${UNBREAKABLE_SPACE}`