### PR TITLE
fix(citation): make plugin trigger correctly when `doc` is passed as an allowed nodeType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.0] - 2023-03-27
 
+### Added
+- docs: add examples on how to enable the citation plugin for the entire document
+
 ### Fixed
 - Ensure citation suggestions are only updated when search-text or document-legislation-type updates.
+- fix(citation): make plugin trigger correctly when `doc` is passed as an allowed nodeType
 
 ### Changed
 - Feature: make citation use the new link node

--- a/README.md
+++ b/README.md
@@ -101,6 +101,31 @@ Configuration:
   - activeInRanges: it's a function that gets the state of the actual instance of the editor and returns an array of ranges for the plugin to be active in, for example `[[0,50], [70,100]]`
   - regex: you can provide your custom regex to detect citations, if not the default one will be used
 
+
+A common usecase is to have the plugin active in the entire document. Here's how to do that using each configuration type:
+
+```js
+import { citationPlugin } from "@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin";
+
+const configA = {
+   type: "nodes",
+   activeInNodeTypes(schema) {
+     // the root node of the document should always have the doc type
+     return new Set([schema.nodes.doc]);
+   }
+ };
+  
+const configB = {
+  type: "ranges",
+  activeInRanges(state) {
+    // a node's nodeSize follows the Prosemirror definition
+    // a non-leaf node's size is the sum of its children's sizes + 2
+    // so to get the last valid position "inside" a node, you need to subtract two from its nodeSize
+    // ref: https://prosemirror.net/docs/ref/#model.Node.nodeSize 
+    return [[0, state.doc.nodeSize - 2]];
+  }
+};
+```
 ### Using the plugin
 If used with the example configuration provided this plugin can be triggered by typing one of the following in the correct RDFa context (the [besluit:motivering](http://data.vlaanderen.be/ns/besluit#motivering) of a [besluit:Besluit](https://data.vlaanderen.be/ns/besluit#Besluit)).
 

--- a/addon/components/citation-plugin/citation-insert.ts
+++ b/addon/components/citation-plugin/citation-insert.ts
@@ -76,6 +76,12 @@ export default class EditorPluginsCitationInsertComponent extends Component<Args
         this.controller.schema,
         this.controller.mainEditorState
       );
+      // if the doc node is included, the button should always be active
+      // the findParentNodeOfType util we import does NOT consider the doc node
+      // in its search.
+      if (nodeTypes.has(this.controller.schema.nodes.doc)) {
+        return false;
+      }
       return !findParentNodeOfType([...nodeTypes])(selection);
     }
   }


### PR DESCRIPTION
cause was a misunderstanding of how `findParentNodeOfType` works. Turns out it never visits the root node.

also updated docs with examples of how to activate the plugin in the entire document