### PR TITLE
Added a new option to the structures to not support unwrap and made the article paragraphs the first structure to use this option

### DIFF
--- a/addon/components/article-structure-plugin/structure-card.hbs
+++ b/addon/components/article-structure-plugin/structure-card.hbs
@@ -26,10 +26,12 @@
           </AuButton>
         </Item>
         <Item>
-          <AuToggleSwitch 
-            @label={{t "article-structure-plugin.remove.content"}} 
-            @checked={{this.removeStructureContent}}
-            @onChange={{this.setRemoveStructureContent}}/>
+          {{#unless this.currentStructureType.noUnwrap}}
+            <AuToggleSwitch
+              @label={{t "article-structure-plugin.remove.content"}}
+              @checked={{this.removeStructureContent}}
+              @onChange={{this.setRemoveStructureContent}}/>
+          {{/unless}}
           <AuButton
             @icon="bin"
             @iconAlignment="left"

--- a/addon/components/article-structure-plugin/structure-card.ts
+++ b/addon/components/article-structure-plugin/structure-card.ts
@@ -38,7 +38,7 @@ export default class EditorPluginsStructureCardComponent extends Component<Args>
   @action
   removeStructure() {
     if (this.structure && this.currentStructureType) {
-      if (this.removeStructureContent) {
+      if (this.removeStructureContent || this.currentStructureType.noUnwrap) {
         this.controller.doCommand(
           removeStructure(this.structure, this.structureTypes)
         );
@@ -105,7 +105,7 @@ export default class EditorPluginsStructureCardComponent extends Component<Args>
 
   get canRemoveStructure() {
     if (this.structure && this.currentStructureType) {
-      if (this.removeStructureContent) {
+      if (this.removeStructureContent || this.currentStructureType.noUnwrap) {
         return true;
       } else {
         return this.controller.checkCommand(

--- a/addon/plugins/article-structure-plugin/index.ts
+++ b/addon/plugins/article-structure-plugin/index.ts
@@ -41,6 +41,7 @@ export type StructureSpec = {
   content?: (args: { pos: number; state: EditorState }) => Fragment;
   continuous: boolean;
   limitTo?: string;
+  noUnwrap?: boolean;
 };
 
 export type ArticleStructurePluginOptions = StructureSpec[];

--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -23,6 +23,7 @@ export const articleParagraphSpec: StructureSpec = {
     remove: 'article-structure-plugin.remove.paragraph',
   },
   continuous: true,
+  noUnwrap: true,
   constructor: ({ schema, number, intl }) => {
     const numberConverted = number?.toString() ?? '1';
     const node = schema.node(


### PR DESCRIPTION
Per Bart request, it doesn't really make sense to unwrap an article paragraph. So I added this new option that allows you to define a structure without the unwrap behaviour