### PR TITLE
GN-4323: Query the backend for fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Numbers inputted into a number variable are validated on defined min/max and if it is a number
 - Fragment insert modal
+- Query backend for fragments
 
 ### Fixed
 - Fixed woodpecker builds crashing on syntax errors

--- a/addon/components/fragment-plugin/fragment-insert.hbs
+++ b/addon/components/fragment-plugin/fragment-insert.hbs
@@ -12,4 +12,5 @@
 <FragmentPlugin::SearchModal
   @open={{this.showModal}}
   @closeModal={{this.closeModal}}
+  @config={{this.config}}
 />

--- a/addon/components/fragment-plugin/fragment-insert.ts
+++ b/addon/components/fragment-plugin/fragment-insert.ts
@@ -4,9 +4,11 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import { SayController } from '@lblod/ember-rdfa-editor';
+import { FragmentPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/fragment-plugin';
 
 interface Args {
   controller: SayController;
+  config: FragmentPluginConfig;
 }
 
 export default class FragmentInsertComponent extends Component<Args> {
@@ -14,6 +16,10 @@ export default class FragmentInsertComponent extends Component<Args> {
 
   get controller() {
     return this.args.controller;
+  }
+
+  get config() {
+    return this.args.config;
   }
 
   @action

--- a/addon/components/fragment-plugin/helpers/alert-load-error.hbs
+++ b/addon/components/fragment-plugin/helpers/alert-load-error.hbs
@@ -1,0 +1,22 @@
+<AuAlert
+  @title='{{t "fragment-plugin.modal.alert.error-title"}}'
+  @skin='error'
+  @icon='alert-triangle'
+  @closable={{false}}
+  class='au-u-margin au-u-margin-top-none'
+  ...attributes
+>
+  <p>{{t 'fragment-plugin.modal.alert.error-intro'}}</p>
+  <code class='au-u-error fragment-modal--error-code'>{{@error}}</code>
+  <p>
+    {{t 'fragment-plugin.modal.alert.error-outro'}}
+    <AuLinkExternal
+      href='mailto:Gelinkt-Notuleren@vlaanderen.be'
+      @icon='mail'
+      @iconAlignment='left'
+    >
+      {{! template-lint-disable no-bare-strings  }}
+      Gelinkt-Notuleren@vlaanderen.be
+    </AuLinkExternal>.
+  </p>
+</AuAlert>

--- a/addon/components/fragment-plugin/helpers/alert-no-items.hbs
+++ b/addon/components/fragment-plugin/helpers/alert-no-items.hbs
@@ -1,0 +1,8 @@
+<AuAlert
+  @title={{t 'fragment-plugin.modal.alert.no-results'}}
+  @skin='warning'
+  @icon='cross'
+  @closable={{false}}
+  class='au-u-margin au-u-margin-top-none'
+  ...attributes
+/>

--- a/addon/components/fragment-plugin/search-modal.hbs
+++ b/addon/components/fragment-plugin/search-modal.hbs
@@ -37,8 +37,30 @@
       </mc.sidebar>
       <mc.content @scroll={{true}}>
         <div class='au-u-padding-top'>
-          Hello you are searching for:
-          {{this.inputSearchText}}
+          {{#if this.fragmentsResource.isRunning}}
+            <div class='au-u-margin'>
+              <AuLoader @padding='large' />
+              <span class='au-u-hidden-visually'>
+                {{t 'fragment-plugin.alert.loading'}}
+              </span>
+            </div>
+          {{else}}
+            {{#if this.error}}
+              <FragmentPlugin::Helpers::AlertLoadError @error={{this.error}} />
+            {{else}}
+              {{#if this.fragmentsResource.value.length}}
+                {{#each this.fragmentsResource.value as |fragment|}}
+                  <AuList::Item
+                    class='au-u-padding-left-small au-u-padding-right-small'
+                  >
+                    {{fragment.title.value}}
+                  </AuList::Item>
+                {{/each}}
+              {{else}}
+                <FragmentPlugin::Helpers::AlertNoItems />
+              {{/if}}
+            {{/if}}
+          {{/if}}
         </div>
       </mc.content>
     </AuMainContainer>

--- a/addon/components/fragment-plugin/search-modal.ts
+++ b/addon/components/fragment-plugin/search-modal.ts
@@ -1,16 +1,28 @@
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
+import { restartableTask, timeout } from 'ember-concurrency';
+import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
+import { fetchFragments } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/fragment-plugin/utils/fetch-data';
+import { FragmentPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/fragment-plugin';
+
 interface Args {
-  config: { endpoint: string };
+  config: FragmentPluginConfig;
   closeModal: () => void;
 }
 
 export default class FragmentPluginSearchModalComponent extends Component<Args> {
+  // Filtering
   @tracked inputSearchText: string | null = null;
+
+  // Pagination
+  @tracked totalCount = 0;
+
+  // Display
+  @tracked error: unknown;
 
   @action
   setInputSearchText(event: InputEvent) {
@@ -23,7 +35,36 @@ export default class FragmentPluginSearchModalComponent extends Component<Args> 
   }
 
   @action
-  closeModal() {
+  async closeModal() {
+    await this.fragmentsResource.cancel();
     this.args.closeModal();
   }
+
+  fragmentSearch = restartableTask(async () => {
+    await timeout(500);
+
+    const abortController = new AbortController();
+
+    try {
+      const queryResult = await fetchFragments({
+        endpoint: this.args.config.endpoint,
+        abortSignal: abortController.signal,
+        filter: {
+          name: this.inputSearchText ?? undefined,
+        },
+      });
+
+      this.totalCount = queryResult.totalCount;
+      return queryResult.results;
+    } catch (error) {
+      this.error = error;
+      return [];
+    } finally {
+      abortController.abort();
+    }
+  });
+
+  fragmentsResource = trackedTask(this, this.fragmentSearch, () => [
+    this.inputSearchText,
+  ]);
 }

--- a/addon/plugins/fragment-plugin/index.ts
+++ b/addon/plugins/fragment-plugin/index.ts
@@ -1,0 +1,3 @@
+export type FragmentPluginConfig = {
+  endpoint: string;
+};

--- a/addon/plugins/fragment-plugin/utils/fetch-data.ts
+++ b/addon/plugins/fragment-plugin/utils/fetch-data.ts
@@ -1,0 +1,75 @@
+import {
+  executeCountQuery,
+  executeQuery,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/sparql-helpers';
+
+type Filter = { name?: string };
+
+const buildCountQuery = ({ name }: Filter) => {
+  return `
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+      SELECT (COUNT(?snippetDocument) AS ?count)
+      WHERE {
+          ?snippetList a ext:SnippetList ;
+              ext:hasSnippet/pav:hasCurrentVersion ?snippetDocument .
+          ?snippetDocument dct:title ?title ;
+              ext:editorDocumentContent ?content ;
+              pav:createdOn ?createdOn .
+          ${name ? `FILTER (CONTAINS(LCASE(?title), "${name}"))` : ''}
+      }
+      `;
+};
+
+const buildFetchQuery = ({ name }: Filter) => {
+  return `
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+      SELECT DISTINCT ?title ?content ?createdOn
+      WHERE {
+          ?snippetList a ext:SnippetList ;
+              ext:hasSnippet/pav:hasCurrentVersion ?snippetDocument .
+          ?snippetDocument dct:title ?title ;
+              ext:editorDocumentContent ?content ;
+              pav:createdOn ?createdOn .
+          ${name ? `FILTER (CONTAINS(LCASE(?title), "${name}"))` : ''}
+      }
+      ORDER BY DESC(?createdOn) OFFSET 0 LIMIT 20
+      `;
+};
+
+export const fetchFragments = async ({
+  endpoint,
+  abortSignal,
+  filter,
+}: {
+  endpoint: string;
+  abortSignal: AbortSignal;
+  filter: Filter;
+}) => {
+  const totalCount = await executeCountQuery({
+    endpoint,
+    query: buildCountQuery(filter),
+    abortSignal,
+  });
+
+  if (totalCount === 0) {
+    return { totalCount, results: [] };
+  }
+
+  const queryResult = await executeQuery<{
+    title: string;
+    createdOn: string;
+    content: string;
+  }>({
+    endpoint,
+    query: buildFetchQuery(filter),
+    abortSignal,
+  });
+
+  return { totalCount, results: queryResult.results.bindings };
+};

--- a/app/components/fragment-plugin/helpers/alert-load-error.js
+++ b/app/components/fragment-plugin/helpers/alert-load-error.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/fragment-plugin/helpers/alert-load-error';

--- a/app/components/fragment-plugin/helpers/alert-no-items.js
+++ b/app/components/fragment-plugin/helpers/alert-no-items.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/fragment-plugin/helpers/alert-no-items';

--- a/app/styles/fragment-plugin.scss
+++ b/app/styles/fragment-plugin.scss
@@ -8,4 +8,8 @@
       border-right: 0;
     }
   }
+
+  &--error-code {
+    font-family: var(--au-font-tertiary);
+  }
 }

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -237,6 +237,9 @@ export default class BesluitSampleController extends Controller {
       link: {
         interactive: true,
       },
+      fragment: {
+        endpoint: 'http://localhost:8890/sparql',
+      },
     };
   }
 

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -115,6 +115,7 @@
                 <StandardTemplatePlugin::Card @controller={{this.controller}} />
                 <FragmentPlugin::FragmentInsert
                   @controller={{this.controller}}
+                  @config={{this.config.fragment}}
                 />
               </Sidebar.Collapsible>
               <ArticleStructurePlugin::StructureCard

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -237,3 +237,9 @@ fragment-plugin:
       title: Filter on
       label: Fragment name
       placeholder: Type something...
+    alert:
+      loading: Loading…
+      no-results: No results found
+      error-title: Error while loading results
+      error-intro: 'An error occured while loading results from the Flemish Codex:'
+      error-outro: In case this problem keeps occuring, please contact

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -242,3 +242,9 @@ fragment-plugin:
       title: Filter op
       label: Fragmentnaam
       placeholder: Typ iets...
+    alert:
+      loading: Laden…
+      no-results: Geen resultaten gevonden
+      error-title: Probleem bij het laden
+      error-intro: "Er heeft zich een fout voorgedaan bij het zoeken in de Vlaamse Codex:"
+      error-outro: Moest dit probleem aanhouden, neem contact op met


### PR DESCRIPTION
## N.B. Note that this PR is one of 5 (currently) PRs for insert fragment functionality, I've tried to break them down into smaller parts.

### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

This PR queries the SPARQL backend for fragments and just displays their title in the Search Modal.

### Connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4323


### Setup
You will need a running https://github.com/lblod/app-reglementaire-bijlage for this to work.

* Start the `app-reglementaire-bijlage` 
* Create some snippets there
* Start this package with `PORT=4300 npm run start`
* Go to `https://localhost:4300`, observe same as in video

https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/e58bcc57-1fbc-4810-8275-cc8c1e846f84







