### PR TITLE
GN-4451: fix roadsign plugin no longer showing rendered templates in modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- GN-4451: fix roadsign plugin no longer showing rendered templates in modal
+
 ## [8.4.2] - 2023-08-02
 ### Fixed
 - GN-4446: fix email-address formatting in error components

--- a/addon/components/roadsign-regulation-plugin/expanded-measure.hbs
+++ b/addon/components/roadsign-regulation-plugin/expanded-measure.hbs
@@ -3,7 +3,11 @@
     <AuHeading @level="6" @skin="6">Voeg maatregel in:</AuHeading>
     <p>
       <AuPill>
-        <RoadsignRegulationPlugin::MeasureTemplate @measure={{@measure.uri}} @template={{@measure.template}} />
+        <RoadsignRegulationPlugin::MeasureTemplate
+          @measure={{@measure.uri}}
+          @template={{@measure.template}}
+          @endpoint={{@endpoint}}
+        />
       </AuPill>
     </p>
     {{#if this.isPotentiallyZonal}}

--- a/addon/components/roadsign-regulation-plugin/expanded-measure.ts
+++ b/addon/components/roadsign-regulation-plugin/expanded-measure.ts
@@ -17,6 +17,7 @@ type Args = {
     zonalityValue?: string,
     temporalValue?: string
   ) => void;
+  endpoint: string;
 };
 
 export default class ExpandedMeasureComponent extends Component<Args> {

--- a/addon/components/roadsign-regulation-plugin/measure-template.ts
+++ b/addon/components/roadsign-regulation-plugin/measure-template.ts
@@ -1,9 +1,8 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { task } from 'ember-concurrency';
-import { tracked } from '@glimmer/tracking';
 import includeInstructions from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/utils/includeInstructions';
 import RoadsignRegistryService from '@lblod/ember-rdfa-editor-lblod-plugins/services/roadsign-registry';
+import { trackedFunction } from 'ember-resources/util/function';
 
 type Args = {
   template: string;
@@ -13,27 +12,22 @@ type Args = {
 };
 export default class MeasureTemplateComponent extends Component<Args> {
   @service declare roadsignRegistry: RoadsignRegistryService;
-  @tracked template = '';
-  endpoint: string;
 
-  constructor(parent: unknown, args: Args) {
-    super(parent, args);
-    this.template = this.args.template;
-    void this.fetchData.perform();
-    this.endpoint = this.args.endpoint;
+  get template() {
+    return this.instructionData.value ?? '';
   }
 
-  fetchData = task(async () => {
+  instructionData = trackedFunction(this, async () => {
     const instructions =
       await this.roadsignRegistry.getInstructionsForMeasure.perform(
         this.args.measure,
-        this.endpoint
+        this.args.endpoint
       );
     const template = includeInstructions(
       this.args.template,
       instructions,
       this.args.annotated
     );
-    this.template = template;
+    return template;
   });
 }

--- a/addon/components/roadsign-regulation-plugin/roadsigns-table.hbs
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-table.hbs
@@ -33,7 +33,13 @@
                 </div>
               </td>
               <td>
-                <AuHelpText skin="secondary" class="au-u-margin-none"><RoadsignRegulationPlugin::MeasureTemplate @measure={{row.uri}} @template={{row.template}} @limitText={{true}}/></AuHelpText>
+                <AuHelpText skin="secondary" class="au-u-margin-none">
+                  <RoadsignRegulationPlugin::MeasureTemplate
+                    @measure={{row.uri}}
+                    @template={{row.template}}
+                    @limitText={{true}}
+                    @endpoint={{@options.endpoint}} />
+                </AuHelpText>
               </td>
               <td>
                 {{#each row.classifications as |classification|}}
@@ -51,7 +57,12 @@
               </td>
             </tr>
           {{#if (eq this.selected row.uri)}}
-            <RoadsignRegulationPlugin::ExpandedMeasure @measure={{row}} @insert={{@insert}} @selectRow={{this.selectRow}} />
+            <RoadsignRegulationPlugin::ExpandedMeasure
+              @measure={{row}}
+              @insert={{@insert}}
+              @selectRow={{this.selectRow}}
+              @endpoint={{@options.endpoint}}
+            />
           {{/if}}
         {{else}}
           <tr>


### PR DESCRIPTION
-------

### Overview

The endpoint configuration wasn't properly passed through to the code that fetched the individual
instructions in the measure template, to render out the final version.

As a result the roadsign measure list no longer showed the rendered templates before inserting.
This has actually been broken since may, I'm not quite sure how we (and the testers) missed this
for this long.


##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->
[GN-4451](https://binnenland.atlassian.net/browse/GN-4451)

### Setup
<!-- PR dependencies -->
<!-- override snippets -->
I think it should be pretty obvious no matter how you run the plugin

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations