### PR TITLE
Cleanup code for template comments + update readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- remove unused code from template comment component
+- remove allowedTypes from indentation menu
 ### Dependencies
 - Bumps `@types/uuid` from 9.0.0 to 9.0.2
 - Bumps `@types/rdf-validate-shacl` from 0.4.0 to 0.4.2

--- a/README.md
+++ b/README.md
@@ -644,6 +644,14 @@ Buttons to remove and move it when selected can be shown with
 ```hbs
 <TemplateCommentsPlugin::EditCard @controller={{this.controller}}/>
 ```
+
+To make sure you can indent inside templateComment, you have to adjust the IndentationMenu to support `TemplateCommentParagraph`'s
+```hbs
+<Plugins::Indentation::IndentationMenu 
+  @controller={{this.controller}}
+  @allowedTypes={{array this.schema.nodes.list_item this.schema.nodes.paragraph this.schema.nodes.templateCommentParagraph}}
+/>
+```
 ## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.

--- a/addon/components/template-comments-plugin/template-comment.ts
+++ b/addon/components/template-comments-plugin/template-comment.ts
@@ -1,23 +1,9 @@
 import Component from '@glimmer/component';
-import { PluginConfig, inputRules } from '@lblod/ember-rdfa-editor';
 import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
-import {
-  bullet_list_input_rule,
-  ordered_list_input_rule,
-} from '@lblod/ember-rdfa-editor/plugins/list';
-import { baseKeymap } from '@lblod/ember-rdfa-editor/core/keymap';
 
 export default class TemplateCommentsPluginTemplateCommentComponent extends Component<EmberNodeArgs> {
-  get outerView() {
-    return this.args.view;
-  }
-
   get controller() {
     return this.args.controller;
-  }
-
-  get schema() {
-    return this.controller.schema;
   }
 
   get selectionInside() {
@@ -28,27 +14,5 @@ export default class TemplateCommentsPluginTemplateCommentComponent extends Comp
       selectPos > nodePos &&
       selectPos < nodePos + this.args.node.nodeSize;
     return startSelectionInsideNode;
-  }
-
-  get keymap() {
-    const keymap = baseKeymap(this.schema);
-    // bind ctrl+i to nothing, so it still gets catched by prosemirror
-    // otherwise the browser will see this as a key pressed, which can be confusing for user.
-    return {
-      ...keymap,
-      'Mod-i': () => true,
-      'Mod-I': () => true,
-    };
-  }
-
-  get plugins(): PluginConfig {
-    return [
-      inputRules({
-        rules: [
-          bullet_list_input_rule(this.schema.nodes.bullet_list),
-          ordered_list_input_rule(this.schema.nodes.ordered_list),
-        ],
-      }),
-    ];
   }
 }

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -29,7 +29,6 @@
               <Toolbar::List @controller={{this.controller}}/>
               <Plugins::Indentation::IndentationMenu 
                 @controller={{this.controller}}
-                @allowedTypes={{array this.schema.nodes.list_item this.schema.nodes.paragraph this.schema.nodes.templateCommentParagraph}}
               />
             </Tb.Group>
             <Tb.Group>


### PR DESCRIPTION
### Overview
There were some functions present that did nothing, as they existed when using embedded-editor, but template comments don't use embedded-editor, but content directly instead.
The readme did not specify how to fix indenting inside template comments. This is added to the readme.

##### connected issues and PRs:
PR where these issues were introduced: https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/220
indentableInsert changed in: https://github.com/lblod/ember-rdfa-editor/pull/923

### How to test/reproduce
check if template comments still work with the removed functions. Or at least check if they were not used.

ADDED:
Check if indenting works as expected.

### Challenges/uncertainties
Indentation was fixed this way to make it easily configurable. However, it might make more sense to create an "indentable" group, that can be added to list items and paragraphs and paragraphWithConfig?
Note: template comment does override the groups of ParagraphWithConfig, so it would have to be added there too. But that is a sensible place to specify it (it is close to the specification of a template node).
=> ADDED specified as a nodespec instead. Nothing has to be changed for template comments, accept for removing `allowedTypes` in the dummy app, as it is not needed anymore.
