### PR TITLE
Simplify template comments to fix bugs: allow any content and any marks of the doc schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- remove unused code from template comment component
+- remove allowedTypes from indentation menu
 ### Dependencies
 - Bumps `@embroider/test-setup` from 1.8.3 to 3.0.1
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - remove unused code from template comment component
 - remove allowedTypes from indentation menu
+- allow normal type of paragraphs (=can have italic mark) in template comments
 ### Dependencies
 - Bumps `@embroider/test-setup` from 1.8.3 to 3.0.1
 ### Fixed
 - Allow `block*` content in `article_paragraph`
 - Move buttons for template comments are blue
+- problems with lists in template comments
 
 ### Added
 - Addition of `variable` group to each variable node-spec.

--- a/README.md
+++ b/README.md
@@ -656,9 +656,9 @@ For enabling it, you need to add the card provided by the plugin to the editor s
 A plugin to insert a template comment anywhere in the document.  
 This is meant as a block of text for extra information to provide to a created template. It has
 the attribute `ext:TemplateComment`. This can (and should) be filtered out when publishing the document, as it is only meant as extra information while filling in a template.  
-It supports basic text with indenting, list items and the marks strong (bold), strikethrough and underline. Italic is not possible as the text is italic by default.
+It supports basic text with indenting, list items and the marks.
 
-Add it to editor by adding `...templateCommentNodes` to your schema and `templateComment: templateCommentView(controller)` as a nodeview.
+Add it to editor by adding `templateComment` to your schema and `templateComment: templateCommentView(controller)` as a nodeview.
 
 Logic to insert a template comment is added with
 ```hbs

--- a/addon/components/template-comments-plugin/template-comment.hbs
+++ b/addon/components/template-comments-plugin/template-comment.hbs
@@ -7,7 +7,7 @@
     if this.selectionInside 'ProseMirror-selectednode'
   }} default-cursor'
 >
-  <em class='text-cursor'>
+  <div class='text-cursor'>
     {{yield}}
-  </em>
+  </div>
 </AuAlert>

--- a/addon/components/template-comments-plugin/template-comment.ts
+++ b/addon/components/template-comments-plugin/template-comment.ts
@@ -1,23 +1,9 @@
 import Component from '@glimmer/component';
-import { PluginConfig, inputRules } from '@lblod/ember-rdfa-editor';
 import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
-import {
-  bullet_list_input_rule,
-  ordered_list_input_rule,
-} from '@lblod/ember-rdfa-editor/plugins/list';
-import { baseKeymap } from '@lblod/ember-rdfa-editor/core/keymap';
 
 export default class TemplateCommentsPluginTemplateCommentComponent extends Component<EmberNodeArgs> {
-  get outerView() {
-    return this.args.view;
-  }
-
   get controller() {
     return this.args.controller;
-  }
-
-  get schema() {
-    return this.controller.schema;
   }
 
   get selectionInside() {
@@ -28,27 +14,5 @@ export default class TemplateCommentsPluginTemplateCommentComponent extends Comp
       selectPos > nodePos &&
       selectPos < nodePos + this.args.node.nodeSize;
     return startSelectionInsideNode;
-  }
-
-  get keymap() {
-    const keymap = baseKeymap(this.schema);
-    // bind ctrl+i to nothing, so it still gets catched by prosemirror
-    // otherwise the browser will see this as a key pressed, which can be confusing for user.
-    return {
-      ...keymap,
-      'Mod-i': () => true,
-      'Mod-I': () => true,
-    };
-  }
-
-  get plugins(): PluginConfig {
-    return [
-      inputRules({
-        rules: [
-          bullet_list_input_rule(this.schema.nodes.bullet_list),
-          ordered_list_input_rule(this.schema.nodes.ordered_list),
-        ],
-      }),
-    ];
   }
 }

--- a/addon/plugins/template-comments-plugin/index.ts
+++ b/addon/plugins/template-comments-plugin/index.ts
@@ -1,5 +1,1 @@
-export {
-  templateComment,
-  templateCommentView,
-  templateCommentNodes,
-} from './node';
+export { templateComment, templateCommentView } from './node';

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -5,7 +5,6 @@ import {
   createEmberNodeView,
   EmberNodeConfig,
 } from '@lblod/ember-rdfa-editor/utils/ember-node';
-import { paragraphWithConfig } from '@lblod/ember-rdfa-editor/nodes/paragraphWithConfig';
 
 export const emberNodeConfig: () => EmberNodeConfig = () => {
   return {
@@ -13,7 +12,7 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
     componentPath: 'template-comments-plugin/template-comment',
     inline: false,
     group: 'block',
-    content: '(templateCommentParagraph | list)+',
+    content: '(paragraph|list)+',
     draggable: false,
     selectable: true,
     isolating: true,
@@ -25,12 +24,8 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
         {
           typeof: EXT('TemplateComment').prefixed,
         },
-        [
-          'i',
-          {},
-          ['h3', {}, 'toelichtingsbepaling'],
-          ['div', { property: EXT('content').prefixed }, 0],
-        ],
+        ['h3', {}, 'toelichtingsbepaling'],
+        ['div', { property: EXT('content').prefixed }, 0],
       ];
     },
     parseDOM: [
@@ -51,11 +46,3 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
 
 export const templateComment = createEmberNodeSpec(emberNodeConfig());
 export const templateCommentView = createEmberNodeView(emberNodeConfig());
-export const templateCommentNodes = {
-  templateComment: templateComment,
-  templateCommentParagraph: paragraphWithConfig({
-    marks: 'strong underline strikethrough',
-    // don't add to any groups, so it is only allowed for template comment
-    group: '',
-  }),
-};

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -75,7 +75,7 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 import { VariableConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/insert-variable-card';
 import {
-  templateCommentNodes,
+  templateComment,
   templateCommentView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-comments-plugin';
 export default class RegulatoryStatementSampleController extends Controller {
@@ -102,7 +102,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       list_item,
       ordered_list,
       bullet_list,
-      ...templateCommentNodes,
+      templateComment,
       placeholder,
       ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
       date: date(this.config.date),

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -29,7 +29,6 @@
               <Toolbar::List @controller={{this.controller}}/>
               <Plugins::Indentation::IndentationMenu 
                 @controller={{this.controller}}
-                @allowedTypes={{array this.schema.nodes.list_item this.schema.nodes.paragraph this.schema.nodes.templateCommentParagraph}}
               />
             </Tb.Group>
             <Tb.Group>


### PR DESCRIPTION
### Overview
Template comments had some problems by trying to avoid allowing `<em>` marks inside its content. The problem was that lists also needed to be allowed, but lists (and their button functionality) would use normal paragraphs again. 
This PR allows normal paragraphs for template nodes, removing the constraint of avoiding `<em>` marks. It also includes some cleanup cherry-picked from another PR.

##### connected issues and PRs:
- cherrypicked cleanup commits from https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/236
- A discussino of the problems with the custom paragraphs and list can be found in the comments of https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/241
- because this simplifies template comments, no specific ember-rdfa-editor version is needed 
-  related bug with lists in template comments: https://binnenland.atlassian.net/browse/GN-4445

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties/Remarks
- TODO: create a ticket to look at this issue further and see if something like fully custom content in a child block is a thing that is (easily, without hacks) possible. Potentially this can be done with an embedded-editor, if the implementation for that is fixed to work with block content *and* it is fixed so that a custom schema can be provided.
- to partially follow the design, a base `<em>` mark could be added when adding a template comment, but I couldn't get this to work (yet), so that's why it isn't included here. This can always be added later.
