### PR TITLE
Feature/allow paragraphs inside article paragraphs

### DIFF
--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -71,13 +71,17 @@ export const article_paragraph: NodeSpec = {
         typeof: node.attrs.typeof as string,
         resource: node.attrs.resource as string,
       },
-      '$',
+      ['span', { contenteditable: false }, '$'],
       [
         'span',
-        { property: ELI('number').prefixed, datatype: XSD('integer').prefixed },
+        {
+          property: ELI('number').prefixed,
+          datatype: XSD('integer').prefixed,
+          contenteditable: false,
+        },
         node.attrs.number,
       ],
-      '. ',
+      ['span', { contenteditable: false }, '. '],
       ['span', { property: SAY('body').prefixed }, 0],
     ];
   },

--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -31,9 +31,13 @@ export const articleParagraphSpec: StructureSpec = {
         resource: `http://data.lblod.info/paragraphs/${uuid()}`,
         number: numberConverted,
       },
-      schema.node('placeholder', {
-        placeholderText: intl?.t(PLACEHOLDERS.body),
-      })
+      schema.node(
+        'paragraph',
+        {},
+        schema.node('placeholder', {
+          placeholderText: intl?.t(PLACEHOLDERS.body),
+        })
+      )
     );
     return { node, selectionConfig: { relativePos: 1, type: 'node' } };
   },
@@ -47,7 +51,7 @@ const contentSelector = `span[property~='${SAY('body').prefixed}'],
                          span[property~='${SAY('body').full}']`;
 
 export const article_paragraph: NodeSpec = {
-  content: 'inline*',
+  content: 'paragraph*',
   inline: false,
   isolating: true,
   defining: true,

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -106,10 +106,14 @@ export const article_header: NodeSpec = {
       'Artikel ',
       [
         'span',
-        { property: ELI('number').prefixed, datatype: XSD('string').prefixed },
+        {
+          property: ELI('number').prefixed,
+          datatype: XSD('string').prefixed,
+          contenteditable: false,
+        },
         node.attrs.number,
       ],
-      ': ',
+      ['span', { contenteditable: false }, ': '],
       [
         'span',
         {

--- a/addon/plugins/article-structure-plugin/structures/structure-header.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header.ts
@@ -43,10 +43,14 @@ export const structure_header: NodeSpec = {
       { property: node.attrs.property as string },
       [
         'span',
-        { property: ELI('number').prefixed, datatype: XSD('string').prefixed },
+        {
+          property: ELI('number').prefixed,
+          datatype: XSD('string').prefixed,
+          contenteditable: false,
+        },
         node.attrs.number,
       ],
-      '. ',
+      ['span', { contenteditable: false }, '. '],
       [
         'span',
         {

--- a/addon/plugins/article-structure-plugin/structures/structure-header.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header.ts
@@ -21,6 +21,7 @@ export const structure_header: NodeSpec = {
   inline: false,
   defining: true,
   isolating: true,
+  selectable: false,
   attrs: {
     property: {
       default: SAY('heading').prefixed,

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -249,7 +249,7 @@ export const besluit_article_header: NodeSpec = {
     delete toplevelAttrs.datatype;
     return [
       'div',
-      toplevelAttrs,
+      { ...toplevelAttrs, contenteditable: false },
       'Artikel ',
       [
         'span',

--- a/app/styles/article-structure-plugin.scss
+++ b/app/styles/article-structure-plugin.scss
@@ -1,0 +1,7 @@
+[typeof="say:Paragraph"] {
+  display: flex;
+
+  [property="eli:number"], [contenteditable="false"], [property="say:body"] {
+    margin-top: 0;
+  }
+}

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -8,6 +8,7 @@
 @import 'date-plugin';
 @import 'variable-plugin';
 @import 'besluit-plugin';
+@import 'article-structure-plugin';
 
 div.table-of-contents {
    padding: $au-unit-small !important;


### PR DESCRIPTION
This is open for discussion as it would change the meaning of article paragraphs, by allowing normal paragraphs inside them we fix 2 things, we allow line breaks with the enter handler as they are normally represented with a paragraph in prosemirror and we make it easier to paste from word inside the article paragraphs.
It makes sense to me but it can be weird that something called paragraph can have paragraphs inside so maybe I'm running into problems I'm not seeing