### PR TITLE
GN-4323: Sidebar button for fragment and a simple modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Numbers inputted into a number variable are validated on defined min/max and if it is a number
+- Fragment insert modal
 
 ### Fixed
 - Fixed woodpecker builds crashing on syntax errors
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.0.1] - 2023-06-15
 ### Fixed
 - Change problematic type in citation that made it to break with new ember
+
 
 ## [8.0.0] - 2023-06-15
 ### Fixed

--- a/addon/components/fragment-plugin/fragment-insert.hbs
+++ b/addon/components/fragment-plugin/fragment-insert.hbs
@@ -1,0 +1,15 @@
+<AuList::Item>
+  <AuButton
+    @icon='add'
+    @iconAlignment='left'
+    @skin='link'
+    {{on 'click' this.openModal}}
+  >
+    {{t 'fragment-plugin.insert.title'}}
+  </AuButton>
+</AuList::Item>
+
+<FragmentPlugin::SearchModal
+  @open={{this.showModal}}
+  @closeModal={{this.closeModal}}
+/>

--- a/addon/components/fragment-plugin/fragment-insert.ts
+++ b/addon/components/fragment-plugin/fragment-insert.ts
@@ -1,0 +1,28 @@
+import { action } from '@ember/object';
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import { SayController } from '@lblod/ember-rdfa-editor';
+
+interface Args {
+  controller: SayController;
+}
+
+export default class FragmentInsertComponent extends Component<Args> {
+  @tracked showModal = false;
+
+  get controller() {
+    return this.args.controller;
+  }
+
+  @action
+  openModal() {
+    this.showModal = true;
+  }
+
+  @action
+  closeModal() {
+    this.showModal = false;
+  }
+}

--- a/addon/components/fragment-plugin/search-modal.hbs
+++ b/addon/components/fragment-plugin/search-modal.hbs
@@ -1,0 +1,46 @@
+<AuModal
+  @modalOpen={{@open}}
+  @closeModal={{fn this.closeModal this.legislationTypeUri this.text}}
+  @title={{t 'fragment-plugin.modal.title'}}
+  @size='large'
+  @padding='none'
+  as |modal|
+>
+  <modal.Body>
+    <AuMainContainer class='fragment-modal--main-container' as |mc|>
+      <mc.sidebar>
+        <div class='au-c-sidebar'>
+          <div class='au-c-sidebar__content au-u-padding'>
+            <AuHeading @level='3' @skin='4' class='au-u-padding-bottom-small'>
+              {{t 'fragment-plugin.modal.search.title'}}
+            </AuHeading>
+            <AuLabel
+              class='au-margin-bottom-small'
+              for='searchTerm'
+              @inline={{false}}
+              @required={{false}}
+              @error={{false}}
+              @warning={{false}}
+            >
+              {{t 'fragment-plugin.modal.search.label'}}
+            </AuLabel>
+            <AuNativeInput
+              @type='text'
+              @width='block'
+              id='searchTerm'
+              value={{this.searchText}}
+              placeholder={{t 'fragment-plugin.modal.search.placeholder'}}
+              {{on 'input' this.setInputSearchText}}
+            />
+          </div>
+        </div>
+      </mc.sidebar>
+      <mc.content @scroll={{true}}>
+        <div class='au-u-padding-top'>
+          Hello you are searching for:
+          {{this.inputSearchText}}
+        </div>
+      </mc.content>
+    </AuMainContainer>
+  </modal.Body>
+</AuModal>

--- a/addon/components/fragment-plugin/search-modal.ts
+++ b/addon/components/fragment-plugin/search-modal.ts
@@ -1,0 +1,29 @@
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface Args {
+  config: { endpoint: string };
+  closeModal: () => void;
+}
+
+export default class FragmentPluginSearchModalComponent extends Component<Args> {
+  @tracked inputSearchText: string | null = null;
+
+  @action
+  setInputSearchText(event: InputEvent) {
+    assert(
+      'inputSearchText must be bound to an input element',
+      event.target instanceof HTMLInputElement
+    );
+
+    this.inputSearchText = event.target.value;
+  }
+
+  @action
+  closeModal() {
+    this.args.closeModal();
+  }
+}

--- a/app/components/fragment-plugin/fragment-insert.js
+++ b/app/components/fragment-plugin/fragment-insert.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/fragment-plugin/fragment-insert';

--- a/app/components/fragment-plugin/search-modal.js
+++ b/app/components/fragment-plugin/search-modal.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/fragment-plugin/search-modal';

--- a/app/styles/fragment-plugin.scss
+++ b/app/styles/fragment-plugin.scss
@@ -1,0 +1,11 @@
+.fragment-modal {
+  &--main-container {
+    height: 100% !important;
+
+    background-color: var(--au-gray-100);
+
+    .au-c-sidebar {
+      border-right: 0;
+    }
+  }
+}

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -11,6 +11,7 @@
 @import 'article-structure-plugin';
 @import 'address-plugin';
 @import 'generic-rdfa-variable';
