### PR TITLE
GN-4351: fix roadsign-regulation code filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix code filtering of roadsign regulation plugin
+
 ## [8.2.0] - 2023-06-26
 ### Added
 - Add a toggle to show the number as words in a number variable

--- a/addon/components/roadsign-regulation-plugin/roadsigns-modal.ts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-modal.ts
@@ -156,11 +156,17 @@ export default class RoadsignRegulationCard extends Component<Args> {
   closeModal() {
     this.args.closeModal();
   }
+
   @action
   searchCodes(term: string) {
     const category = this.categorySelected?.value;
     const type = this.typeSelected?.value;
-    return this.roadsignRegistry.searchCode.perform(term, category, type);
+    return this.roadsignRegistry.searchCode.perform(
+      this.endpoint,
+      term,
+      category,
+      type
+    );
   }
 
   async fetchCodeCombinations() {


### PR DESCRIPTION
### Overview
This PR fixes the issue with filtering roadsign-regulations by their code. The main issue was the endpoint not being passed to the `searchCode task`.

##### connected issues and PRs:
Jira: https://binnenland.atlassian.net/browse/GN-4351?atlOrigin=eyJpIjoiYjA4YjRkOTcyYjIzNDFhNWJmNjFiMzhjMGE2OTY3YzAiLCJwIjoiaiJ9

### How to test/reproduce
- Create a decision with type `Reglementen en verordeningen`
- Open the insert-mobility-measure modal
- Type a valid code in the code filter dropdown

### Challenges/uncertainties
Note: you will notice a lot of other errors in the console popping up (failed requests). These are out of scope for this PR, but I'm now working on a small refactor of the components which should fix these issues.


### Checks PR readiness
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] changelog
- [x] npm lint
- [x] no new deprecations
