### PR TITLE
Fix ember 3.28 compatibility of number variable node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed compatibility issue with ember 3.28 in number variable component
+
 ## [8.4.0] - 2023-07-06
 
 ### Changed

--- a/addon/components/variable-number/number.ts
+++ b/addon/components/variable-number/number.ts
@@ -9,7 +9,7 @@ import {
 } from '@lblod/ember-rdfa-editor';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { service } from '@ember/service';
+import { inject as service } from '@ember/service';
 import intlService from 'ember-intl/services/intl';
 import { localCopy } from 'tracked-toolbox';
 import {


### PR DESCRIPTION
### Overview
The number variable node used the import statement `import { service } from '@ember/service'` which is not supported in ember 3.28. This PR changes the statement to `import { inject as service } from '@ember/service'` 
