### PR TITLE
fix(deps): revert dev dependency on editor back to 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- revert editor bump to 4.0.0, bump to 3.10.0 instead
+
 ## [8.3.0] - 2023-07-06
 ### Added
 - Insert the snippet

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@embroider/test-setup": "^1.8.3",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@lblod/ember-rdfa-editor": "^4.0.0",
+        "@lblod/ember-rdfa-editor": "^3.10.0",
         "@rdfjs/types": "^1.1.0",
         "@release-it/keep-a-changelog": "^3.1.0",
         "@tsconfig/ember": "^1.0.1",
@@ -4039,9 +4039,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-4.0.0.tgz",
-      "integrity": "sha512-qpPx8NB3ieoa+g6woLjnuaGe8t+v/wa+hnusyi5SGfFM9Otw5VsBwAmmeQLIGLKgvn4loCA4PVt85ei19OydEA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-3.10.0.tgz",
+      "integrity": "sha512-vIERr5LBJSq0XeVgxntp8ip1nbvDzcRphLLK5lR0CkU4J3UQ8gEU1o6PaOxd3nrYWMZloR1iOC632mSoe77Ezg==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@embroider/test-setup": "^1.8.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@lblod/ember-rdfa-editor": "^4.0.0",
+    "@lblod/ember-rdfa-editor": "^3.10.0",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^3.1.0",
     "@tsconfig/ember": "^1.0.1",

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -289,7 +289,7 @@ export default class BesluitSampleController extends Controller {
     });
     const presetContent =
       localStorage.getItem('EDITOR_CONTENT') ?? sampleData.DecisionTemplate;
-    controller.initialize(presetContent);
+    controller.setHtmlContent(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);
   }

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -12,7 +12,6 @@ import {
 } from '@lblod/ember-rdfa-editor/plugins/text-style';
 import {
   block_rdfa,
-  docWithConfig,
   hard_break,
   horizontal_rule,
   invisible_rdfa,
@@ -85,10 +84,10 @@ export default class RegulatoryStatementSampleController extends Controller {
   get schema() {
     return new Schema({
       nodes: {
-        doc: docWithConfig({
+        doc: {
           content:
             'table_of_contents? ((chapter|block)+|(title|block)+|(article|block)+)',
-        }),
+        },
         paragraph,
 
         repaired_block,
@@ -233,7 +232,7 @@ export default class RegulatoryStatementSampleController extends Controller {
     const presetContent =
       localStorage.getItem('EDITOR_CONTENT') ??
       `<div resource='http://localhost/test' typeof='say:DocumentContent'>Insert here</div>`;
-    controller.initialize(presetContent);
+    controller.setHtmlContent(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);
   }


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->
revert the dev dependency on the editor back to 3.10 until we are ready to commit to 4.0.0 in the apps

