### PR TITLE
Remove unused code and plugin dependency from citation-insert component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update schema on dummy page to make articles insertable in empty document
 - Add padding to structure card
 
+### Removed:
+- Removal of prosemirror-plugin dependency of `CitationPlugin::CitationInsert` component.
+
 ## [3.1.0] - 2023-03-02
 
 ### Fixed

--- a/addon/components/citation-plugin/citation-insert.ts
+++ b/addon/components/citation-plugin/citation-insert.ts
@@ -12,10 +12,7 @@ import {
   Decision,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin/utils/vlaamse-codex';
 import { citedText } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin/utils/cited-text';
-import {
-  CitationPlugin,
-  CitationPluginConfig,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
+import { CitationPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
 import {
   LEGISLATION_TYPE_CONCEPTS,
   LEGISLATION_TYPES,
@@ -25,7 +22,6 @@ import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 
 interface Args {
   controller: SayController;
-  plugin: CitationPlugin;
   config: CitationPluginConfig;
 }
 
@@ -82,14 +78,6 @@ export default class EditorPluginsCitationInsertComponent extends Component<Args
       );
       return !findParentNodeOfType([...nodeTypes])(selection);
     }
-  }
-
-  get plugin() {
-    return this.args.plugin;
-  }
-
-  get activeRanges() {
-    return this.plugin.getState(this.controller.mainEditorState)?.activeRanges;
   }
 
   get controller() {

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -63,7 +63,6 @@
                 />
                 <CitationPlugin::CitationInsert 
                   @controller={{this.controller}} 
-                  @plugin={{this.citationPlugin}}
                   @config={{this.config.citation}}
                 />
                 <RdfaDatePlugin::Insert 


### PR DESCRIPTION
This PR ensures the citation-plugin functionality can be used without the citation prosemirror-plugin and regex-based autocomplete feature.

In order to integrate the citation-plugin without the autocomplete functionality, only the `CitationPlugin::CitationInsert` needs to be used.