### PR TITLE
GN-4365: add optional internationalization support to static version of table of contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+- Expect additional `intl: IntlService` argument for the `table_of_contents` node in order to support an internationalized static version.
+
 ## [8.1.0] - 2023-06-22
 ### Added
 - Numbers inputted into a number variable are validated on defined min/max and if it is a number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking
-- Expect additional `intl: IntlService` argument for the `table_of_contents` node in order to support an internationalized static version.
+### Added
+- Add optional `intl: IntlService` argument for the `table_of_contents` node in order to support an internationalized static version.
 
 ## [8.1.0] - 2023-06-22
 ### Added

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ In order to enable the plugin you need to add the table of contents button to th
 ```
 
 ```
-  tableOfContentsView(this.config.tableOfContents)(controller),
+  tableOfContentsView(this.config.tableOfContents, this.intl)(controller),
 ```
 ### Configuring the plugin with a custom config
 
@@ -437,6 +437,8 @@ You can configure the nodeview with the hiearchy of the nodes
 ],
 },
 ```
+
+Additionally the table-of-contents nodespec and nodeview optionally expect an instance of the IntlService ember service from the `ember-intl` package.
 
 
 ## template-variable-plugin

--- a/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
+++ b/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
@@ -9,7 +9,7 @@ import IntlService from 'ember-intl/services/intl';
 
 export const emberNodeConfig: (
   config: TableOfContentsConfig,
-  intl: IntlService
+  intl?: IntlService
 ) => EmberNodeConfig = (config, intl) => {
   return {
     name: 'table-of-contents',
@@ -27,7 +27,9 @@ export const emberNodeConfig: (
     },
     toDOM(node) {
       const { entries } = node.attrs;
-
+      const title = intl
+        ? intl.t('table-of-contents-plugin.title')
+        : 'Inhoudstafel';
       if (!entries) {
         return [
           'div',
@@ -35,14 +37,14 @@ export const emberNodeConfig: (
             'data-ember-node': 'table-of-contents',
             class: 'table-of-contents',
           },
-          ['h3', {}, intl.t('table-of-contents-plugin.title')],
+          ['h3', {}, title],
         ];
       }
 
       return [
         'div',
         { 'data-ember-node': 'table-of-contents', class: 'table-of-contents' },
-        ['h3', {}, intl.t('table-of-contents-plugin.title')],
+        ['h3', {}, title],
         createTableOfContents(entries),
       ];
     },
@@ -69,9 +71,9 @@ export const emberNodeConfig: (
 
 export const table_of_contents = (
   config: TableOfContentsConfig,
-  intl: IntlService
+  intl?: IntlService
 ) => createEmberNodeSpec(emberNodeConfig(config, intl));
 export const tableOfContentsView = (
   config: TableOfContentsConfig,
-  intl: IntlService
+  intl?: IntlService
 ) => createEmberNodeView(emberNodeConfig(config, intl));

--- a/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
+++ b/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
@@ -5,10 +5,12 @@ import {
 } from '@lblod/ember-rdfa-editor/utils/ember-node';
 import { TableOfContentsConfig } from '..';
 import { createTableOfContents } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/utils';
+import IntlService from 'ember-intl/services/intl';
 
 export const emberNodeConfig: (
-  config: TableOfContentsConfig
-) => EmberNodeConfig = (config) => {
+  config: TableOfContentsConfig,
+  intl: IntlService
+) => EmberNodeConfig = (config, intl) => {
   return {
     name: 'table-of-contents',
     componentPath: 'table-of-contents-plugin/ember-nodes/table-of-contents',
@@ -33,14 +35,14 @@ export const emberNodeConfig: (
             'data-ember-node': 'table-of-contents',
             class: 'table-of-contents',
           },
-          ['h3', {}, 'Inhoudstafel'],
+          ['h3', {}, intl.t('table-of-contents-plugin.title')],
         ];
       }
 
       return [
         'div',
         { 'data-ember-node': 'table-of-contents', class: 'table-of-contents' },
-        ['h3', {}, 'Inhoudstafel'],
+        ['h3', {}, intl.t('table-of-contents-plugin.title')],
         createTableOfContents(entries),
       ];
     },
@@ -65,7 +67,11 @@ export const emberNodeConfig: (
   };
 };
 
-export const table_of_contents = (config: TableOfContentsConfig) =>
-  createEmberNodeSpec(emberNodeConfig(config));
-export const tableOfContentsView = (config: TableOfContentsConfig) =>
-  createEmberNodeView(emberNodeConfig(config));
+export const table_of_contents = (
+  config: TableOfContentsConfig,
+  intl: IntlService
+) => createEmberNodeSpec(emberNodeConfig(config, intl));
+export const tableOfContentsView = (
+  config: TableOfContentsConfig,
+  intl: IntlService
+) => createEmberNodeView(emberNodeConfig(config, intl));

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -113,7 +113,10 @@ export default class RegulatoryStatementSampleController extends Controller {
 
         hard_break,
         block_rdfa,
-        table_of_contents: table_of_contents(this.config.tableOfContents),
+        table_of_contents: table_of_contents(
+          this.config.tableOfContents,
+          this.intl
+        ),
         invisible_rdfa,
         link: link(this.config.link),
       },
@@ -182,9 +185,10 @@ export default class RegulatoryStatementSampleController extends Controller {
   ) => Record<string, NodeViewConstructor> = (controller) => {
     return {
       variable: variableView(controller),
-      table_of_contents: tableOfContentsView(this.config.tableOfContents)(
-        controller
-      ),
+      table_of_contents: tableOfContentsView(
+        this.config.tableOfContents,
+        this.intl
+      )(controller),
       link: linkView(this.config.link)(controller),
       date: dateView(this.config.date)(controller),
       number: numberView(controller),


### PR DESCRIPTION
### Overview
This PR adds internationalization support to the static version of the table-of-contents node. When constructing the table_of_contents nodespec and nodeview, an optional `intl: IntlService` argument can be provided.

##### connected issues and PRs:
Jira: https://binnenland.atlassian.net/browse/GN-4365?atlOrigin=eyJpIjoiZmI3OWExMWQ1Mzc5NGUzN2FiOTA0MjUwMmJmNTQzM2MiLCJwIjoiaiJ9

### How to test/reproduce
Enable the table-of-contents node on the regulatory statements dummy route and check if the static version is correctly internationalized.

### Challenges/uncertainties
- I'm not completely sure about the interface, the main issue I'm trying to solve is giving access to ember-intl to the `toDOM` node-spec method.



### Checks PR readiness
- [x] changelog
- [x] npm lint
