### PR TITLE
Change date labels based on designer feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change paragraph symbol to §
 - Update schema on dummy page to make articles insertable in empty document
 - Add padding to structure card
+- Change date labels based on designer feedback
 
 ## [3.1.0] - 2023-03-02
 

--- a/addon/components/rdfa-date-plugin/card.hbs
+++ b/addon/components/rdfa-date-plugin/card.hbs
@@ -47,7 +47,7 @@
           {{#each this.formats as |format|}}
             <AuFormRow>
               <AuControlRadio
-                @label={{format.label}}
+                @label={{if this.onlyDate format.dateFormat format.dateTimeFormat}}
                 @identifier={{format.key}}
                 @name="dateFormat"
                 @value={{format.key}}

--- a/addon/components/rdfa-date-plugin/card.hbs
+++ b/addon/components/rdfa-date-plugin/card.hbs
@@ -47,7 +47,7 @@
           {{#each this.formats as |format|}}
             <AuFormRow>
               <AuControlRadio
-                @label={{if this.onlyDate format.dateFormat format.dateTimeFormat}}
+                @label={{if format.label format.label (if this.onlyDate format.dateFormat format.dateTimeFormat)}}
                 @identifier={{format.key}}
                 @name="dateFormat"
                 @value={{format.key}}

--- a/addon/plugins/rdfa-date-plugin/index.ts
+++ b/addon/plugins/rdfa-date-plugin/index.ts
@@ -12,6 +12,7 @@ export const defaultDateFormats: DateFormat[] = [
 ];
 
 export type DateFormat = {
+  label?: string;
   key: string;
   dateFormat: string;
   dateTimeFormat: string;

--- a/addon/plugins/rdfa-date-plugin/index.ts
+++ b/addon/plugins/rdfa-date-plugin/index.ts
@@ -1,12 +1,10 @@
 export const defaultDateFormats: DateFormat[] = [
   {
-    label: 'Short Date',
     key: 'short',
     dateFormat: 'dd/MM/yy',
     dateTimeFormat: 'dd/MM/yy HH:mm',
   },
   {
-    label: 'Long Date',
     key: 'long',
     dateFormat: 'EEEE dd MMMM yyyy',
     dateTimeFormat: 'PPPPp',
@@ -14,7 +12,6 @@ export const defaultDateFormats: DateFormat[] = [
 ];
 
 export type DateFormat = {
-  label: string;
   key: string;
   dateFormat: string;
   dateTimeFormat: string;

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -125,13 +125,11 @@ export default class BesluitSampleController extends Controller {
         },
         formats: [
           {
-            label: 'Short Date',
             key: 'short',
             dateFormat: 'dd/MM/yy',
             dateTimeFormat: 'dd/MM/yy HH:mm',
           },
           {
-            label: 'Long Date',
             key: 'long',
             dateFormat: 'EEEE dd MMMM yyyy',
             dateTimeFormat: 'PPPPp',

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -130,13 +130,11 @@ export default class RegulatoryStatementSampleController extends Controller {
         },
         formats: [
           {
-            label: 'Short Date',
             key: 'short',
             dateFormat: 'dd/MM/yy',
             dateTimeFormat: 'dd/MM/yy HH:mm',
           },
           {
-            label: 'Long Date',
             key: 'long',
             dateFormat: 'EEEE dd MMMM yyyy',
             dateTimeFormat: 'PPPPp',


### PR DESCRIPTION
Saska said that putting the formats in the labels was going to be more clear to the end user