### PR TITLE
Revert ember-auto-import to 2.5.0 and pin ember-auto-import to 2.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumps `eslint-plugin-prettier` to 5.0.0
 - Bumps `@types/ember__utils` from 4.0.2 to 4.0.3
 - Bumps `@types/ember__controller` from 4.0.3 to 4.0.5
-- Bumps `ember-auto-import` from 2.5.0 to 2.6.3
 - Bumps `tracked-built-ins` from 3.1.0 to 3.1.1
 - Bumps `word-wrap` from 1.2.3 to 1.2.4
+- Pin `ember-auto-import` to 2.5.x
 
 ### Changed
 - Number variable input box has a cleaner UI by adjusting the top margins.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "buffer": "^6.0.3",
         "codemirror": "^6.0.1",
         "date-fns": "^2.30.0",
-        "ember-auto-import": "^2.4.3",
+        "ember-auto-import": "~2.5.0",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-typescript": "^5.2.1",
@@ -12347,9 +12347,9 @@
       }
     },
     "node_modules/ember-auto-import": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.6.3.tgz",
-      "integrity": "sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.5.0.tgz",
+      "integrity": "sha512-fKERUmpZLn4RJiCwTjS7D5zJxgnbF4E6GiSp1GYh53K96S+5UBs06r7ScDI52rq34z0+qdSrA6qiDJ3i/lWqKg==",
       "dependencies": {
         "@babel/core": "^7.16.7",
         "@babel/plugin-proposal-class-properties": "^7.16.7",
@@ -12359,7 +12359,6 @@
         "@embroider/shared-internals": "^2.0.0",
         "babel-loader": "^8.0.6",
         "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
-        "babel-plugin-ember-template-compilation": "^2.0.1",
         "babel-plugin-htmlbars-inline-precompile": "^5.2.1",
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
         "broccoli-debug": "^0.6.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "buffer": "^6.0.3",
     "codemirror": "^6.0.1",
     "date-fns": "^2.30.0",
-    "ember-auto-import": "^2.4.3",
+    "ember-auto-import": "~2.5.0",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-typescript": "^5.2.1",


### PR DESCRIPTION
### Overview
`ember-auto-import` 2.6.x gives issues in combination with `ember-resources`, so this PR reverts and pins `ember-auto-import` to 2.5.x
