### PR TITLE
Fix number variable tooltip's css when inside a header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumps `eslint` from 7.32.0 to 8.44.0
 - Bumps `semver` from 5.7.1 to 5.7.2
 
+### Changed
+- Number variable input box has a cleaner UI by adjusting the top margins.
+
 ## [8.4.1] - 2023-07-06
 
 ### Fixed

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -112,4 +112,14 @@
   input[type='number'] {
     width: 100%;
   }
+
+  // we want to control the padding ourselves in the tooltip
+  .au-c-content * {
+    margin-top: 0;
+  }
+
+  // add top padding starting from second element
+  * :not(*:nth-child(1)) {
+    margin-top: 5px;
+  } 
 }


### PR DESCRIPTION
### Overview
Before the tooltip box would look like this:
![afbeelding](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/126079676/25ef7037-dc33-4cbf-962b-030c4522aa43)
With too much padding between the input and other buttons.

Now it looks like this:
![afbeelding](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/126079676/3e2beb16-2ba0-4044-97a4-1a4b9036a2dd)

I added some 5px padding too, as before everything sticked together a bit too much.

##### connected issues and PRs:
No ticket was created, as I saw this when testing a different PR.

### How to test/reproduce
Add a number variable and you'll see the difference. 
