### PR TITLE
[Variables/codelists] support labels in codelists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - navigation links in TOC of readme
+- support for option labels in Variable-plugin
 
 ## [7.1.0] - 2023-05-18
 

--- a/addon/plugins/variable-plugin/utils/fetch-data.ts
+++ b/addon/plugins/variable-plugin/utils/fetch-data.ts
@@ -15,19 +15,23 @@ export type CodeListOption = {
 
 function generateCodeListOptionsQuery(codelistUri: string): string {
   const codeListOptionsQuery = `
-    PREFIX lblodMobilitiet: <http://data.lblod.info/vocabularies/mobiliteit/>
+    PREFIX lblodMobiliteit: <http://data.lblod.info/vocabularies/mobiliteit/>
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX schema: <http://schema.org/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     SELECT DISTINCT * WHERE { 
-      <${codelistUri}> a lblodMobilitiet:Codelist.
+      <${codelistUri}> a lblodMobiliteit:Codelist.
       ?codelistOptions skos:inScheme <${codelistUri}>.
-      ?codelistOptions skos:prefLabel ?label.
+      ?codelistOptions skos:prefLabel ?value.
       OPTIONAL {
         ?codelistOptions schema:position ?position .
       }
       OPTIONAL {
         <${codelistUri}> dct:type ?type.
+      }
+      OPTIONAL {
+        ?codelistOptions ext:summary ?label.
       }
     }
     ORDER BY (!BOUND(?position)) ASC(?position)
@@ -56,8 +60,8 @@ export async function fetchCodeListOptions(
 function parseCodelistOptions(queryResult: QueryResult): CodeListOption[] {
   const bindings = queryResult.results.bindings;
   return bindings.map((binding) => ({
-    value: binding['label']?.value,
-    label: binding['label']?.value,
+    value: binding['value']?.value,
+    label: binding['label'] ? binding['label'].value : binding['value']?.value,
   }));
 }
 


### PR DESCRIPTION
connected PR: [frontend-reglementaire-bijlage #81](https://github.com/lblod/frontend-reglementaire-bijlage/pull/81)

Also fetches labels of codelist options (if they exist) and show them (if they exist).
Note: this change is not yet done for MOW. However, this update works with options with no labels too. So this is not breaking and can be merged before that fix.