### PR TITLE
fix(decision-nodes): make nodespecs unambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.1] - 2023-03-27
 
+### Fixed
+- Prevent decision nodes regenerating when (de)serializing
+
 ### Dependencies
 - bump `ember-rdfa-editor` to v3.4.1
 

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -127,14 +127,12 @@ export const article_container: NodeSpec = {
     {
       tag: 'div',
       getAttrs(element: HTMLElement) {
-        if (
-          hasRDFaAttribute(element, 'property', PROV('value')) &&
-          hasRDFaAttribute(element, 'typeof', BESLUIT('Besluit'))
-        ) {
+        if (hasRDFaAttribute(element, 'property', PROV('value'))) {
           return getRdfaAttrs(element);
         }
         return false;
       },
+      context: 'besluit/',
     },
   ],
 };
@@ -279,6 +277,7 @@ export const besluit_article_header: NodeSpec = {
 };
 
 export const besluit_article_content: NodeSpec = {
+  group: 'block',
   content: 'block+',
   inline: false,
   attrs: {
@@ -302,6 +301,7 @@ export const besluit_article_content: NodeSpec = {
         }
         return false;
       },
+      context: 'besluit_article//',
     },
   ],
 };


### PR DESCRIPTION
One of the specs was simply wrong: the article_section of a decision should not have the decision type. In certain scenarios, this node was created by default (without the type), which caused a weird state in combination with the besluit_article_content spec, causing the document state to always change when serializing/deserializing

fix: added a context specifier for both nodes so they only parse in the exact cases they are expected to

solves (or helps with solving) https://binnenland.atlassian.net/browse/GN-4169