### PR TITLE
GN-4370: Allow block content in `article_paragraph`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Allow `block*` content in `article_paragraph`
 
 ## [9.0.2] - 2023-07-28
 ### Dependencies

--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -53,7 +53,7 @@ const contentSelector = `span[property~='${SAY('body').prefixed}'],
                          span[property~='${SAY('body').full}']`;
 
 export const article_paragraph: NodeSpec = {
-  content: 'paragraph*',
+  content: 'block*',
   inline: false,
   isolating: true,
   defining: true,


### PR DESCRIPTION
### Overview

Allows to insert `inline*` content in `article_paragraph`, that helps insert `table` among other stuff.

#### Connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4370


### Setup

1. Checkout
2. `npm run start`

### How to test/reproduce

Observe that it is not possible to reproduce issue with inserting table in article paragraph described in https://binnenland.atlassian.net/browse/GN-4370, this does not stop from inserting table into other article nodes, the fix is implemented in `embed-rdfa-editor` MR https://github.com/lblod/ember-rdfa-editor/pull/911



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