+@import 'fragment-plugin';
 
 div.table-of-contents {
   padding: $au-unit-small !important;

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -8,12 +8,12 @@
     <:content>
       <EditorContainer
         @editorOptions={{hash
-        showRdfa='true'
-        showRdfaHighlight='true'
-        showRdfaHover='true'
-        showPaper='true'
-        showToolbarBottom=null
-      }}
+          showRdfa='true'
+          showRdfaHighlight='true'
+          showRdfaHover='true'
+          showPaper='true'
+          showToolbarBottom=null
+        }}
         @showRdfaBlocks={{this.controller.showRdfaBlocks}}
       >
         <:top>
@@ -70,22 +70,30 @@
           {{#if this.controller}}
             <Sidebar as |Sidebar|>
               <Sidebar.Collapsible @title='Insert'>
-                <AuButton @skin="link"
-                          @disabled={{not this.canInsertDescription}}
-                  {{on "click" this.insertDescription}}>
+                <AuButton
+                  @skin='link'
+                  @disabled={{not this.canInsertDescription}}
+                  {{on 'click' this.insertDescription}}
+                >
                   description
                 </AuButton>
-                <AuButton @skin="link"
-                          @disabled={{not this.canInsertTitle}}
-                  {{on "click" this.insertTitle}}>title
+                <AuButton
+                  @skin='link'
+                  @disabled={{not this.canInsertTitle}}
+                  {{on 'click' this.insertTitle}}
+                >title
                 </AuButton>
-                <AuButton @skin="link"
-                          @disabled={{not this.canInsertMotivation}}
-                  {{on "click" this.insertMotivation}}>motivation
+                <AuButton
+                  @skin='link'
+                  @disabled={{not this.canInsertMotivation}}
+                  {{on 'click' this.insertMotivation}}
+                >motivation
                 </AuButton>
-                <AuButton @skin="link"
-                          @disabled={{not this.canInsertContainer}}
-                  {{on "click" this.insertArticleContainer}}>articles
+                <AuButton
+                  @skin='link'
+                  @disabled={{not this.canInsertContainer}}
+                  {{on 'click' this.insertArticleContainer}}
+                >articles
                 </AuButton>
                 <ArticleStructurePlugin::ArticleStructureCard
                   @controller={{this.controller}}
@@ -105,6 +113,9 @@
                   @options={{this.config.roadsignRegulation}}
                 />
                 <StandardTemplatePlugin::Card @controller={{this.controller}} />
+                <FragmentPlugin::FragmentInsert
+                  @controller={{this.controller}}
+                />
               </Sidebar.Collapsible>
               <ArticleStructurePlugin::StructureCard
                 @controller={{this.controller}}

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -227,3 +227,13 @@ generic-rdfa-variable:
   modal:
     insert: Insert
     cancel: Cancel
+
+fragment-plugin:
+  insert:
+    title: Insert fragment
+  modal:
+    title: Choose a fragment
+    search:
+      title: Filter on
+      label: Fragment name
+      placeholder: Type something...

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -197,7 +197,7 @@ variable:
     type-number: typ een nummer...
     error-not-integer: Only integers are allowed
     error-not-number: Only numbers are allowed
-    error-number-between: The number should be between {minValue} and {maxValue} 
+    error-number-between: The number should be between {minValue} and {maxValue}
     error-number-above: The number should be bigger than {minValue}
     error-number-below: The number should be smaller than {maxValue}
 variable-plugin:
@@ -232,3 +232,13 @@ generic-rdfa-variable:
   modal:
     insert: Invoegen
     cancel: Terug
+
+fragment-plugin:
+  insert:
+    title: Fragment invoegen
+  modal:
+    title: Kies een fragment
+    search:
+      title: Filter op
+      label: Fragmentnaam
+      placeholder: Typ iets...


### PR DESCRIPTION
## N.B. Note that this PR is one of 5 (currently) PRs for insert fragment functionality, I've tried to break them down into smaller parts.

### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Note that this PR is one of 5 (currently) PRs for insert fragment functionality. This PR adds "Fragment insert" in the sidebar and the "Fragment search modal"

#### Connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4323

#### Added
- Fragment Insert button for the sidebar
- Fragment search modal

### How to test/reproduce
Open the Besluit editor and click on the 'Fragment Insert' button in the sidebar. Verify that the modal appears


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check if dummy app is correctly updated
- [X] Check cancel/go-back flows
- [x] changelog
- [X] npm lint
- [X] no new deprecations


https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/b11f9be8-0f58-4281-8942-396be4ff0d6c




