### PR TITLE
Addition of a document-title plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Addition of document-title plugin
+
 ### Changed
 - Woodpecker: do not run changelog-check when PR contains `dependabot` label
 ### Dependencies

--- a/addon/components/document-title-plugin/insert-title-card.hbs
+++ b/addon/components/document-title-plugin/insert-title-card.hbs
@@ -1,0 +1,5 @@
+<AuList::Item>
+  <AuButton @icon="add" @iconAlignment="left" @skin="link" {{on 'click' this.insertTitle}} @disabled={{not this.canInsertTitle}}>
+    {{t "document-title-plugin.insert-title"}}
+  </AuButton>
+</AuList::Item>

--- a/addon/components/document-title-plugin/insert-title-card.ts
+++ b/addon/components/document-title-plugin/insert-title-card.ts
@@ -1,0 +1,41 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { SayController } from '@lblod/ember-rdfa-editor';
+import IntlService from 'ember-intl/services/intl';
+import insertDocumentTitle from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/commands/insert-document-title';
+
+type Args = {
+  controller: SayController;
+};
+export default class InsertTitleCardComponent extends Component<Args> {
+  @service declare intl: IntlService;
+
+  @action
+  insertTitle() {
+    this.args.controller.doCommand(
+      insertDocumentTitle({
+        placeholder: this.intl.t(
+          'document-title-plugin.document-title-placeholder'
+        ),
+      }),
+      {
+        view: this.args.controller.mainEditorView,
+      }
+    );
+    this.args.controller.focus();
+  }
+
+  get canInsertTitle() {
+    return this.args.controller.checkCommand(
+      insertDocumentTitle({
+        placeholder: this.intl.t(
+          'document-title-plugin.document-title-placeholder'
+        ),
+      }),
+      {
+        view: this.args.controller.mainEditorView,
+      }
+    );
+  }
+}

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -65,7 +65,7 @@ const insertStructure = (
   };
 };
 
