### PR TITLE
Number variable: check validity of min/max input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce internationalization in the table of contents node based on the document language.
 - The whole table of contents node (include its entries) is now exported in its `serialize` method without the need of an `entries` attribute.
 - GN-4461: update readme to specify needed imports for template comment
+- Check validity on number minimum/maximum inputs
 
 ### Changed
 - Use one-way-binding in variable label input

--- a/addon/components/variable-plugin/number/insert.hbs
+++ b/addon/components/variable-plugin/number/insert.hbs
@@ -11,6 +11,7 @@
       <AuNativeInput
         id={{id}}
         value={{this.minimumValue}}
+        {{on 'input' this.updateMinimumValue}}
         {{this.minimumInput}}
         placeholder={{t 'variable-plugin.number.minimum-placeholder'}}
         @width='block'
@@ -27,6 +28,7 @@
       <AuNativeInput
         id={{id}}
         value={{this.maximumValue}}
+        {{on 'input' this.updateMaximumValue}}
         {{this.maximumInput}}
         placeholder={{t 'variable-plugin.number.maximum-placeholder'}}
         @width='block'

--- a/addon/components/variable-plugin/number/insert.hbs
+++ b/addon/components/variable-plugin/number/insert.hbs
@@ -11,7 +11,7 @@
       <AuNativeInput
         id={{id}}
         value={{this.minimumValue}}
-        {{on 'input' this.updateMinimumValue}}
+        {{this.minimumInput}}
         placeholder={{t 'variable-plugin.number.minimum-placeholder'}}
         @width='block'
         @type="number"
@@ -27,7 +27,7 @@
       <AuNativeInput
         id={{id}}
         value={{this.maximumValue}}
-        {{on 'input' this.updateMaximumValue}}
+        {{this.maximumInput}}
         placeholder={{t 'variable-plugin.number.maximum-placeholder'}}
         @width='block'
         @type="number"

--- a/addon/components/variable-plugin/number/insert.ts
+++ b/addon/components/variable-plugin/number/insert.ts
@@ -16,6 +16,8 @@ export default class NumberInsertComponent extends Component<Args> {
   @tracked label?: string;
   @tracked minimumValue = '';
   @tracked maximumValue = '';
+  @tracked validMinimum = true;
+  @tracked validMaximum = true;
 
   get controller() {
     return this.args.controller;
@@ -26,6 +28,9 @@ export default class NumberInsertComponent extends Component<Args> {
   }
 
   get numberVariableError() {
+    if (!this.validMinimum || !this.validMaximum) {
+      return this.intl.t('variable.number.error-not-number');
+    }
     const minVal = this.minimumValue;
     const maxVal = this.maximumValue;
     if (
@@ -44,15 +49,17 @@ export default class NumberInsertComponent extends Component<Args> {
     this.label = (event.target as HTMLInputElement).value;
   }
 
-  @action
-  updateMinimumValue(event: InputEvent) {
-    this.minimumValue = (event.target as HTMLInputElement).value;
-  }
+  updateMinimumValue = (event: InputEvent) => {
+    const element = event.target as HTMLInputElement;
+    this.validMinimum = element.checkValidity();
+    this.minimumValue = element.value;
+  };
 
-  @action
-  updateMaximumValue(event: InputEvent) {
-    this.maximumValue = (event.target as HTMLInputElement).value;
-  }
+  updateMaximumValue = (event: InputEvent) => {
+    const element = event.target as HTMLInputElement;
+    this.validMaximum = element.checkValidity();
+    this.maximumValue = element.value;
+  };
 
   @action
   insert() {

--- a/addon/components/variable-plugin/number/insert.ts
+++ b/addon/components/variable-plugin/number/insert.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { isNumber } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/strings';
 import { inject as service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
+import { modifier } from 'ember-modifier';
 
 type Args = {
   controller: SayController;
@@ -18,6 +19,26 @@ export default class NumberInsertComponent extends Component<Args> {
   @tracked maximumValue = '';
   @tracked validMinimum = true;
   @tracked validMaximum = true;
+
+  minimumInput = modifier(
+    (element: HTMLInputElement) => {
+      element.addEventListener('input', this.updateMinimumValue);
+      this.validMinimum = element.checkValidity();
+      return () =>
+        element.removeEventListener('input', this.updateMinimumValue);
+    },
+    { eager: false },
+  );
+
+  maximumInput = modifier(
+    (element: HTMLInputElement) => {
+      element.addEventListener('input', this.updateMaximumValue);
+      this.validMaximum = element.checkValidity();
+      return () =>
+        element.removeEventListener('input', this.updateMaximumValue);
+    },
+    { eager: false },
+  );
 
   get controller() {
     return this.args.controller;

--- a/addon/components/variable-plugin/number/insert.ts
+++ b/addon/components/variable-plugin/number/insert.ts
@@ -22,20 +22,14 @@ export default class NumberInsertComponent extends Component<Args> {
 
   minimumInput = modifier(
     (element: HTMLInputElement) => {
-      element.addEventListener('input', this.updateMinimumValue);
       this.validMinimum = element.checkValidity();
-      return () =>
-        element.removeEventListener('input', this.updateMinimumValue);
     },
     { eager: false },
   );
 
   maximumInput = modifier(
     (element: HTMLInputElement) => {
-      element.addEventListener('input', this.updateMaximumValue);
       this.validMaximum = element.checkValidity();
-      return () =>
-        element.removeEventListener('input', this.updateMaximumValue);
     },
     { eager: false },
   );


### PR DESCRIPTION
### Overview
This PR adds functionality which checks the validity of the min/max input fields each time their value changes. It uses the `checkValidity` API for this.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4436?atlOrigin=eyJpIjoiOTEyNTdlNWI4OWU5NDIxNjgyZDAzMWMzY2ZkYzBlZTkiLCJwIjoiaiJ9

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
- Open the number insert card on firefox
- Input text which is not a number in the minimum/maximum fields
- An error message should show up and the `insert` button should be disabled.



### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
