### PR TITLE
Hotfix: use content attribute as a fallback to extract the codelist URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fixed subsection 'move down' dutch translation
+- Hotfix: use content attribute as a fallback to extract the codelist URI
 
 ## [2.1.1] - 2023-02-07
 

--- a/addon/plugins/variable-plugin/nodes.ts
+++ b/addon/plugins/variable-plugin/nodes.ts
@@ -102,9 +102,12 @@ const emberNodeConfig: EmberNodeConfig = {
             .find((el) => hasRDFaAttribute(el, 'property', EXT('instance')))
             ?.getAttribute('resource');
           const mappingResource = node.getAttribute('resource');
-          const codelistResource = [...node.children]
-            .find((el) => hasRDFaAttribute(el, 'property', EXT('codelist')))
-            ?.getAttribute('resource');
+          const codelistSpan = [...node.children].find((el) =>
+            hasRDFaAttribute(el, 'property', EXT('codelist'))
+          );
+          const codelistResource =
+            codelistSpan?.getAttribute('resource') ??
+            codelistSpan?.getAttribute('content');
           const source = [...node.children]
             .find((el) => hasRDFaAttribute(el, 'property', DCT('source')))
             ?.getAttribute('resource');


### PR DESCRIPTION
For newly created codelists in MOW, the `resource` attribute is used to indicate the codelist URI, but in older codelists, the `content` attribute was used. This is a hotfix which ensures that possible `content` attributes are checked in order to extract the codelist URI.

Solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-4095.