### PR TITLE
GN-4365: use dutch instead of english for static version of table-of-contents node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed woodpecker builds crashing on syntax errors
+- Use dutch language in static version of table of contents
 ### Dependencies
 - Bumps `@types/rdfjs__dataset` from 2.0.0 to 2.0.2
 - Bumps `@types/ember__array` from 4.0.3 to 4.0.4

--- a/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
+++ b/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
@@ -33,14 +33,14 @@ export const emberNodeConfig: (
             'data-ember-node': 'table-of-contents',
             class: 'table-of-contents',
           },
-          ['h3', {}, 'Table Of Contents'],
+          ['h3', {}, 'Inhoudstafel'],
         ];
       }
 
       return [
         'div',
         { 'data-ember-node': 'table-of-contents', class: 'table-of-contents' },
-        ['h3', {}, 'Table Of Contents'],
+        ['h3', {}, 'Inhoudstafel'],
         createTableOfContents(entries),
       ];
     },


### PR DESCRIPTION
### Overview
This PR is a quick fix in order to ensure the static version of the table-of-contents node is displayed in dutch instead of english. A more extensive fix with the concept of a 'document language' may follow later.

##### connected issues and PRs:
Jira: https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4/backlog?issueLimit=100&atlOrigin=eyJpIjoiYTQxYmFlMDE5NzVhNDQxY2FmOTAwYTQzOWQ3MjliNTYiLCJwIjoiaiJ9

### How to test/reproduce
Insert a table-of-contents node and check if the exported version is titled 'Inhoudstafel' instead of 'Table of Contents'

### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
