### PR TITLE
chore(deps): bump editor to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Addition of a precompile step to woodpecker PR check
+### Fixed
+- fix type error due to bad tsconfig
 ### Changed
 - Woodpecker: do not run changelog-check when PR contains `dependabot` label
 - Made the number variable also show placeholders
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumps `eslint-plugin-ember` from 11.4.6 to 11.9.0
 - Bumps `@typescript-eslint/eslint-plugin` from 5.45.0 to 5.60.1
 - Bumps `ember-velcro` to 2.1.0
+- Bumps `@lblod/ember-rdfa-editor` to 4.0.0
 
 ## [8.2.2] - 2023-06-28
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@embroider/test-setup": "^1.8.3",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@lblod/ember-rdfa-editor": "^3.8.0",
+        "@lblod/ember-rdfa-editor": "^4.0.0",
         "@rdfjs/types": "^1.1.0",
         "@release-it/keep-a-changelog": "^3.1.0",
         "@tsconfig/ember": "^1.0.1",
@@ -130,7 +130,7 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^2.4.2",
-        "@lblod/ember-rdfa-editor": "^3.8.0",
+        "@lblod/ember-rdfa-editor": "^4.0.0",
         "ember-concurrency": "^2.3.7"
       }
     },
@@ -3903,44 +3903,6 @@
         "babel-plugin-debug-macros": "^0.3.4"
       }
     },
-    "node_modules/@glint/config": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@glint/config/-/config-0.9.7.tgz",
-      "integrity": "sha512-XkWIZ3fuOlcofUJUaJmRS57mVVNi+Af2HtrZkBXEOCh4+BNz2wclxv2WKvkhmtvLhEUOhHb5eU3gwI58SuwgXQ==",
-      "deprecated": "Now a part of @glint/core",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.17.0",
-        "silent-error": "^1.1.1"
-      }
-    },
-    "node_modules/@glint/environment-ember-loose": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@glint/environment-ember-loose/-/environment-ember-loose-0.9.7.tgz",
-      "integrity": "sha512-MlCGZtB1Clp4vQWIm2APSnCm7nL8wVhFMOhVy2qzpV0nfLyg3pcN9CQHNpfdJvCydBB72cA4/ahPj7VEFL6xsg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@glint/config": "^0.9.7",
-        "@glint/template": "^0.9.7"
-      },
-      "peerDependencies": {
-        "@glimmer/component": "^1.1.2",
-        "ember-cli-htmlbars": "^6.0.1",
-        "ember-modifier": "^3.2.7"
-      },
-      "peerDependenciesMeta": {
-        "ember-cli-htmlbars": {
-          "optional": true
-        },
-        "ember-modifier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@glint/template": {
       "version": "0.9.7",
       "license": "MIT",
@@ -4080,9 +4042,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-3.8.0.tgz",
-      "integrity": "sha512-QFVr21zgimyGJ5E1s74iJFVCWKwJKgTr3bu5dibKcJG+LQY0rzsywL/zzj8NMovmR8W5ieMd+lvileLfpBQeNg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-4.0.0.tgz",
+      "integrity": "sha512-qpPx8NB3ieoa+g6woLjnuaGe8t+v/wa+hnusyi5SGfFM9Otw5VsBwAmmeQLIGLKgvn4loCA4PVt85ei19OydEA==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.1.1",
@@ -4117,7 +4079,7 @@
         "ember-intl": "^5.7.2",
         "ember-truth-helpers": "^3.0.0",
         "ember-unique-id-helper-polyfill": "^1.2.2",
-        "ember-velcro": "^1.1.0",
+        "ember-velcro": "^2.1.0",
         "handlebars": "^4.7.7",
         "handlebars-loader": "^1.7.2",
         "iter-tools": "^7.4.0",
@@ -4149,25 +4111,6 @@
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^2.4.2",
         "ember-cli-sass": "^11.0.1"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor/node_modules/ember-velcro": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ember-velcro/-/ember-velcro-1.1.0.tgz",
-      "integrity": "sha512-oZxcQvd39o0Miv4C4a44BMkzSuS5X684eVLX2Ct4qh7ofAvqSWpEGF9dUDwzCOq5hk4WS8DMsXa0azonv6tP7Q==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/addon-shim": "^1.0.0",
-        "@floating-ui/dom": "^1.0.1",
-        "ember-functions-as-helper-polyfill": "^2.1.1",
-        "ember-modifier": "^3.2.7"
-      },
-      "engines": {
-        "node": "14.* || >= 16"
-      },
-      "peerDependencies": {
-        "@glint/environment-ember-loose": "^0.9.4",
-        "@glint/template": "^0.9.5"
       }
     },
     "node_modules/@lblod/marawa": {
@@ -5277,8 +5220,9 @@
     },
     "node_modules/@types/prosemirror-dev-tools": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-dev-tools/-/prosemirror-dev-tools-3.0.3.tgz",
