### PR TITLE
Update Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Update docker build to serve static files
+
 ## [9.0.0] - 2023-07-24
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM madnificent/ember:4.9.2 as builder
+FROM madnificent/ember:4.12.1-node_18 as builder
 
 LABEL maintainer="info@redpencil.io"
 
@@ -6,5 +6,8 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
-EXPOSE 80
-CMD ["ember", "s", "--port", "80"]
+RUN ember build -prod
+
+FROM semtech/static-file-service:0.2.0
+ENV EMBER_GN_FEATURE_REGULATORY_STATEMENTS=false
+COPY --from=builder /app/dist /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,4 @@ COPY . .
 RUN ember build -prod
 
 FROM semtech/static-file-service:0.2.0
-ENV EMBER_GN_FEATURE_REGULATORY_STATEMENTS=false
 COPY --from=builder /app/dist /data


### PR DESCRIPTION
### Overview
updates the docker build to serve static files

### How to test/reproduce
`docker build` the image and run it

### Challenges/uncertainties
it could be there was a specific reason for using ember serve, typically if the image is used to mount sources and run those. In that case, please close the PR and add this info to the readme.