-function findInsertionRange(args: {
+export function findInsertionRange(args: {
   doc: PNode;
   $from: ResolvedPos;
   nodeType: NodeType;

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -2,19 +2,13 @@ import {
   Command,
   Fragment,
   NodeSelection,
-  NodeType,
-  PNode,
-  ResolvedPos,
-  Schema,
   TextSelection,
 } from '@lblod/ember-rdfa-editor';
 import recalculateStructureNumbers from './recalculate-structure-numbers';
 import { StructureSpec } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
 import wrapStructureContent from './wrap-structure-content';
 import IntlService from 'ember-intl/services/intl';
-import { findNodes } from '@lblod/ember-rdfa-editor/utils/position-utils';
-import { containsOnlyPlaceholder } from '../utils/structure';
-import { findParentNodeClosestToPos } from '@curvenote/prosemirror-utils';
+import { findInsertionRange } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/_private/find-insertion-range';
 
 const insertStructure = (
   structureSpec: StructureSpec,
@@ -64,78 +58,5 @@ const insertStructure = (
     return true;
   };
 };
-
-export function findInsertionRange(args: {
-  doc: PNode;
-  $from: ResolvedPos;
-  nodeType: NodeType;
-  schema: Schema;
-  limitTo?: string;
-}) {
-  const { doc, $from, nodeType, schema, limitTo } = args;
-  for (let currentDepth = $from.depth; currentDepth >= 0; currentDepth--) {
-    const currentAncestor = $from.node(currentDepth);
-    const index = $from.index(currentDepth);
-    if (currentAncestor.canReplaceWith(index, index, nodeType)) {
-      if (containsOnlyPlaceholder(schema, currentAncestor)) {
-        return { from: $from.start(currentDepth), to: $from.end(currentDepth) };
-      } else {
-        const insertPos = $from.after(currentDepth + 1);
-        return { from: insertPos, to: insertPos };
-      }
-    }
-  }
-  const limitContainer = limitTo
-    ? findParentNodeClosestToPos(
-        $from,
-        (node) => node.type === schema.nodes[limitTo]
-      )
-    : null;
-
-  const limitContainerRange = limitContainer
-    ? {
-        from: limitContainer.pos,
-        to: limitContainer.pos + limitContainer.node.nodeSize,
-      }
-    : { from: 0, to: doc.nodeSize };
-  const filterFunction = ({ from, to }: { from: number; to: number }) => {
-    if (from >= limitContainerRange.from && to <= limitContainerRange.to) {
-      const node = doc.nodeAt(from);
-      if (node) {
-        if (node.canReplaceWith(node.childCount, node.childCount, nodeType)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  };
-  const nextContainerRange =
-    findNodes({
-      doc,
-      start: $from.pos,
-      visitParentUpwards: true,
-      reverse: false,
-      filter: filterFunction,
-    }).next().value ??
-    findNodes({
-      doc,
-      start: $from.pos,
-      visitParentUpwards: true,
-      reverse: true,
-      filter: filterFunction,
-    }).next().value;
-  if (nextContainerRange) {
-    const { from, to } = nextContainerRange;
-    const containerNode = doc.nodeAt(from);
-    if (containerNode) {
-      if (containsOnlyPlaceholder(schema, containerNode)) {
-        return { from: from + 1, to: to - 1 };
-      } else {
-        return { from: to - 1, to: to - 1 };
-      }
-    }
-  }
-  return null;
-}
 
 export default insertStructure;

--- a/addon/plugins/document-title-plugin/commands/insert-document-title.ts
+++ b/addon/plugins/document-title-plugin/commands/insert-document-title.ts
@@ -1,0 +1,43 @@
+import { Command } from '@lblod/ember-rdfa-editor';
+import { v4 as uuid } from 'uuid';
+
+interface InsertDocumentTitleArgs {
+  placeholder: string;
+}
+export default function insertDocumentTitle({
+  placeholder,
+}: InsertDocumentTitleArgs): Command {
+  return function (state, dispatch) {
+    const { schema, selection } = state;
+    if (
+      !state.doc.canReplaceWith(
+        selection.$from.index(0),
+        selection.$from.index(0),
+        schema.nodes.document_title
+      )
+    ) {
+      return false;
+    }
+
+    if (dispatch) {
+      const tr = state.tr;
+      tr.insert(
+        selection.from - 1,
+        schema.node(
+          'document_title',
+          { __rdfaId: uuid() },
+          schema.node(
+            'paragraph',
+            null,
+            schema.node('placeholder', {
+              placeholderText: placeholder,
+            })
+          )
+        )
+      );
+      dispatch(tr);
+    }
+
+    return true;
+  };
+}

--- a/addon/plugins/document-title-plugin/commands/insert-document-title.ts
+++ b/addon/plugins/document-title-plugin/commands/insert-document-title.ts
@@ -1,4 +1,5 @@
 import { Command } from '@lblod/ember-rdfa-editor';
+import { findInsertionRange } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/commands/insert-structure';
 import { v4 as uuid } from 'uuid';
 
 interface InsertDocumentTitleArgs {
@@ -8,21 +9,22 @@ export default function insertDocumentTitle({
   placeholder,
 }: InsertDocumentTitleArgs): Command {
   return function (state, dispatch) {
-    const { schema, selection } = state;
-    if (
-      !state.doc.canReplaceWith(
-        selection.$from.index(0),
-        selection.$from.index(0),
-        schema.nodes.document_title
-      )
-    ) {
+    const { schema } = state;
+    const insertionRange = findInsertionRange({
+      doc: state.doc,
+      $from: state.doc.resolve(0),
+      nodeType: schema.nodes.document_title,
+      schema,
+    });
+    if (!insertionRange) {
       return false;
     }
 
     if (dispatch) {
       const tr = state.tr;
-      tr.insert(
-        selection.from - 1,
+      tr.replaceWith(
+        insertionRange.from,
+        insertionRange.to,
         schema.node(
           'document_title',
           { __rdfaId: uuid() },

--- a/addon/plugins/document-title-plugin/commands/insert-document-title.ts
+++ b/addon/plugins/document-title-plugin/commands/insert-document-title.ts
@@ -1,5 +1,5 @@
 import { Command } from '@lblod/ember-rdfa-editor';
-import { findInsertionRange } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/commands/insert-structure';
+import { findInsertionRange } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/_private/find-insertion-range';
 import { v4 as uuid } from 'uuid';
 
 interface InsertDocumentTitleArgs {

--- a/addon/plugins/document-title-plugin/nodes/document-title.ts
+++ b/addon/plugins/document-title-plugin/nodes/document-title.ts
@@ -1,0 +1,36 @@
+import { NodeSpec, getRdfaAttrs, rdfaAttrs } from '@lblod/ember-rdfa-editor';
+
+import { ELI } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+
+import { hasRDFaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+
+export const document_title: NodeSpec = {
+  content: 'paragraph{1}',
+  inline: false,
+  defining: true,
+  canSplit: false,
+  group: '',
+  attrs: {
+    ...rdfaAttrs,
+    property: {
+      default: 'eli:title',
+    },
+    datatype: {
+      default: 'xsd:string',
+    },
+  },
+  toDOM(node) {
+    return ['h4', node.attrs, 0];
+  },
+  parseDOM: [
+    {
+      tag: 'h1,h2,h3,h4,h5',
+      getAttrs(element: HTMLElement) {
+        if (hasRDFaAttribute(element, 'property', ELI('title'))) {
+          return getRdfaAttrs(element);
+        }
+        return false;
+      },
+    },
+  ],
+};

--- a/addon/plugins/document-title-plugin/nodes/index.ts
+++ b/addon/plugins/document-title-plugin/nodes/index.ts
@@ -1,0 +1,1 @@
+export { document_title } from './document-title';

--- a/addon/utils/_private/find-insertion-range.ts
+++ b/addon/utils/_private/find-insertion-range.ts
@@ -1,0 +1,77 @@
+import { findParentNodeClosestToPos } from '@curvenote/prosemirror-utils';
+import { NodeType, PNode, ResolvedPos, Schema } from '@lblod/ember-rdfa-editor';
+import { containsOnlyPlaceholder } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/utils/structure';
+import { findNodes } from '@lblod/ember-rdfa-editor/utils/position-utils';
+
+export function findInsertionRange(args: {
+  doc: PNode;
+  $from: ResolvedPos;
+  nodeType: NodeType;
+  schema: Schema;
+  limitTo?: string;
+}) {
+  const { doc, $from, nodeType, schema, limitTo } = args;
+  for (let currentDepth = $from.depth; currentDepth >= 0; currentDepth--) {
+    const currentAncestor = $from.node(currentDepth);
+    const index = $from.index(currentDepth);
+    if (currentAncestor.canReplaceWith(index, index, nodeType)) {
+      if (containsOnlyPlaceholder(schema, currentAncestor)) {
+        return { from: $from.start(currentDepth), to: $from.end(currentDepth) };
+      } else {
+        const insertPos = $from.after(currentDepth + 1);
+        return { from: insertPos, to: insertPos };
+      }
+    }
+  }
+  const limitContainer = limitTo
+    ? findParentNodeClosestToPos(
+        $from,
+        (node) => node.type === schema.nodes[limitTo]
+      )
+    : null;
+
+  const limitContainerRange = limitContainer
+    ? {
+        from: limitContainer.pos,
+        to: limitContainer.pos + limitContainer.node.nodeSize,
+      }
+    : { from: 0, to: doc.nodeSize };
+  const filterFunction = ({ from, to }: { from: number; to: number }) => {
+    if (from >= limitContainerRange.from && to <= limitContainerRange.to) {
+      const node = doc.nodeAt(from);
+      if (node) {
+        if (node.canReplaceWith(node.childCount, node.childCount, nodeType)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+  const nextContainerRange =
+    findNodes({
+      doc,
+      start: $from.pos,
+      visitParentUpwards: true,
+      reverse: false,
+      filter: filterFunction,
+    }).next().value ??
+    findNodes({
+      doc,
+      start: $from.pos,
+      visitParentUpwards: true,
+      reverse: true,
+      filter: filterFunction,
+    }).next().value;
+  if (nextContainerRange) {
+    const { from, to } = nextContainerRange;
+    const containerNode = doc.nodeAt(from);
+    if (containerNode) {
+      if (containsOnlyPlaceholder(schema, containerNode)) {
+        return { from: from + 1, to: to - 1 };
+      } else {
+        return { from: to - 1, to: to - 1 };
+      }
+    }
+  }
+  return null;
+}

--- a/app/components/document-title-plugin/insert-title-card.js
+++ b/app/components/document-title-plugin/insert-title-card.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/document-title-plugin/insert-title-card';

--- a/app/styles/document-title-plugin.scss
+++ b/app/styles/document-title-plugin.scss
@@ -1,0 +1,9 @@
+[property='eli:title']:before {
+  content: 'Document-titel' !important;
+}
+
+[lang='en-US'] {
+  [property='eli:title']:before {
+    content: 'Document title' !important;
+  }
+}

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -69,6 +69,7 @@ import {
   number,
   numberView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/number';
+import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
 export default class RegulatoryStatementSampleController extends Controller {
   @service declare importRdfaSnippet: ImportRdfaSnippet;
   @service declare intl: IntlService;
@@ -86,10 +87,10 @@ export default class RegulatoryStatementSampleController extends Controller {
       nodes: {
         doc: {
           content:
-            'table_of_contents? ((chapter|block)+|(title|block)+|(article|block)+)',
+            'table_of_contents? document_title? ((chapter|block)+|(title|block)+|(article|block)+)',
         },
         paragraph,
-
+        document_title,
         repaired_block,
 
         list_item,

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -11,6 +11,7 @@
 @import 'article-structure-plugin';
 @import 'address-plugin';
 @import 'generic-rdfa-variable';
+@import 'document-title-plugin';
 
 div.table-of-contents {
   padding: $au-unit-small !important;

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -59,6 +59,7 @@
           {{#if this.controller}}
           <Sidebar as |Sidebar|>
             <Sidebar.Collapsible @title='Insert'>
+              <DocumentTitlePlugin::InsertTitleCard @controller={{this.controller}}/>
               <ArticleStructurePlugin::ArticleStructureCard 
                 @controller={{this.controller}}
                 @options={{this.config.structures}}

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -179,6 +179,11 @@ date-plugin:
     required: 'This field cannot be empty'
     fractions: 'Fractions of a second, such as S or T, are not supported.'
     unknown: 'Invalid format'
+
+document-title-plugin:
+  document-title-placeholder: Enter document title
+  insert-title: Insert document title
+
 variable:
   number:
     placeholder: number

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -184,6 +184,10 @@ date-plugin:
     fractions: "Fracties van seconden, zoals S en T, zijn niet ondersteund."
     unknown: "Ongeldig formaat"
 
+document-title-plugin:
+  document-title-placeholder: Geef document-titel op
+  insert-title: Document-titel invoegen
+
 validation-plugin:
   default-fix-message: Oplossen
 


### PR DESCRIPTION
### Overview
This PR adds a document-title plugin containing the document-title widget and node-spec contained in the regulatory-statements frontend so it can be

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4416?atlOrigin=eyJpIjoiMTcwOTZhMWFmN2JlNDYwZDkyNmIwNDMzN2ZjYjc4YjAiLCJwIjoiaiJ9

### How to test/reproduce
- Visit the regulatory-statements dummy route
- Insert a document-title

### Challenges/uncertainties
- Note: in the future, we can still move this functionality into the `article-structure-plugin`.



### Checks PR readiness
- [x] Check if dummy app is correctly updated
- [x] changelog
- [x] npm lint
- [x] no new deprecations
