### PR TITLE
Set correct group for TemplateCommentParagraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Allow `block*` content in `article_paragraph`
+- Add paragraphGroup to paragraphForTemplate so it can be wrapped by list
+- add a name to paragraphForTemplate so it gets parsed as itself 
 
 ## [9.1.1] - 2023-08-02
 ### Fixed

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -52,10 +52,12 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
 export const templateComment = createEmberNodeSpec(emberNodeConfig());
 export const templateCommentView = createEmberNodeView(emberNodeConfig());
 export const templateCommentNodes = {
-  templateComment: templateComment,
   templateCommentParagraph: paragraphWithConfig({
     marks: 'strong underline strikethrough',
-    // don't add to any groups, so it is only allowed for template comment
-    group: '',
+    // don't add to block group, so it is only allowed for template comment
+    // but add to paragraphGroup so lists accept it
+    group: 'paragraphGroup',
+    name: 'templateCommentParagraph',
   }),
+  templateComment: templateComment,
 };

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -57,7 +57,7 @@ export const templateCommentNodes = {
     // don't add to block group, so it is only allowed for template comment
     // but add to paragraphGroup so lists accept it
     group: 'paragraphGroup',
-    name: 'templateCommentParagraph',
+    subType: 'templateCommentParagraph',
   }),
   templateComment: templateComment,
 };


### PR DESCRIPTION
### Overview
see most of the explanation in https://github.com/lblod/ember-rdfa-editor/pull/918
This changes the ParagraphWithConfig's group config to be `paragraphGroup`, so it can be included in a list. It also passes a `name` so that the specific paragraph will be recognized in parsing

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4445
- bug that you could not add lists in template comments (no issue was created for this)>

### Setup
npm link with https://github.com/lblod/ember-rdfa-editor/pull/918


### How to test/reproduce
Add a template comment, see you can add lists.
When reloading, see that paragraphs are not converted to lists, or more importantly, in the structure see that it stays the same (and does not get converted to e.g. a regular paragraph).

### Challenges/uncertainties
BEFORE MERGE: this needs an update to ember-rdfa-editor. So before merging, the other PR needs to be released and the version should be updated here...

Note: linting (precompile) error in CI will be fixed with updating ember-rdfa-editor version
