### PR TITLE
GN-4262: addition of WGS84 coordinates to address variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - GN-4261: addition of an address variable
+- GN-4262: addition of WGS84 coordinates to address variables
 
 ### Breaking
 - Removal of old address-plugin

--- a/addon/plugins/variable-plugin/utils/address-helpers.ts
+++ b/addon/plugins/variable-plugin/utils/address-helpers.ts
@@ -60,7 +60,6 @@ export async function fetchAddresses(
 
   if (result.ok) {
     const jsonResult = (await result.json()) as LocationRegisterResult;
-    console.log(jsonResult);
     const addresses = jsonResult.LocationResult.map(
       (entry) =>
         new Address({
@@ -99,7 +98,6 @@ export async function resolveAddress(
   });
   if (response.ok) {
     const result = (await response.json()) as AddressRegisterResult;
-    console.log(result);
     if (result.adressen.length) {
       const addressRegisterId = result.adressen[0].identificator.id;
       return ResolvedAddress.resolve(address, addressRegisterId);

--- a/addon/plugins/variable-plugin/utils/address-helpers.ts
+++ b/addon/plugins/variable-plugin/utils/address-helpers.ts
@@ -69,7 +69,7 @@ export async function fetchAddresses(
           municipality: entry.Municipality,
           location: {
             lat_WGS84: entry.Location.Lat_WGS84,
-            lon_WGS84: entry.Location.Lon_WGS84,
+            long_WGS84: entry.Location.Lon_WGS84,
           },
         }),
     );

--- a/addon/plugins/variable-plugin/utils/address-helpers.ts
+++ b/addon/plugins/variable-plugin/utils/address-helpers.ts
@@ -8,6 +8,12 @@ type LocationRegisterResult = {
     Thoroughfarename: string; // street
     Housenumber?: string | null;
     Zipcode: string;
+    Location: {
+      Lat_WGS84: number;
+      Lon_WGS84: number;
+      X_Lambert72: number;
+      Y_Lambert72: number;
+    };
   }[];
 };
 
@@ -54,6 +60,7 @@ export async function fetchAddresses(
 
   if (result.ok) {
     const jsonResult = (await result.json()) as LocationRegisterResult;
+    console.log(jsonResult);
     const addresses = jsonResult.LocationResult.map(
       (entry) =>
         new Address({
@@ -61,6 +68,10 @@ export async function fetchAddresses(
           housenumber: entry.Housenumber,
           zipcode: entry.Zipcode,
           municipality: entry.Municipality,
+          location: {
+            lat_WGS84: entry.Location.Lat_WGS84,
+            lon_WGS84: entry.Location.Lon_WGS84,
+          },
         }),
     );
     return addresses;

--- a/addon/plugins/variable-plugin/variables/address.ts
+++ b/addon/plugins/variable-plugin/variables/address.ts
@@ -30,7 +30,7 @@ import {
 
 type Location = {
   lat_WGS84: number;
-  lon_WGS84: number;
+  long_WGS84: number;
 };
 export class Address {
   declare street: string;
@@ -63,7 +63,7 @@ export class Address {
         this.zipcode === other.zipcode &&
         this.municipality === other.municipality &&
         this.location.lat_WGS84 === other.location.lat_WGS84 &&
-        this.location.lon_WGS84 === other.location.lon_WGS84
+        this.location.long_WGS84 === other.location.long_WGS84
       );
     } else {
       return false;
@@ -112,8 +112,8 @@ const constructLocationNode = (location: Location) => {
       content: location.lat_WGS84.toString(),
     }),
     span({
-      property: GEO('lon').full,
-      content: location.lon_WGS84.toString(),
+      property: GEO('long').full,
+      content: location.long_WGS84.toString(),
     }),
   );
 };
@@ -173,18 +173,18 @@ const parseLocationNode = (locationNode: Element): Location | undefined => {
     'property',
     GEO('lat'),
   )?.getAttribute('content');
-  const lon_WGS84 = findChildWithRdfaAttribute(
+  const long_WGS84 = findChildWithRdfaAttribute(
     locationNode,
     'property',
-    GEO('lon'),
+    GEO('long'),
   )?.getAttribute('content');
-  if (lat_WGS84 && lon_WGS84) {
+  if (lat_WGS84 && long_WGS84) {
     const lat_WGS84_number = parseFloat(lat_WGS84);
-    const lon_WGS84_number = parseFloat(lon_WGS84);
-    if (!isNaN(lat_WGS84_number) && !isNaN(lon_WGS84_number)) {
+    const long_WGS84_number = parseFloat(long_WGS84);
+    if (!isNaN(lat_WGS84_number) && !isNaN(long_WGS84_number)) {
       return {
         lat_WGS84: lat_WGS84_number,
-        lon_WGS84: lon_WGS84_number,
+        long_WGS84: long_WGS84_number,
       };
     }
   }

--- a/addon/utils/constants.ts
+++ b/addon/utils/constants.ts
@@ -22,3 +22,8 @@ export const MOBILITEIT = namespace(
 );
 
 export const ADRES = namespace('https://data.vlaanderen.be/ns/adres/', 'adres');
+export const GENERIEK = namespace(
+  'https://data.vlaanderen.be/ns/generiek/#',
+  'generiek',
+);
+export const GEO = namespace('http://www.w3.org/2003/01/geo/wgs84_pos#', 'geo');


### PR DESCRIPTION
### Overview
This PR adds WGS84 (https://en.wikipedia.org/wiki/World_Geodetic_System) coordinates to address variables. The coordinates are fetched alongside the addresses from the location register (https://geo.api.vlaanderen.be/geolocation/v4/Location). 
The geo namespace is used (https://www.w3.org/2003/01/geo/) in order to represent the coordinates.

##### connected issues and PRs:
Jira: https://binnenland.atlassian.net/browse/GN-4262?atlOrigin=eyJpIjoiMWIxMDJiZmFhOWViNGQ1M2ExN2UzODM1N2NlMTU5MzkiLCJwIjoiaiJ9
<!-- Link to PRs that are related (and in what way) -->

### How to test/reproduce
- Insert and fill in an address
- Check if the coordinates are stored in the address node attributes
- Check if the coordinates are correctly serialized to HTML
- Check if the coordinates are correctly parsed from HTML
- Check if the coordinates correspond to the selected address

### Challenges/uncertainties
Aside from WGS84 coordinates, the location register also provides Lambert72 coordinates (the system employed by the Belgian geographic institute) https://nl.wikipedia.org/wiki/Lambertco%C3%B6rdinaten. Unsure what the best coordinate system would be for us to use. The WGS system seems more universal



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
