### PR TITLE
GN-4323: Snippet insertion fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumps `eslint-plugin-ember` from 11.9.0 to 11.10.0
 - Bumps `@types/ember__runloop` from 4.0.2 to 4.0.3
 
+### Fixed
+- Snippet insertion accounts for wrapping document
+
 ## [9.0.1] - 2023-07-24
 
 ### Changed

--- a/addon/components/snippet-plugin/snippet-insert.ts
+++ b/addon/components/snippet-plugin/snippet-insert.ts
@@ -36,15 +36,27 @@ export default class SnippetInsertComponent extends Component<Args> {
   @action
   onInsert(content: string) {
     const domParser = new DOMParser();
+    const parsed = domParser.parseFromString(content, 'text/html').body;
+    const documentDiv = parsed.querySelector('div[data-say-document="true"]');
 
     this.closeModal();
 
-    this.controller.withTransaction((tr) => {
-      return tr.replaceSelectionWith(
-        ProseParser.fromSchema(this.controller.schema).parse(
-          domParser.parseFromString(content, 'text/html'),
+    if (documentDiv) {
+      return this.controller.withTransaction((tr) =>
+        tr.replaceSelectionWith(
+          ProseParser.fromSchema(this.controller.schema).parse(documentDiv, {
+            preserveWhitespace: true,
+          }),
         ),
       );
-    });
+    }
+
+    this.controller.withTransaction((tr) =>
+      tr.replaceSelectionWith(
+        ProseParser.fromSchema(this.controller.schema).parse(parsed, {
+          preserveWhitespace: true,
+        }),
+      ),
+    );
   }
 }


### PR DESCRIPTION
All snippets are essentially full documents, we cannot just insert one `doc` into another `doc`. Did not see that when just trying to insert "bold" text, but started failing on bigger structures.