### PR TITLE
add `template comments` support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,12 @@
 
 # broccoli-debug
 /DEBUG/
+
+# idea editor
+.idea/.gitignore
+.idea/vcs.xml
+
+# VScode & extensions settings
+.vscode/extensions.json
+.vscode/settings.json
+.favorites.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add template-comments plugin
+  - A plugin to insert and edit template comments (as a "block")
+  - can be inserted anywhere
+  - have a specific rdfa-attribute so they can be removed at publishing
+
 ## [9.0.1] - 2023-07-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ Logic to insert a template comment is added with
 <TemplateCommentsPlugin::Insert @controller={{this.controller}}/>
 ```
 
-A button to remove it when selected can be shown with
+Buttons to remove and move it when selected can be shown with
 ```hbs
 <TemplateCommentsPlugin::EditCard @controller={{this.controller}}/>
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This addon contains the following editor plugins:
 * [template-variable-plugin](#template-variable-plugin)
 * [validation-plugin](#validation-plugin)
 * [address-plugin](#address-plugin)
+* [template-comments-plugin](#template-comments-plugin)
 
 You can configure your editor like this:
 ```hbs
@@ -626,6 +627,23 @@ For enabling it, you need to add the card provided by the plugin to the editor s
 <AddressPlugin::Insert @controller={{this.controller}} />
 ```
 
+## template-comments-plugin
+A plugin to insert a template comment anywhere in the document.  
+This is meant as a block of text for extra information to provide to a created template. It has
+the attribute `ext:TemplateComment`. This can (and should) be filtered out when publishing the document, as it is only meant as extra information while filling in a template.  
+It supports basic text with indenting, list items and the marks strong (bold), strikethrough and underline. Italic is not possible as the text is italic by default.
+
+Add it to editor by adding `...templateCommentNodes` to your schema and `templateComment: templateCommentView(controller)` as a nodeview.
+
+Logic to insert a template comment is added with
+```hbs
+<TemplateCommentsPlugin::Insert @controller={{this.controller}}/>
+```
+
+A button to remove it when selected can be shown with
+```hbs
+<TemplateCommentsPlugin::EditCard @controller={{this.controller}}/>
+```
 ## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.

--- a/addon/components/template-comments-plugin/edit-card.hbs
+++ b/addon/components/template-comments-plugin/edit-card.hbs
@@ -1,0 +1,28 @@
+{{#if this.isInsideComment}}
+  <AuCard
+    @flex={{true}}
+    @divided={{true}}
+    @expandable={{false}}
+    @shadow={{true}}
+    @size='flush' as |c|
+  >
+    <c.content class='au-c-content--small'>
+      <AuList
+        @divider={{true}}
+        class='au-u-padding-top-tiny au-u-padding-bottom-tiny' as |Item|
+      >
+        <Item>
+          <AuButton
+            @icon='bin'
+            @iconAlignment='left'
+            @skin='link'
+            @alert={{true}}
+            {{on 'click' this.remove}}
+          >
+            {{t 'template-comments-plugin.edit.remove'}}
+          </AuButton>
+        </Item>
+      </AuList>
+    </c.content>
+  </AuCard>
+{{/if}}

--- a/addon/components/template-comments-plugin/edit-card.hbs
+++ b/addon/components/template-comments-plugin/edit-card.hbs
@@ -13,6 +13,17 @@
       >
         <Item>
           <AuButton
+            @icon='arrow-up'
+            @iconAlignment='left'
+            @skin='link'
+            @alert={{true}}
+            {{on 'click' this.moveUp}}
+          >
+            {{t 'template-comments-plugin.edit.move-up'}}
+          </AuButton>
+        </Item>
+        <Item>
+          <AuButton
             @icon='bin'
             @iconAlignment='left'
             @skin='link'
@@ -20,6 +31,17 @@
             {{on 'click' this.remove}}
           >
             {{t 'template-comments-plugin.edit.remove'}}
+          </AuButton>
+        </Item>
+        <Item>
+          <AuButton
+            @icon='arrow-down'
+            @iconAlignment='left'
+            @skin='link'
+            @alert={{true}}
+            {{on 'click' this.moveDown}}
+          >
+            {{t 'template-comments-plugin.edit.move-down'}}
           </AuButton>
         </Item>
       </AuList>

--- a/addon/components/template-comments-plugin/edit-card.ts
+++ b/addon/components/template-comments-plugin/edit-card.ts
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { SayController } from '@lblod/ember-rdfa-editor/addon';
-import { NodeSelection } from '@lblod/ember-rdfa-editor';
+import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 
 type Args = {
   controller: SayController;
@@ -18,18 +18,7 @@ export default class TemplateCommentsPluginEditCardComponent extends Component<A
 
   get templateComment() {
     const { selection } = this.controller.mainEditorState;
-    if (
-      selection instanceof NodeSelection &&
-      selection.node.type === this.commentType
-    ) {
-      const comment = {
-        node: selection.node,
-        pos: selection.from,
-      };
-      return comment;
-    } else {
-      return;
-    }
+    return findParentNodeOfType(this.commentType)(selection);
   }
 
   get isInsideComment() {
@@ -41,14 +30,9 @@ export default class TemplateCommentsPluginEditCardComponent extends Component<A
     const comment = this.templateComment;
     if (!comment) return;
     const { node: node, pos: pos } = comment;
-    // when removing, we are inside an embedded editor, but want to remove
-    // a node based on the main editor. Hence the view has to be specified.
-    this.controller.withTransaction(
-      (tr) => {
-        tr.replace(pos, pos + node.nodeSize);
-        return tr;
-      },
-      { view: this.controller.mainEditorView },
-    );
+    this.controller.withTransaction((tr) => {
+      tr.replace(pos, pos + node.nodeSize);
+      return tr;
+    });
   }
 }

--- a/addon/components/template-comments-plugin/edit-card.ts
+++ b/addon/components/template-comments-plugin/edit-card.ts
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { SayController } from '@lblod/ember-rdfa-editor/addon';
+import { NodeSelection } from '@lblod/ember-rdfa-editor';
 
 type Args = {
   controller: SayController;
@@ -15,15 +16,19 @@ export default class TemplateCommentsPluginEditCardComponent extends Component<A
     return this.controller.schema.nodes.templateComment;
   }
 
-  // A template comment is an atom node ("leaf node"). This means it can't be found
-  // with node finders like `getParentOfType`. `.nodeAfter` will give the template comment as it is atom.
   get templateComment() {
-    const currentSelection = this.controller.mainEditorState.selection;
-    const maybeCommentNode = currentSelection.$from.nodeAfter;
-    if (maybeCommentNode?.type === this.commentType) {
-      return { node: maybeCommentNode, pos: currentSelection.$from.pos };
+    const { selection } = this.controller.mainEditorState;
+    if (
+      selection instanceof NodeSelection &&
+      selection.node.type === this.commentType
+    ) {
+      const comment = {
+        node: selection.node,
+        pos: selection.from,
+      };
+      return comment;
     } else {
-      return null;
+      return;
     }
   }
 

--- a/addon/components/template-comments-plugin/edit-card.ts
+++ b/addon/components/template-comments-plugin/edit-card.ts
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { SayController } from '@lblod/ember-rdfa-editor/addon';
+import { TextSelection } from '@lblod/ember-rdfa-editor';
 import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 
 type Args = {
@@ -32,6 +33,71 @@ export default class TemplateCommentsPluginEditCardComponent extends Component<A
     const { node: node, pos: pos } = comment;
     this.controller.withTransaction((tr) => {
       tr.replace(pos, pos + node.nodeSize);
+      return tr;
+    });
+  }
+
+  /* Move the template comment before the node left of this */
+  @action
+  moveUp() {
+    const comment = this.templateComment;
+    if (!comment) return;
+    const { node: node, pos: pos } = comment;
+    const resolvedPos = this.controller.mainEditorState.doc.resolve(pos);
+    const nodeBefore = resolvedPos.nodeBefore;
+    if (!nodeBefore) return;
+    const amountToMove = -nodeBefore.nodeSize;
+    const initialCursorPos =
+      this.controller.mainEditorState.selection.$head.pos;
+    const newPos = pos + amountToMove;
+    const newCursorPos = initialCursorPos + amountToMove;
+    this.controller.withTransaction((tr) => {
+      tr.delete(pos, pos + node.nodeSize);
+      tr.insert(newPos, node);
+      const mappedSelection = TextSelection.create(
+        tr.doc,
+        newCursorPos,
+        newCursorPos,
+      );
+      tr.setSelection(mappedSelection);
+      this.controller.focus();
+      return tr;
+    });
+  }
+
+  /* Move the template comment after the node right of this */
+  @action
+  moveDown() {
+    const comment = this.templateComment;
+    if (!comment) return;
+
+    const { node: commentNode, pos: startPos } = comment;
+    const posAfterComment = startPos + commentNode.nodeSize;
+    const resolvedPos =
+      this.controller.mainEditorState.doc.resolve(posAfterComment);
+    const nodeAfterComment = resolvedPos.nodeAfter;
+    if (!nodeAfterComment) return;
+
+    const amountToMove = commentNode.nodeSize + nodeAfterComment.nodeSize;
+
+    const newPos = startPos + amountToMove;
+    const initialCursorPos =
+      this.controller.mainEditorState.selection.$head.pos;
+    const newCursorPos = initialCursorPos + amountToMove;
+
+    this.controller.withTransaction((tr) => {
+      tr.insert(newPos, commentNode);
+      // do delete after setting the selection,
+      //so the selection position can be easily constructed
+      const mappedSelection = TextSelection.create(
+        tr.doc,
+        newCursorPos,
+        newCursorPos,
+      );
+      tr.setSelection(mappedSelection);
+      tr.delete(startPos, startPos + commentNode.nodeSize);
+
+      this.controller.focus();
       return tr;
     });
   }

--- a/addon/components/template-comments-plugin/edit-card.ts
+++ b/addon/components/template-comments-plugin/edit-card.ts
@@ -1,0 +1,49 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { SayController } from '@lblod/ember-rdfa-editor/addon';
+
+type Args = {
+  controller: SayController;
+};
+
+export default class TemplateCommentsPluginEditCardComponent extends Component<Args> {
+  get controller() {
+    return this.args.controller;
+  }
+
+  get commentType() {
+    return this.controller.schema.nodes.templateComment;
+  }
+
+  // A template comment is an atom node ("leaf node"). This means it can't be found
+  // with node finders like `getParentOfType`. `.nodeAfter` will give the template comment as it is atom.
+  get templateComment() {
+    const currentSelection = this.controller.mainEditorState.selection;
+    const maybeCommentNode = currentSelection.$from.nodeAfter;
+    if (maybeCommentNode?.type === this.commentType) {
+      return { node: maybeCommentNode, pos: currentSelection.$from.pos };
+    } else {
+      return null;
+    }
+  }
+
+  get isInsideComment() {
+    return !!this.templateComment;
+  }
+
+  @action
+  remove() {
+    const comment = this.templateComment;
+    if (!comment) return;
+    const { node: node, pos: pos } = comment;
+    // when removing, we are inside an embedded editor, but want to remove
+    // a node based on the main editor. Hence the view has to be specified.
+    this.controller.withTransaction(
+      (tr) => {
+        tr.replace(pos, pos + node.nodeSize);
+        return tr;
+      },
+      { view: this.controller.mainEditorView },
+    );
+  }
+}

--- a/addon/components/template-comments-plugin/insert.hbs
+++ b/addon/components/template-comments-plugin/insert.hbs
@@ -1,0 +1,11 @@
+<AuList::Item>
+  <AuButton
+    @icon='add'
+    @iconAlignment='left'
+    @skin='link'
+    @disabled={{not this.canInsert}}
+    {{on 'click' this.doInsert}}
+  >
+    {{t 'template-comments-plugin.insert.title'}}
+  </AuButton>
+</AuList::Item>

--- a/addon/components/template-comments-plugin/insert.ts
+++ b/addon/components/template-comments-plugin/insert.ts
@@ -1,8 +1,7 @@
-import { findParentNode, canInsert } from '@curvenote/prosemirror-utils';
+import { findParentNode } from '@curvenote/prosemirror-utils';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { Command, SayController } from '@lblod/ember-rdfa-editor';
-import { templateComment } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-comments-plugin';
 
 type Args = {
   controller: SayController;

--- a/addon/components/template-comments-plugin/insert.ts
+++ b/addon/components/template-comments-plugin/insert.ts
@@ -46,7 +46,7 @@ export default class TemplateCommentsPluginInsertCardComponent extends Component
               .replaceRangeWith(
                 parent.start,
                 parent.start,
-                this.schema.nodes.templateComment.create(),
+                this.schema.nodes.templateComment.createAndFill(),
               )
               .scrollIntoView(),
           );

--- a/addon/components/template-comments-plugin/insert.ts
+++ b/addon/components/template-comments-plugin/insert.ts
@@ -1,0 +1,59 @@
+import { findParentNode } from '@curvenote/prosemirror-utils';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { Command, SayController } from '@lblod/ember-rdfa-editor';
+
+type Args = {
+  controller: SayController;
+};
+
+export default class TemplateCommentsPluginInsertCardComponent extends Component<Args> {
+  get controller() {
+    return this.args.controller;
+  }
+
+  get schema() {
+    return this.controller.schema;
+  }
+
+  get canInsert() {
+    return this.controller.checkCommand(this.insertCommand());
+  }
+
+  @action
+  doInsert() {
+    this.controller.doCommand(this.insertCommand());
+  }
+
+  /* insert before the first node in the selection
+   * This avoids splitting up existing nodes and follows the logic
+   * that a comment is desired before the place of the cursor
+   */
+  insertCommand(): Command {
+    return (state, dispatch) => {
+      if (!this.controller || this.controller.inEmbeddedView) return false;
+      if (dispatch) {
+        const selection = this.controller.mainEditorState.selection;
+        const parent = findParentNode((node) => {
+          return (
+            node.type !== this.controller.schema.nodes.text &&
+            node.type !== this.controller.schema.nodes.placeholder
+          );
+        })(selection);
+        if (parent) {
+          dispatch(
+            state.tr
+              .replaceRangeWith(
+                parent.start,
+                parent.start,
+                this.schema.nodes.templateComment.create(),
+              )
+              .scrollIntoView(),
+          );
+          this.controller.focus();
+        }
+      }
+      return true;
+    };
+  }
+}

--- a/addon/components/template-comments-plugin/insert.ts
+++ b/addon/components/template-comments-plugin/insert.ts
@@ -1,7 +1,8 @@
-import { findParentNode } from '@curvenote/prosemirror-utils';
+import { findParentNode, canInsert } from '@curvenote/prosemirror-utils';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { Command, SayController } from '@lblod/ember-rdfa-editor';
+import { templateComment } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-comments-plugin';
 
 type Args = {
   controller: SayController;
@@ -32,26 +33,47 @@ export default class TemplateCommentsPluginInsertCardComponent extends Component
   insertCommand(): Command {
     return (state, dispatch) => {
       if (!this.controller || this.controller.inEmbeddedView) return false;
-      if (dispatch) {
-        const selection = this.controller.mainEditorState.selection;
-        const parent = findParentNode((node) => {
-          return (
-            node.type !== this.controller.schema.nodes.text &&
-            node.type !== this.controller.schema.nodes.placeholder
-          );
-        })(selection);
-        if (parent) {
-          dispatch(
-            state.tr
-              .replaceRangeWith(
-                parent.start,
-                parent.start,
-                this.schema.nodes.templateComment.createAndFill(),
-              )
-              .scrollIntoView(),
-          );
+
+      const selection = this.controller.mainEditorState.selection;
+      const parent = findParentNode((node) => {
+        return (
+          node.type !== this.controller.schema.nodes.text &&
+          node.type !== this.controller.schema.nodes.placeholder
+        );
+      })(selection);
+
+      const newTemplateNode = this.schema.nodes.templateComment.createAndFill();
+      if (!parent) {
+        // if no parent, selection is somewhere at the top of doc, so insert at start of doc
+        if (dispatch) {
+          const transaction = state.tr
+            .insert(0, newTemplateNode)
+            .scrollIntoView();
+
+          dispatch(transaction);
           this.controller.focus();
         }
+        return true;
+      }
+
+      // get the parent of parent
+      // check what content is allowed (contentMatchAt) by using the "index"
+      // check if template comment is allowed as comment.
+      // In principle this should be the same as `CanAppend`, but this seems to work better.
+      const insertPos = parent.pos;
+      const resolvedPos = state.doc.resolve(insertPos);
+      const parentAboveInsertion = resolvedPos.parent;
+      const indexInParent = resolvedPos.index();
+      const allowedContent = parentAboveInsertion.contentMatchAt(indexInParent);
+      const allowed = allowedContent.matchType(newTemplateNode.type);
+      if (!allowed) return false;
+      if (dispatch) {
+        const transaction = state.tr
+          .insert(insertPos, newTemplateNode)
+          .scrollIntoView();
+
+        dispatch(transaction);
+        this.controller.focus();
       }
       return true;
     };

--- a/addon/components/template-comments-plugin/insert.ts
+++ b/addon/components/template-comments-plugin/insert.ts
@@ -40,8 +40,9 @@ export default class TemplateCommentsPluginInsertCardComponent extends Component
           node.type !== this.controller.schema.nodes.placeholder
         );
       })(selection);
-
       const newTemplateNode = this.schema.nodes.templateComment.createAndFill();
+      if (!newTemplateNode) return false;
+
       if (!parent) {
         // if no parent, selection is somewhere at the top of doc, so insert at start of doc
         if (dispatch) {

--- a/addon/components/template-comments-plugin/template-comment.hbs
+++ b/addon/components/template-comments-plugin/template-comment.hbs
@@ -3,9 +3,11 @@
   @title={{t 'template-comments-plugin.long-title'}}
   @skin='info'
   @icon='circle-info'
-  class='template-comment'
+  class='template-comment {{
+    if this.selectionInside 'ProseMirror-selectednode'
+  }}'
 >
   <em>
-   {{yield}}
+    {{yield}}
   </em>
 </AuAlert>

--- a/addon/components/template-comments-plugin/template-comment.hbs
+++ b/addon/components/template-comments-plugin/template-comment.hbs
@@ -1,0 +1,21 @@
+<AuAlert
+  @size='small'
+  @title={{t 'template-comments-plugin.long-title'}}
+  @skin='info'
+  @icon='circle-info'
+  class='template-comment'
+>
+  <em>
+    <EmberNode::EmbeddedEditor
+      @controller={{@controller}}
+      @node={{@node}}
+      @view={{@view}}
+      @getPos={{@getPos}}
+      @selected={{@selected}}
+      @placeholder={{t 'template-comments-plugin.placeholder'}}
+      @schema={{this.schema}}
+      @keymap={{this.keymap}}
+      @plugins={{this.plugins}}
+    />
+  </em>
+</AuAlert>

--- a/addon/components/template-comments-plugin/template-comment.hbs
+++ b/addon/components/template-comments-plugin/template-comment.hbs
@@ -6,16 +6,6 @@
   class='template-comment'
 >
   <em>
-    <EmberNode::EmbeddedEditor
-      @controller={{@controller}}
-      @node={{@node}}
-      @view={{@view}}
-      @getPos={{@getPos}}
-      @selected={{@selected}}
-      @placeholder={{t 'template-comments-plugin.placeholder'}}
-      @schema={{this.schema}}
-      @keymap={{this.keymap}}
-      @plugins={{this.plugins}}
-    />
+   {{yield}}
   </em>
 </AuAlert>

--- a/addon/components/template-comments-plugin/template-comment.hbs
+++ b/addon/components/template-comments-plugin/template-comment.hbs
@@ -5,9 +5,9 @@
   @icon='circle-info'
   class='template-comment {{
     if this.selectionInside 'ProseMirror-selectednode'
-  }}'
+  }} default-cursor'
 >
-  <em>
+  <em class='text-cursor'>
     {{yield}}
   </em>
 </AuAlert>

--- a/addon/components/template-comments-plugin/template-comment.ts
+++ b/addon/components/template-comments-plugin/template-comment.ts
@@ -21,7 +21,7 @@ export default class TemplateCommentsPluginTemplateCommentComponent extends Comp
   }
 
   get selectionInside() {
-    const { selectPos } = this.controller.mainEditorState.selection.$from;
+    const { pos: selectPos } = this.controller.mainEditorState.selection.$from;
     const nodePos = this.args.getPos();
     const startSelectionInsideNode =
       nodePos !== undefined &&

--- a/addon/components/template-comments-plugin/template-comment.ts
+++ b/addon/components/template-comments-plugin/template-comment.ts
@@ -22,8 +22,12 @@ export default class TemplateCommentsPluginTemplateCommentComponent extends Comp
   }
 
   get selectionInside() {
-    const { selection } = this.controller.mainEditorState;
-    return !!findParentNodeOfType(this.schema.nodes.templateComment)(selection);
+    const { pos } = this.controller.mainEditorState.selection.$from;
+    const startSelectionInsideNode =
+      this.args.getPos() !== undefined &&
+      pos > this.args.getPos() &&
+      pos < this.args.getPos() + this.args.node.nodeSize;
+    return startSelectionInsideNode;
   }
 
   get keymap() {

--- a/addon/components/template-comments-plugin/template-comment.ts
+++ b/addon/components/template-comments-plugin/template-comment.ts
@@ -6,7 +6,6 @@ import {
   ordered_list_input_rule,
 } from '@lblod/ember-rdfa-editor/plugins/list';
 import { baseKeymap } from '@lblod/ember-rdfa-editor/core/keymap';
-import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 
 export default class TemplateCommentsPluginTemplateCommentComponent extends Component<EmberNodeArgs> {
   get outerView() {

--- a/addon/components/template-comments-plugin/template-comment.ts
+++ b/addon/components/template-comments-plugin/template-comment.ts
@@ -21,11 +21,12 @@ export default class TemplateCommentsPluginTemplateCommentComponent extends Comp
   }
 
   get selectionInside() {
-    const { pos } = this.controller.mainEditorState.selection.$from;
+    const { selectPos } = this.controller.mainEditorState.selection.$from;
+    const nodePos = this.args.getPos();
     const startSelectionInsideNode =
-      this.args.getPos() !== undefined &&
-      pos > this.args.getPos() &&
-      pos < this.args.getPos() + this.args.node.nodeSize;
+      nodePos !== undefined &&
+      selectPos > nodePos &&
+      selectPos < nodePos + this.args.node.nodeSize;
     return startSelectionInsideNode;
   }
 

--- a/addon/components/template-comments-plugin/template-comment.ts
+++ b/addon/components/template-comments-plugin/template-comment.ts
@@ -17,12 +17,7 @@ export default class TemplateCommentsPluginTemplateCommentComponent extends Comp
   }
 
   get keymap() {
-    const keymap = baseKeymap(this.schema, {
-      embeddedConfig: {
-        state: this.outerView.state,
-        dispatch: this.outerView.dispatch.bind(this),
-      },
-    });
+    const keymap = baseKeymap(this.schema);
     // bind ctrl+i to nothing, so it still gets catched by prosemirror
     // otherwise the browser will see this as a key pressed, which can be confusing for user.
     return {

--- a/addon/components/template-comments-plugin/template-comment.ts
+++ b/addon/components/template-comments-plugin/template-comment.ts
@@ -6,14 +6,24 @@ import {
   ordered_list_input_rule,
 } from '@lblod/ember-rdfa-editor/plugins/list';
 import { baseKeymap } from '@lblod/ember-rdfa-editor/core/keymap';
+import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 
 export default class TemplateCommentsPluginTemplateCommentComponent extends Component<EmberNodeArgs> {
   get outerView() {
     return this.args.view;
   }
 
+  get controller() {
+    return this.args.controller;
+  }
+
   get schema() {
-    return this.args.controller.schema;
+    return this.controller.schema;
+  }
+
+  get selectionInside() {
+    const { selection } = this.controller.mainEditorState;
+    return !!findParentNodeOfType(this.schema.nodes.templateComment)(selection);
   }
 
   get keymap() {

--- a/addon/components/template-comments-plugin/template-comment.ts
+++ b/addon/components/template-comments-plugin/template-comment.ts
@@ -1,0 +1,83 @@
+import Component from '@glimmer/component';
+import { PluginConfig, Schema, inputRules } from '@lblod/ember-rdfa-editor';
+import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
+import {
+  hard_break,
+  paragraph,
+  repaired_block,
+  text,
+} from '@lblod/ember-rdfa-editor/nodes';
+import {
+  bullet_list,
+  bullet_list_input_rule,
+  list_item,
+  ordered_list,
+  ordered_list_input_rule,
+} from '@lblod/ember-rdfa-editor/plugins/list';
+import {
+  strikethrough,
+  strong,
+  underline,
+} from '@lblod/ember-rdfa-editor/plugins/text-style';
+import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
+import { baseKeymap } from '@lblod/ember-rdfa-editor/core/keymap';
+
+export default class TemplateCommentsPluginTemplateCommentComponent extends Component<EmberNodeArgs> {
+  get outerView() {
+    return this.args.view;
+  }
+
+  get schema() {
+    return new Schema({
+      nodes: {
+        doc: {
+          content: 'block+',
+        },
+        paragraph,
+        repaired_block,
+        placeholder,
+
+        text,
+
+        hard_break,
+
+        // currently a list_item can create an error when it is in an embedded editor
+        list_item,
+        ordered_list,
+        bullet_list,
+      },
+      marks: {
+        strong,
+        underline,
+        strikethrough,
+      },
+    });
+  }
+
+  get keymap() {
+    const keymap = baseKeymap(this.schema, {
+      embeddedConfig: {
+        state: this.outerView.state,
+        dispatch: this.outerView.dispatch.bind(this),
+      },
+    });
+    // bind ctrl+i to nothing, so it still gets catched by prosemirror
+    // otherwise the browser will see this as a key pressed, which can be confusing for user.
+    return {
+      ...keymap,
+      'Mod-i': () => true,
+      'Mod-I': () => true,
+    };
+  }
+
+  get plugins(): PluginConfig {
+    return [
+      inputRules({
+        rules: [
+          bullet_list_input_rule(this.schema.nodes.bullet_list),
+          ordered_list_input_rule(this.schema.nodes.ordered_list),
+        ],
+      }),
+    ];
+  }
+}

--- a/addon/components/template-comments-plugin/template-comment.ts
+++ b/addon/components/template-comments-plugin/template-comment.ts
@@ -1,25 +1,10 @@
 import Component from '@glimmer/component';
-import { PluginConfig, Schema, inputRules } from '@lblod/ember-rdfa-editor';
+import { PluginConfig, inputRules } from '@lblod/ember-rdfa-editor';
 import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
 import {
-  hard_break,
-  paragraph,
-  repaired_block,
-  text,
-} from '@lblod/ember-rdfa-editor/nodes';
-import {
-  bullet_list,
   bullet_list_input_rule,
-  list_item,
-  ordered_list,
   ordered_list_input_rule,
 } from '@lblod/ember-rdfa-editor/plugins/list';
-import {
-  strikethrough,
-  strong,
-  underline,
-} from '@lblod/ember-rdfa-editor/plugins/text-style';
-import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
 import { baseKeymap } from '@lblod/ember-rdfa-editor/core/keymap';
 
 export default class TemplateCommentsPluginTemplateCommentComponent extends Component<EmberNodeArgs> {
@@ -28,30 +13,7 @@ export default class TemplateCommentsPluginTemplateCommentComponent extends Comp
   }
 
   get schema() {
-    return new Schema({
-      nodes: {
-        doc: {
-          content: 'block+',
-        },
-        paragraph,
-        repaired_block,
-        placeholder,
-
-        text,
-
-        hard_break,
-
-        // currently a list_item can create an error when it is in an embedded editor
-        list_item,
-        ordered_list,
-        bullet_list,
-      },
-      marks: {
-        strong,
-        underline,
-        strikethrough,
-      },
-    });
+    return this.args.controller.schema;
   }
 
   get keymap() {

--- a/addon/plugins/template-comments-plugin/index.ts
+++ b/addon/plugins/template-comments-plugin/index.ts
@@ -1,0 +1,1 @@
+export { templateComment, templateCommentView } from './node';

--- a/addon/plugins/template-comments-plugin/index.ts
+++ b/addon/plugins/template-comments-plugin/index.ts
@@ -1,1 +1,5 @@
-export { templateComment, templateCommentView } from './node';
+export {
+  templateComment,
+  templateCommentView,
+  templateCommentNodes,
+} from './node';

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -55,5 +55,7 @@ export const templateCommentNodes = {
   templateComment: templateComment,
   templateCommentParagraph: paragraphWithConfig({
     marks: 'strong underline strikethrough',
+    // don't add to any groups, so it is only allowed for template comment
+    group: ''
   }),
 };

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -13,7 +13,7 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
     componentPath: 'template-comments-plugin/template-comment',
     inline: false,
     group: 'block',
-    content: 'block+',
+    content: '(paragraph | list)+',
     draggable: false,
     selectable: true,
     isolating: true,

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -13,7 +13,7 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
     componentPath: 'template-comments-plugin/template-comment',
     inline: false,
     group: 'block',
-    content: '(paragraph | list)+',
+    content: '(templateCommentParagraph | list)+',
     draggable: false,
     selectable: true,
     isolating: true,

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -1,0 +1,53 @@
+import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { hasRDFaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import {
+  createEmberNodeSpec,
+  createEmberNodeView,
+  EmberNodeConfig,
+} from '@lblod/ember-rdfa-editor/utils/ember-node';
+
+export const emberNodeConfig: () => EmberNodeConfig = () => {
+  return {
+    name: 'template-comment',
+    componentPath: 'template-comments-plugin/template-comment',
+    inline: false,
+    group: 'block',
+    defining: true,
+    content: 'block*',
+    draggable: false,
+    selectable: true,
+    needsFFKludge: true,
+    atom: true,
+    attrs: {},
+    toDOM() {
+      return [
+        'div',
+        {
+          typeof: EXT('TemplateComment').prefixed,
+        },
+        [
+          'i',
+          {},
+          ['h3', {}, 'toelichtingsbepaling'],
+          ['div', { property: EXT('content').prefixed }, 0],
+        ],
+      ];
+    },
+    parseDOM: [
+      {
+        tag: 'div',
+        getAttrs(element: HTMLElement) {
+          if (hasRDFaAttribute(element, 'typeof', EXT('TemplateComment'))) {
+            return {};
+          }
+          return false;
+        },
+        contentElement: `div[property~='${EXT('content').prefixed}'],
+        div[property~='${EXT('content').full}']`,
+      },
+    ],
+  };
+};
+
+export const templateComment = createEmberNodeSpec(emberNodeConfig());
+export const templateCommentView = createEmberNodeView(emberNodeConfig());

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -56,6 +56,6 @@ export const templateCommentNodes = {
   templateCommentParagraph: paragraphWithConfig({
     marks: 'strong underline strikethrough',
     // don't add to any groups, so it is only allowed for template comment
-    group: ''
+    group: '',
   }),
 };

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -5,6 +5,7 @@ import {
   createEmberNodeView,
   EmberNodeConfig,
 } from '@lblod/ember-rdfa-editor/utils/ember-node';
+import { paragraphWithConfig } from '@lblod/ember-rdfa-editor/nodes/paragraphWithConfig';
 
 export const emberNodeConfig: () => EmberNodeConfig = () => {
   return {
@@ -12,12 +13,11 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
     componentPath: 'template-comments-plugin/template-comment',
     inline: false,
     group: 'block',
-    defining: true,
-    content: 'block*',
+    content: 'block+',
     draggable: false,
     selectable: true,
-    needsFFKludge: true,
-    atom: true,
+    isolating: true,
+    atom: false,
     attrs: {},
     toDOM() {
       return [
@@ -51,3 +51,9 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
 
 export const templateComment = createEmberNodeSpec(emberNodeConfig());
 export const templateCommentView = createEmberNodeView(emberNodeConfig());
+export const templateCommentNodes = {
+  templateComment: templateComment,
+  templateCommentParagraph: paragraphWithConfig({
+    marks: 'strong underline strikethrough',
+  }),
+};

--- a/app/components/template-comments-plugin/comment-editor.js
+++ b/app/components/template-comments-plugin/comment-editor.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/template-comments-plugin/comment-editor';

--- a/app/components/template-comments-plugin/edit-card.js
+++ b/app/components/template-comments-plugin/edit-card.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/template-comments-plugin/edit-card';

--- a/app/components/template-comments-plugin/insert-template-comment.js
+++ b/app/components/template-comments-plugin/insert-template-comment.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/template-comments-plugin/insert-template-comment';

--- a/app/components/template-comments-plugin/insert.js
+++ b/app/components/template-comments-plugin/insert.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/template-comments-plugin/insert';

--- a/app/components/template-comments-plugin/template-comment.js
+++ b/app/components/template-comments-plugin/template-comment.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/template-comments-plugin/template-comment';

--- a/app/styles/template-comments-plugin.scss
+++ b/app/styles/template-comments-plugin.scss
@@ -1,0 +1,18 @@
+@import "ember-appuniversum";
+
+.template-comment {
+  color: var(--au-blue-900);
+  .au-c-alert__content {
+    margin-top: 0;
+    ::selection {
+      background-color: var(--au-blue-300);
+    }
+  }
+  background-color: var(--au-blue-200);
+  .au-c-alert__icon {
+    background-color: var(--au-blue-200);
+  }
+  .au-c-alert__message{
+    color: var(--au-gray-900);
+  }
+}

--- a/app/styles/template-comments-plugin.scss
+++ b/app/styles/template-comments-plugin.scss
@@ -2,17 +2,31 @@
 
 .template-comment {
   color: var(--au-blue-900);
+
   .au-c-alert__content {
     margin-top: 0;
+
     ::selection {
       background-color: var(--au-blue-300);
     }
   }
+
   background-color: var(--au-blue-200);
+
   .au-c-alert__icon {
     background-color: var(--au-blue-200);
   }
-  .au-c-alert__message{
+
+  .au-c-alert__message {
     color: var(--au-gray-900);
+
+    p {
+      white-space: break-spaces;
+      word-wrap: break-word;
+    }
+  }
+
+  &.ProseMirror-selectednode {
+    outline: 2px solid var(--au-blue-500);
   }
 }

--- a/app/styles/template-comments-plugin.scss
+++ b/app/styles/template-comments-plugin.scss
@@ -30,3 +30,11 @@
     outline: 2px solid var(--au-blue-500);
   }
 }
+
+.default-cursor {
+  cursor: default;
+}
+
+.text-cursor {
+  cursor: text;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@embroider/test-setup": "^1.8.3",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@lblod/ember-rdfa-editor": "^4.0.0",
+        "@lblod/ember-rdfa-editor": "^4.2.0",
         "@rdfjs/types": "^1.1.0",
         "@release-it/keep-a-changelog": "^3.1.0",
         "@tsconfig/ember": "^3.0.0",
@@ -130,7 +130,7 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^2.4.2",
-        "@lblod/ember-rdfa-editor": "^4.0.0",
+        "@lblod/ember-rdfa-editor": "^4.2.0",
         "ember-concurrency": "^2.3.7"
       }
     },
@@ -4054,9 +4054,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-4.0.0.tgz",
-      "integrity": "sha512-qpPx8NB3ieoa+g6woLjnuaGe8t+v/wa+hnusyi5SGfFM9Otw5VsBwAmmeQLIGLKgvn4loCA4PVt85ei19OydEA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-4.2.0.tgz",
+      "integrity": "sha512-giWDvGvk2UrwsViE5E+zyPEKAgPfb6YxrdNhb7NJ32w/t+n4Sv08b8IpVMDVbY25dJJuhxxJTNM+VreTc30TDQ==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@embroider/test-setup": "^1.8.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@lblod/ember-rdfa-editor": "^4.0.0",
+    "@lblod/ember-rdfa-editor": "^4.2.0",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^3.1.0",
     "@tsconfig/ember": "^3.0.0",
@@ -148,7 +148,7 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.2",
-    "@lblod/ember-rdfa-editor": "^4.0.0",
+    "@lblod/ember-rdfa-editor": "^4.2.0",
     "ember-concurrency": "^2.3.7"
   },
   "overrides": {

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -71,6 +71,10 @@ import {
   numberView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/number';
 import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
+import {
+  templateComment,
+  templateCommentView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-comments-plugin';
 export default class RegulatoryStatementSampleController extends Controller {
   @service declare importRdfaSnippet: ImportRdfaSnippet;
   @service declare intl: IntlService;
@@ -97,6 +101,7 @@ export default class RegulatoryStatementSampleController extends Controller {
         list_item,
         ordered_list,
         bullet_list,
+        templateComment,
         placeholder,
         ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
         date: date(this.config.date),
@@ -194,6 +199,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       link: linkView(this.config.link)(controller),
       date: dateView(this.config.date)(controller),
       number: numberView(controller),
+      templateComment: templateCommentView(controller),
     };
   };
   @tracked plugins: Plugin[] = [

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -72,7 +72,7 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/number';
 import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
 import {
-  templateComment,
+  templateCommentNodes,
   templateCommentView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-comments-plugin';
 export default class RegulatoryStatementSampleController extends Controller {
@@ -87,52 +87,50 @@ export default class RegulatoryStatementSampleController extends Controller {
     say: 'https://say.data.gift/ns/',
   };
 
-  get schema() {
-    return new Schema({
-      nodes: {
-        doc: docWithConfig({
-          content:
-            'table_of_contents? document_title? ((chapter|block)+|(title|block)+|(article|block)+)',
-        }),
-        paragraph,
-        document_title,
-        repaired_block,
+  schema = new Schema({
+    nodes: {
+      doc: docWithConfig({
+        content:
+          'table_of_contents? document_title? ((chapter|block)+|(title|block)+|(article|block)+)',
+      }),
+      paragraph,
+      document_title,
+      repaired_block,
 
-        list_item,
-        ordered_list,
-        bullet_list,
-        templateComment,
-        placeholder,
-        ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
-        date: date(this.config.date),
-        variable,
-        number: number,
-        ...STRUCTURE_NODES,
-        heading,
-        blockquote,
+      list_item,
+      ordered_list,
+      bullet_list,
+      ...templateCommentNodes,
+      placeholder,
+      ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+      date: date(this.config.date),
+      variable,
+      number: number,
+      ...STRUCTURE_NODES,
+      heading,
+      blockquote,
 
-        horizontal_rule,
-        code_block,
+      horizontal_rule,
+      code_block,
 
-        text,
+      text,
 
-        image,
+      image,
 
-        hard_break,
-        block_rdfa,
-        table_of_contents: table_of_contents(this.config.tableOfContents),
-        invisible_rdfa,
-        link: link(this.config.link),
-      },
-      marks: {
-        inline_rdfa,
-        em,
-        strong,
-        underline,
-        strikethrough,
-      },
-    });
-  }
+      hard_break,
+      block_rdfa,
+      table_of_contents: table_of_contents(this.config.tableOfContents),
+      invisible_rdfa,
+      link: link(this.config.link),
+    },
+    marks: {
+      inline_rdfa,
+      em,
+      strong,
+      underline,
+      strikethrough,
+    },
+  });
 
   get config() {
     return {

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -13,6 +13,7 @@
 @import 'generic-rdfa-variable';
 @import 'document-title-plugin';
 @import 'snippet-plugin';
+@import 'template-comments-plugin';
 
 div.table-of-contents {
   padding: $au-unit-small !important;

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -27,7 +27,10 @@
             </Tb.Group>
             <Tb.Group>
               <Toolbar::List @controller={{this.controller}}/>
-              <Plugins::Indentation::IndentationMenu @controller={{this.controller}}/>
+              <Plugins::Indentation::IndentationMenu 
+                @controller={{this.controller}}
+                @extraTypes={{this.schema.nodes.templateCommentParagraph}}
+              />
             </Tb.Group>
             <Tb.Group>
               <Plugins::Link::LinkMenu @controller={{this.controller}}/>

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -29,7 +29,7 @@
               <Toolbar::List @controller={{this.controller}}/>
               <Plugins::Indentation::IndentationMenu 
                 @controller={{this.controller}}
-                @extraTypes={{this.schema.nodes.templateCommentParagraph}}
+                @allowedTypes={{array this.schema.nodes.list_item this.schema.nodes.paragraph this.schema.nodes.templateCommentParagraph}}
               />
             </Tb.Group>
             <Tb.Group>

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -72,6 +72,9 @@
                 @controller={{this.controller}}
                 @config={{this.config.snippet}}
               />
+              <TemplateCommentsPlugin::Insert
+                @controller={{this.controller}}
+              />
             </Sidebar.Collapsible>
             <VariablePlugin::InsertVariableCard
                 @controller={{this.controller}}
@@ -84,6 +87,9 @@
             <RdfaDatePlugin::Card
               @controller={{this.controller}}
               @options={{this.config.date}}
+            />
+            <TemplateCommentsPlugin::EditCard
+              @controller={{this.controller}}
             />
             <VariablePlugin::TemplateVariableCard @controller={{this.controller}}  @options={{this.config.templateVariable}}/>
           </Sidebar>

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -253,7 +253,6 @@ snippet-plugin:
       error-outro: In case this problem keeps occurring, please contact
 
 template-comments-plugin:
-  placeholder: Add a comment
   long-title: Template comment or example
   insert:
     title: Add template comment or example

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -252,6 +252,14 @@ snippet-plugin:
       error-intro: 'An error occurred while loading results'
       error-outro: In case this problem keeps occurring, please contact
 
+template-comments-plugin:
+  placeholder: Add a comment
+  long-title: Template comment or example
+  insert:
+    title: Add template comment or example
+  edit:
+    remove: Remove template comment or example  
+
 pagination:
   next: Next page
   previous: Previous page

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -257,7 +257,9 @@ template-comments-plugin:
   insert:
     title: Add template comment or example
   edit:
-    remove: Remove template comment or example  
+    remove: Remove template comment or example
+    move-up: Move comment up
+    move-down: Move comment down
 
 pagination:
   next: Next page

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -256,6 +256,13 @@ snippet-plugin:
       error-intro: "Er is een fout opgetreden tijdens het laden van de resultaten:"
       error-outro: Moest dit probleem aanhouden, neem contact op met
 
+template-comments-plugin:
+  placeholder: Voeg een toelichtings- of voorbeeldbepaling in
+  long-title: Toelichtings- of voorbeeldbepaling
+  insert:
+    title: Toelichtings- of voorbeeldbepaling invoegen
+  edit:
+    remove: Verwijder Toelichtings- of voorbeeldbepaling
 pagination:
   next: Volgende pagina
   previous: Vorige pagina

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -257,7 +257,6 @@ snippet-plugin:
       error-outro: Moest dit probleem aanhouden, neem contact op met
 
 template-comments-plugin:
-  placeholder: Voeg een toelichtings- of voorbeeldbepaling in
   long-title: Toelichtings- of voorbeeldbepaling
   insert:
     title: Toelichtings- of voorbeeldbepaling invoegen

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -262,6 +262,8 @@ template-comments-plugin:
     title: Toelichtings- of voorbeeldbepaling invoegen
   edit:
     remove: Verwijder Toelichtings- of voorbeeldbepaling
+    move-down: Toelichtings- of voorbeeldbepaling naar onder
+    move-up: Toelichtings- of voorbeeldbepaling naar boven
 pagination:
   next: Volgende pagina
   previous: Vorige pagina


### PR DESCRIPTION
### Overview
This adds "template comments": a block of text that can be inserted "anywhere" to give some extra explanation how to fill in a document.
This text is only informational and should be hidden at publishing (_currently not implemented yet_).

Also bumps editor to [4.2.0](https://github.com/lblod/ember-rdfa-editor/releases/tag/v4.2.0). This does not include any breaking changes, but does include changes needed for this PR.

##### connected issues and PRs:
- [template comments GN-4264](https://binnenland.atlassian.net/browse/GN-4264)
- [ember-rdfa-editor#908 PR for embedded-editor changes](https://github.com/lblod/ember-rdfa-editor/pull/908)

### Setup
Need https://github.com/lblod/ember-rdfa-editor/pull/908
- use `npm link` in `ember-rdfa-editor`
- use `npm link @lblod/ember-rdfa-editor` in this repo
- run `ember ts:precompile' in `ember-rdfa-editor` to compile the types and avoid those giving errors.

OR, now that [ember-rdfa-editor 4.2.0](https://github.com/lblod/ember-rdfa-editor/releases/tag/v4.2.0) is released:
- no setup needed - 
### How to test/reproduce
- Go to Regulatory Statements "tab"
- insert a template comment with the button under "insert"
- you can type in the template comment and do everything specified in the issue:

see [comment on design](https://binnenland.atlassian.net/browse/GN-4277?focusedCommentId=79273) what should specifically be implemented: 
- indenting
- numbering
- bullet points
- bold text formatting 

On the right side buttons appear to move and delete the template comment.

### Challenges/uncertainties
~~Some known bugs. Specific of embedded editor are written in [#908 PR](https://github.com/lblod/ember-rdfa-editor/pull/908)~~ => these were a problem with the configuration of the schema in the plugins repo specifically. This has been fixed.

Other problems:

<details>
<summary>Details</summary>

- The list plugin has problems.
  1. create a template comment
  2. type some text
  3. try to make it a list item
  4. an error will occur that an undefined value got unwrapped. This is in the `dispatchInner` of the embedded-editor
  Note that it does work if you copy a list item directly as the first item. It seems like the actual wrapping logic of pressing the list-item button is the problem.

- ~~undo seems to not work correctly anymore (also a problem with transactions?)~~ For some reason [this commit](https://github.com/lblod/ember-rdfa-editor/pull/908/commits/008dcd53b49305271004b0e197ff918b20813eed) fixes the problem
- Italicalizing is not needed. The button (CTRL+I) is disabled, but pressing the button still adds it.
  - Easiest solution is probably: add a "non-italic-paragraph" node to use as content for the template comment

</details>

Problems have been fixed by changing from embedded-editor (which should only be used for inline content) to just using content logic of ember node.
- lists now work as expected
- italize has been "disabled" by using a paragraphWithConfig

#### Move buttons
These have been implemented in an easy way to just move between nodes, as it wasn't really specified in the design and "moving up or down" in general is kind of a hard thing to specify (and probably not desired for a comment?).
The implementation seems to not work for nested nodes because `nodeBefore` and `nodeAfter` don't return anything. A better implementation might be to use nodeBefore if possible, and otherwise change to findInAncestor (like the structures-plugin) to find a fitting (allowed) node to insert. 
