### PR TITLE
GN-4404: Made the number variable also show placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Woodpecker: do not run changelog-check when PR contains `dependabot` label
+- Made the number variable also show placeholders
 
 ## [8.2.2] - 2023-06-28
 

--- a/addon/plugins/variable-plugin/nodes.ts
+++ b/addon/plugins/variable-plugin/nodes.ts
@@ -78,15 +78,14 @@ export const contentToDom = ({
   node: PNode;
 }) => {
   if (type === 'number') {
-    if (
-      node.attrs[WRITTEN_NUMBER_PNODE_KEY] ||
-      Number.isNaN(Number(content)) ||
-      content === null ||
-      content === ''
-    ) {
-      return n2words(Number(content), { lang: 'nl' });
+    if (!Number.isNaN(Number(content)) && content !== null && content !== '') {
+      if (node.attrs[WRITTEN_NUMBER_PNODE_KEY]) {
+        return n2words(Number(content), { lang: 'nl' });
+      } else {
+        return content;
+      }
     } else {
-      return content;
+      return 'nummer';
     }
   } else {
     return content;
@@ -192,7 +191,9 @@ export const attributesToDOM = (node: PNode, content = null): DOMOutputSpec => {
         content: content ? content : '',
         ...(!!datatype && { datatype: datatype as string }),
       },
-      content ? contentToDom({ content, type: type as string, node }) : 0,
+      content !== null
+        ? contentToDom({ content, type: type as string, node })
+        : 0,
     ],
   ];
 };

--- a/addon/plugins/variable-plugin/nodes.ts
+++ b/addon/plugins/variable-plugin/nodes.ts
@@ -73,7 +73,7 @@ export const contentToDom = ({
   type,
   node,
 }: {
-  content: string;
+  content: string | null;
   type: string;
   node: PNode;
 }) => {
@@ -85,7 +85,7 @@ export const contentToDom = ({
         return content;
       }
     } else {
-      return 'nummer';
+      return 'Voeg getal in';
     }
   } else {
     return content;
@@ -136,7 +136,10 @@ export const parseAttributes = (node: HTMLElement): false | Attrs => {
   return false;
 };
 
-export const attributesToDOM = (node: PNode, content = null): DOMOutputSpec => {
+export const attributesToDOM = (
+  node: PNode,
+  content?: string | null
+): DOMOutputSpec => {
   const {
     mappingResource,
     codelistResource,
@@ -191,7 +194,7 @@ export const attributesToDOM = (node: PNode, content = null): DOMOutputSpec => {
         content: content ? content : '',
         ...(!!datatype && { datatype: datatype as string }),
       },
-      content !== null
+      content !== undefined
         ? contentToDom({ content, type: type as string, node })
         : 0,
     ],


### PR DESCRIPTION
### Overview
Reworked the variable plugin to show the placeholder nummer when no number was inserted

##### connected issues and PRs:
[jira ticket](https://binnenland.atlassian.net/browse/GN-4404?atlOrigin=eyJpIjoiZTA0YmM3YTAwNWNhNDA5YTlmZjJiMTNlNTI4ZDEyYzYiLCJwIjoiaiJ9)


### Setup
none

### How to test/reproduce
Insert a number variable, don't fill it and then click on the show html export button, you should see nummer instead of nothing 

### Challenges/uncertainties
Currently only nummer gets written, which is correct for now, but it has to change when the document language gets implemented in https://github.com/lblod/ember-rdfa-editor/pull/872



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
