### PR TITLE
Feature/improve toc scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update schema on dummy page to make articles insertable in empty document
 - Add padding to structure card
 - Placeholder text when inserting date
+- Feature/improve toc scroll
 
 ### Removed:
 - Removal of prosemirror-plugin dependency of `CitationPlugin::CitationInsert` component.

--- a/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
+++ b/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
@@ -83,7 +83,24 @@ export default class TableOfContentsComponent extends Component<EmberNodeArgs> {
       const selection = Selection.near(resolvedPos, 1);
       if (selection) {
         tr.setSelection(selection);
-        tr.scrollIntoView();
+        const coords = this.controller.mainEditorView.coordsAtPos(
+          selection.from
+        );
+        const config = this.config[0];
+        if (config.scrollContainer) {
+          const sayContainer = document.getElementsByClassName(
+            config.scrollContainer
+          )[0];
+          const alreadyScrolled = sayContainer.scrollTop;
+          const MAGIC_NUMBER_TOPBAR_HEIGHT: number =
+            config.scrollingPadding ?? 150;
+          sayContainer.scrollTo(
+            0,
+            coords.top + alreadyScrolled - MAGIC_NUMBER_TOPBAR_HEIGHT
+          );
+        } else {
+          tr.scrollIntoView();
+        }
       }
       return tr;
     });

--- a/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
+++ b/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
@@ -88,13 +88,11 @@ export default class TableOfContentsComponent extends Component<EmberNodeArgs> {
         );
         const config = this.config[0];
         if (config.scrollContainer) {
-          const sayContainer = document.getElementsByClassName(
-            config.scrollContainer
-          )[0];
-          const alreadyScrolled = sayContainer.scrollTop;
+          const scrollContainer: HTMLElement = config.scrollContainer;
+          const alreadyScrolled = scrollContainer.scrollTop;
           const MAGIC_NUMBER_TOPBAR_HEIGHT: number =
             config.scrollingPadding ?? 150;
-          sayContainer.scrollTo(
+          scrollContainer.scrollTo(
             0,
             coords.top + alreadyScrolled - MAGIC_NUMBER_TOPBAR_HEIGHT
           );

--- a/addon/plugins/table-of-contents-plugin/index.ts
+++ b/addon/plugins/table-of-contents-plugin/index.ts
@@ -1,5 +1,5 @@
 export type TableOfContentsConfig = {
   nodeHierarchy: string[];
-  scrollContainer: string;
-  scrollingPadding: number;
+  scrollContainer?: string;
+  scrollingPadding?: number;
 }[];

--- a/addon/plugins/table-of-contents-plugin/index.ts
+++ b/addon/plugins/table-of-contents-plugin/index.ts
@@ -1,5 +1,5 @@
 export type TableOfContentsConfig = {
   nodeHierarchy: string[];
-  scrollContainer?: string;
+  scrollContainer?: HTMLElement;
   scrollingPadding?: number;
 }[];

--- a/addon/plugins/table-of-contents-plugin/index.ts
+++ b/addon/plugins/table-of-contents-plugin/index.ts
@@ -1,3 +1,5 @@
 export type TableOfContentsConfig = {
   nodeHierarchy: string[];
+  scrollContainer: string;
+  scrollingPadding: number;
 }[];

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -127,6 +127,7 @@ export default class RegulatoryStatementSampleController extends Controller {
             'title|chapter|section|subsection|article',
             'structure_header|article_header',
           ],
+          scrollContainer: 'say-container__main',
         },
       ],
       date: {

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -127,7 +127,9 @@ export default class RegulatoryStatementSampleController extends Controller {
             'title|chapter|section|subsection|article',
             'structure_header|article_header',
           ],
-          scrollContainer: 'say-container__main',
+          scrollContainer: document.getElementsByClassName(
+            'say-container__main'
+          )[0] as HTMLElement,
         },
       ],
       date: {


### PR DESCRIPTION
I don't really like the solution to be honest because it involves a magic number and it has to be individually configured for every environment the editor runs on. Furthermore it has to change if the height of the topbar changes, but at least is better than before, and we can always run the previous behaviour if not configured.
As this was timeboxed I didn't want to really go further but this can be improved by maybe calculating this magic number in any way, but I don't know how right now