+      "integrity": "sha512-Pgn+1J9iuCDnULtJvDj4DV+4shA2SbHXprF6G7NT+HcnzZ0x6qoJ6OyHTAygN9co19ZI0xIDgKmq0sjDNrrl9A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prosemirror-view": "^1.24.0"
       }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@embroider/test-setup": "^1.8.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@lblod/ember-rdfa-editor": "^3.8.0",
+    "@lblod/ember-rdfa-editor": "^4.0.0",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^3.1.0",
     "@tsconfig/ember": "^1.0.1",
@@ -148,7 +148,7 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.2",
-    "@lblod/ember-rdfa-editor": "^3.8.0",
+    "@lblod/ember-rdfa-editor": "^4.0.0",
     "ember-concurrency": "^2.3.7"
   },
   "overrides": {

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -289,7 +289,7 @@ export default class BesluitSampleController extends Controller {
     });
     const presetContent =
       localStorage.getItem('EDITOR_CONTENT') ?? sampleData.DecisionTemplate;
-    controller.setHtmlContent(presetContent);
+    controller.initialize(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);
   }

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -12,6 +12,7 @@ import {
 } from '@lblod/ember-rdfa-editor/plugins/text-style';
 import {
   block_rdfa,
+  docWithConfig,
   hard_break,
   horizontal_rule,
   invisible_rdfa,
@@ -84,10 +85,10 @@ export default class RegulatoryStatementSampleController extends Controller {
   get schema() {
     return new Schema({
       nodes: {
-        doc: {
+        doc: docWithConfig({
           content:
             'table_of_contents? ((chapter|block)+|(title|block)+|(article|block)+)',
-        },
+        }),
         paragraph,
 
         repaired_block,

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -229,7 +229,7 @@ export default class RegulatoryStatementSampleController extends Controller {
     const presetContent =
       localStorage.getItem('EDITOR_CONTENT') ??
       `<div resource='http://localhost/test' typeof='say:DocumentContent'>Insert here</div>`;
-    controller.setHtmlContent(presetContent);
+    controller.initialize(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "skipLibCheck": true,
     "experimentalDecorators": true,
     "typeRoots": [
-      "./node_modules/@types",
+      "./node_modules/@types"
     ],
     "paths": {
       "dummy/tests/*": [
@@ -46,24 +46,16 @@
         "addon-test-support/*"
       ],
       "*": [
-        "types/*",
-        "node_modules/@lblod/ember-rdfa-editor/types/*"
-      ],
-      "@lblod/ember-rdfa-editor": [
-        "node_modules/@lblod/ember-rdfa-editor/addon"
-      ],
-      "@lblod/ember-rdfa-editor/*": [
-        "node_modules/@lblod/ember-rdfa-editor/addon/*"
-      ],
-    },
+        "types/*"
+      ]
+    }
   },
   "include": [
     "app/**/*",
     "addon/**/*",
     "tests/**/*",
     "types/**/*",
-    "node_modules/@lblod/ember-rdfa-editor/types/**/*",
     "test-support/**/*",
-    "addon-test-support/**/*",
+    "addon-test-support/**/*"
   ]
 }


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->
bumps editor to [4.0.0](https://github.com/lblod/ember-rdfa-editor/releases/tag/v4.0.0)
fixes the `dompurify` type error:
it was due to a misconfiguration of the `tsconfig` file. That file was routing `ember-rdfa-editor` imports to the `/addon` directory, which was done for development with the npm link, but that causes type resolution issues and is not recommended.

So for now when developing in that scenario, we simply have to run `ember ts:precompile` manually when we change the public editor types.


