### PR TITLE
update ember-rdfa-editor from 3.10 to 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - When a number is too big to be converted to words, display it numerically.
+- Can only insert a number variable with a minimum that is smaller than its maximum
 ### Changed
 - Make `errorMessage` of number input modal reactive to attribute changes
+- Number variable input box has a cleaner UI by adjusting the top margins.
+- Demo uses `initialize` and `docWithConfig` introduced in `ember-rdfa-editor@4.0.0`
 ### Dependencies
+- Bumps `@lblod/ember-rdfa-editor` from 3.10.0 to 4.0.0
 - Bumps `@typescript-eslint/parser` from 5.60.0 to 5.61.0
 - Bumps `@tsconfig/ember` from 1.0.1 to 3.0.0
 - Bumps `fetch-sparql-endpoint` from 3.1.1 to 3.3.3
@@ -27,11 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumps `ember-auto-import` from 2.5.0 to 2.6.3
 - Bumps `tracked-built-ins` from 3.1.0 to 3.1.1
 
-### Changed
-- Number variable input box has a cleaner UI by adjusting the top margins.
 
-### Fixed
-- Can only insert a number variable with a minimum that is smaller than its maximum
+
 
 ## [8.4.1] - 2023-07-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@embroider/test-setup": "^1.8.3",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@lblod/ember-rdfa-editor": "^3.10.0",
+        "@lblod/ember-rdfa-editor": "^4.0.0",
         "@rdfjs/types": "^1.1.0",
         "@release-it/keep-a-changelog": "^3.1.0",
         "@tsconfig/ember": "^3.0.0",
@@ -130,7 +130,7 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^2.4.2",
-        "@lblod/ember-rdfa-editor": "^3.10.0",
+        "@lblod/ember-rdfa-editor": "^4.0.0",
         "ember-concurrency": "^2.3.7"
       }
     },
@@ -4102,9 +4102,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-3.10.0.tgz",
-      "integrity": "sha512-vIERr5LBJSq0XeVgxntp8ip1nbvDzcRphLLK5lR0CkU4J3UQ8gEU1o6PaOxd3nrYWMZloR1iOC632mSoe77Ezg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-4.0.0.tgz",
+      "integrity": "sha512-qpPx8NB3ieoa+g6woLjnuaGe8t+v/wa+hnusyi5SGfFM9Otw5VsBwAmmeQLIGLKgvn4loCA4PVt85ei19OydEA==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@embroider/test-setup": "^1.8.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@lblod/ember-rdfa-editor": "^3.10.0",
+    "@lblod/ember-rdfa-editor": "^4.0.0",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^3.1.0",
     "@tsconfig/ember": "^3.0.0",
@@ -148,7 +148,7 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.2",
-    "@lblod/ember-rdfa-editor": "^3.10.0",
+    "@lblod/ember-rdfa-editor": "^4.0.0",
     "ember-concurrency": "^2.3.7"
   },
   "overrides": {

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -290,7 +290,7 @@ export default class BesluitSampleController extends Controller {
     });
     const presetContent =
       localStorage.getItem('EDITOR_CONTENT') ?? sampleData.DecisionTemplate;
-    controller.setHtmlContent(presetContent);
+    controller.initialize(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);
   }

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -19,6 +19,7 @@ import {
 import {
   block_rdfa,
   doc,
+  docWithConfig,
   hard_break,
   horizontal_rule,
   invisible_rdfa,
@@ -152,7 +153,7 @@ export default class BesluitSampleController extends Controller {
   get schema() {
     return new Schema({
       nodes: {
-        doc,
+        doc: docWithConfig(),
         paragraph,
 
         repaired_block,

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -18,7 +18,6 @@ import {
 
 import {
   block_rdfa,
-  doc,
   docWithConfig,
   hard_break,
   horizontal_rule,

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -12,6 +12,7 @@ import {
 } from '@lblod/ember-rdfa-editor/plugins/text-style';
 import {
   block_rdfa,
+  docWithConfig,
   hard_break,
   horizontal_rule,
   invisible_rdfa,
@@ -85,10 +86,10 @@ export default class RegulatoryStatementSampleController extends Controller {
   get schema() {
     return new Schema({
       nodes: {
-        doc: {
+        doc: docWithConfig({
           content:
             'table_of_contents? document_title? ((chapter|block)+|(title|block)+|(article|block)+)',
-        },
+        }),
         paragraph,
         document_title,
         repaired_block,

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -234,7 +234,7 @@ export default class RegulatoryStatementSampleController extends Controller {
     const presetContent =
       localStorage.getItem('EDITOR_CONTENT') ??
       `<div resource='http://localhost/test' typeof='say:DocumentContent'>Insert here</div>`;
-    controller.setHtmlContent(presetContent);
+    controller.initialize(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);
   }


### PR DESCRIPTION
### Overview
bumps ember-rdfa-editor to the next "major" release. Includes some nice fixes for ember-nodes, so handy for the current tickets that are being worked on.

### How to test/reproduce
Check the release notes: https://github.com/lblod/ember-rdfa-editor/releases/tag/v4.0.0

Two most important aspects:
- stopEvent and ignoreMutation work differently for ember-nodes. This *should* just work better and not break anything. But to "test" this, you should see if plugins using ember-nodes still work as expected. (think of key-bindings and the likes)
- doc nodespec needs a `toDom` function. This is done by using `docWithConfig`. Without this, error will happen.

### Challenges/uncertainties
I haven't done bumping of dependency before, so don't make the assumption this is the correct way to do it. Please actually review :) 