### PR TITLE
Ensure citation suggestions are only updated when search-text or document-legislation-type updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Ensure citation suggestions are only updated when search-text or document-legislation-type updates.
+
 ### Changed
 - Feature: make citation use the new link node
 - BREAKING: citation mark has been removed

--- a/addon/components/citation-plugin/citation-card.hbs
+++ b/addon/components/citation-plugin/citation-card.hbs
@@ -11,6 +11,10 @@
       this.documentText
       this.documentLegislationType
     }}
+    {{did-update
+      this.update
+      this.activeDecoration
+    }}
     as |c|
   >
     <c.header>

--- a/addon/components/citation-plugin/citation-card.ts
+++ b/addon/components/citation-plugin/citation-card.ts
@@ -42,6 +42,21 @@ export default class CitationCardComponent extends Component<Args> {
   @tracked decision: Decision | null = null;
   @tracked cardText: string | null = null;
   @tracked cardLegislationType: string | null = null;
+  @tracked documentLegislationType: Option<string>;
+  @tracked documentText: Option<string>;
+
+  @action
+  update() {
+    if (this.activeDecoration) {
+      const { legislationTypeUri, searchText } = this.activeDecoration?.spec;
+      if (legislationTypeUri !== this.documentLegislationType) {
+        this.documentLegislationType = legislationTypeUri;
+      }
+      if (searchText !== this.documentText) {
+        this.documentText = searchText;
+      }
+    }
+  }
 
   get controller(): SayController {
     return this.args.controller;
@@ -62,14 +77,6 @@ export default class CitationCardComponent extends Component<Args> {
   get activeDecoration(): Option<CitationDecoration> {
     const { from, to } = this.controller.mainEditorState.selection;
     return this.decorations?.find(from, to)[0];
-  }
-
-  get documentLegislationType(): Option<string> {
-    return this.activeDecoration?.spec.legislationTypeUri;
-  }
-
-  get documentText(): Option<string> {
-    return this.activeDecoration?.spec.searchText;
   }
 
   get searchText(): string {

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -58,7 +58,13 @@ import {
   citationPlugin,
   CitationPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
-
+import {
+  createInvisiblesPlugin,
+  hardBreak,
+  heading as headingInvisible,
+  paragraph as paragraphInvisible,
+  space,
+} from '@lblod/ember-rdfa-editor/plugins/invisibles';
 export default class BesluitSampleController extends Controller {
   @service declare importRdfaSnippet: importRdfaSnippet;
   @service declare intl: IntlService;
@@ -161,7 +167,17 @@ export default class BesluitSampleController extends Controller {
       link: linkView(this.config.link)(controller),
     };
   };
-  @tracked plugins: Plugin[] = [tablePlugin, tableKeymap, this.citationPlugin];
+  @tracked plugins: Plugin[] = [
+    tablePlugin,
+    tableKeymap,
+    this.citationPlugin,
+    createInvisiblesPlugin(
+      [space, hardBreak, paragraphInvisible, headingInvisible],
+      {
+        shouldShowInvisibles: false,
+      }
+    ),
+  ];
 
   @action
   setPrefixes(element: HTMLElement) {

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -55,7 +55,13 @@ import { code_block } from '@lblod/ember-rdfa-editor/plugins/code';
 import { image } from '@lblod/ember-rdfa-editor/plugins/image';
 import { inline_rdfa } from '@lblod/ember-rdfa-editor/marks';
 import date from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/rdfa-date-plugin/nodes/date';
-
+import {
+  createInvisiblesPlugin,
+  hardBreak,
+  heading as headingInvisible,
+  paragraph as paragraphInvisible,
+  space,
+} from '@lblod/ember-rdfa-editor/plugins/invisibles';
 export default class RegulatoryStatementSampleController extends Controller {
   @service declare importRdfaSnippet: ImportRdfaSnippet;
   @service declare intl: IntlService;
@@ -166,7 +172,16 @@ export default class RegulatoryStatementSampleController extends Controller {
       link: linkView(this.config.link)(controller),
     };
   };
-  @tracked plugins: Plugin[] = [tablePlugin, tableKeymap];
+  @tracked plugins: Plugin[] = [
+    tablePlugin,
+    tableKeymap,
+    createInvisiblesPlugin(
+      [space, hardBreak, paragraphInvisible, headingInvisible],
+      {
+        shouldShowInvisibles: false,
+      }
+    ),
+  ];
 
   @action
   setPrefixes(element: HTMLElement) {

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -40,6 +40,7 @@
               </Tb.Group>
               <Tb.Spacer/>
               <Tb.Group>
+                <Plugins::Formatting::FormattingToggle @controller={{this.controller}}/>
                 <BesluitTypePlugin::ToolbarDropdown @controller={{this.controller}}/>
                 <Plugins::RdfaBlockRender::RdfaBlocksToggle @controller={{this.controller}}/>
               </Tb.Group>

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -40,6 +40,7 @@
             </Tb.Group>
             <Tb.Spacer/>
             <Tb.Group>
+              <Plugins::Formatting::FormattingToggle @controller={{this.controller}}/>
               <TableOfContentsPlugin::ToolbarButton @controller={{this.controller}}/>
               <Plugins::RdfaBlockRender::RdfaBlocksToggle @controller={{this.controller}}/>
             </Tb.Group>


### PR DESCRIPTION
The tracked `documentText` and `documentLegislationType` properties are only updated if they change, this ensures that the citation suggestions are less frequently reloaded. Should solve https://binnenland.atlassian.net/browse/GN-4191