### PR TITLE
GN-4446: fix email-address formatting in error components (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- GN-4446: fix email-address formatting in error components
 
 ## [8.4.1] - 2023-07-06
 

--- a/addon/components/citation-plugin/helpers/alert-load-error.hbs
+++ b/addon/components/citation-plugin/helpers/alert-load-error.hbs
@@ -10,11 +10,11 @@
   <p>
     {{t "citaten-plugin.alert.error-outro"}}
     <AuLinkExternal
-      href="mailto:Gelinkt-Notuleren@vlaanderen.be"
+      href="mailto:gelinktnotuleren@vlaanderen.be"
       @icon="mail"
       @iconAlignment="left">
       {{!-- template-lint-disable no-bare-strings  --}}
-      Gelinkt-Notuleren@vlaanderen.be
+      gelinktnotuleren@vlaanderen.be
     </AuLinkExternal>.
   </p>
 </AuAlert>

--- a/addon/components/snippet-plugin/helpers/alert-load-error.hbs
+++ b/addon/components/snippet-plugin/helpers/alert-load-error.hbs
@@ -11,12 +11,12 @@
   <p>
     {{t 'snippet-plugin.modal.alert.error-outro'}}
     <AuLinkExternal
-      href='mailto:Gelinkt-Notuleren@vlaanderen.be'
+      href='mailto:gelinktnotuleren@vlaanderen.be'
       @icon='mail'
       @iconAlignment='left'
     >
       {{! template-lint-disable no-bare-strings  }}
-      Gelinkt-Notuleren@vlaanderen.be
+      gelinktnotuleren@vlaanderen.be
     </AuLinkExternal>.
   </p>
 </AuAlert>


### PR DESCRIPTION
### Overview
The wrong contact email address (`gelinkt-notuleren@vlaanderen.be`) was used in some error components. This PR updates that email address to the correct one: `gelinktnotuleren@vlaanderen.be`.

##### connected issues and PRs:
Jira: https://binnenland.atlassian.net/browse/GN-4446?atlOrigin=eyJpIjoiNTlmNzg1OTBjZjNmNDczZmJiOTFkYmUwOWM0M2IyZjQiLCJwIjoiaiJ9
