### PR TITLE
GN-4263: update address variable according to updated design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GN-4461: update readme to specify needed imports for template comment
 
 ### Changed
+- GN-4263: update address variable edit UI/UX according to updated design
+- Allow the address municipality-edit field to be prefilled
 - Use one-way-binding in variable label input
 - Use one-way-binding in number variable inputs
 

--- a/README.md
+++ b/README.md
@@ -665,8 +665,12 @@ get codelistEditOptions() {
 This addon provides a seperate edit component which allows users to search for an address and update the select address variable. Additionally, they can also choose whether to include the housenumber of an address.
 You can add this edit-component to a template as follows:
 ```hbs
-<VariablePlugin::Address::Edit @controller={{this.controller}}/>
+<VariablePlugin::Address::Edit @controller={{this.controller}} @defaultMuncipality='Antwerpen'/>
 ```
+
+The edit card can be configured with two arguments:
+- An instance of a `SayController` (required)
+- A `defaultMuncipality` which should be used as the default value of the `muncipality` field in the edit-card (optional)
 
 ## validation-plugin
 

--- a/addon/components/loading-alert.hbs
+++ b/addon/components/loading-alert.hbs
@@ -1,0 +1,28 @@
+{{#if this.isVisible}}
+  <div
+    class="au-c-alert {{this.skin}} {{this.size}}"
+    role="alert"
+    data-test-alert
+    ...attributes
+  >
+    <AuLoader/>
+    <div class="au-c-alert__content">
+      {{#if @title}}
+        <p class="au-c-alert__title" data-test-alert-title>{{@title}}</p>
+      {{/if}}
+      <div class="au-c-alert__message" data-test-alert-message>{{yield}}</div>
+    </div>
+    {{#if @closable}}
+      <button
+        class="au-c-alert__close"
+        type="button"
+        data-test-alert-close
+        {{on "click" this.closeAlert}}
+      >
+        <AuIcon @icon="cross" @size="large" />
+        {{!-- template-lint-disable no-bare-strings --}}
+        <span class="au-u-hidden-visually">Sluit alert</span>
+      </button>
+    {{/if}}
+  </div>
+{{/if}}

--- a/addon/components/loading-alert.ts
+++ b/addon/components/loading-alert.ts
@@ -1,0 +1,3 @@
+//@ts-expect-error ember-appuniversum uses vanilla javascript
+import AuAlertComponent from '@appuniversum/ember-appuniversum/components/au-alert';
+export default class LoadingAlertComponent extends AuAlertComponent {}

--- a/addon/components/variable-plugin/address/edit.hbs
+++ b/addon/components/variable-plugin/address/edit.hbs
@@ -1,35 +1,86 @@
 {{#if this.showCard}}
   <AuCard @flex={{true}} @divided={{true}} @shadow={{true}} @size="small" as |c|>
     <c.content>
-      <AuLabel for='address-select'>
-        {{t "editor-plugins.address.edit.title"}}
-      </AuLabel>
-      <PowerSelect
-        id="adress-select"
-        @loadingMessage={{t "editor-plugins.utils.loading"}}
-        @searchMessage={{t "editor-plugins.address.edit.search-message"}}
-        @noMatchesMessage={{t "editor-plugins.address.edit.no-results"}}
-        @placeholder={{if this.includeHouseNumber 
-                          (t "editor-plugins.address.edit.placeholder-with-number") 
-                          (t "editor-plugins.address.edit.placeholder-without-number")}}
-        @renderInPlace={{true}}
-        @searchEnabled={{true}}
-        @search={{perform this.searchAddress}}
-        @selected={{this.selectedAddress}}
-        @onChange={{this.selectAddress}} as |address|>
-        {{address.formatted}}
-      </PowerSelect>
-      <AuToggleSwitch
-        @checked={{this.includeHouseNumber}}
-        @onChange={{this.toggleIncludeHouseNumber}}
-        @label={{t "editor-plugins.address.edit.include-housenumber"}}
-      />
-      <AuButton 
-        {{on 'click' (perform this.updateAddressVariable)}} 
-        @disabled={{not this.canUpdate}}
-        @loading={{this.updateAddressVariable.isRunning}}>
-        {{t "editor-plugins.utils.insert"}}
-      </AuButton>
+      <form class="au-c-form">
+        <AuLabel for='municipality-select'>
+          {{t "editor-plugins.address.edit.municipality.label"}}*
+        </AuLabel>
+        <PowerSelect
+          id="municipality-select"
+          @loadingMessage={{t "editor-plugins.utils.loading"}}
+          @searchMessage={{t "editor-plugins.address.edit.municipality.search-message"}}
+          @noMatchesMessage={{t "editor-plugins.address.edit.municipality.no-results"}}
+          @placeholder={{t "editor-plugins.address.edit.municipality.placeholder"}}
+          @renderInPlace={{true}}
+          @searchEnabled={{true}}
+          @search={{perform this.searchMunicipality}}
+          @selected={{this.newMunicipality}}
+          @onChange={{this.selectMunicipality}} as |municipality|>
+          {{municipality}}
+        </PowerSelect>
+        <AuLabel for='streetname-select'>
+          {{t "editor-plugins.address.edit.street.label"}}*
+        </AuLabel>
+        <PowerSelect
+          id="streetname-select"
+          @loadingMessage={{t "editor-plugins.utils.loading"}}
+          @searchMessage={{t "editor-plugins.address.edit.street.search-message"}}
+          @noMatchesMessage={{t "editor-plugins.address.edit.street.no-results"}}
+          @placeholder={{t "editor-plugins.address.edit.street.placeholder"}}
+          @renderInPlace={{true}}
+          @searchEnabled={{true}}
+          @search={{perform this.searchStreet}}
+          @selected={{this.newStreetName}}
+          @disabled={{not this.canUpdateStreet}}
+          @onChange={{this.selectStreet}} as |street|>
+          {{street}}
+        </PowerSelect>
+        <div class="au-o-grid au-o-grid--tiny">
+          <div class="au-o-grid__item au-u-1-2@medium">
+            <AuLabel for="housenumber-select">
+              {{t "editor-plugins.address.edit.housenumber.label"}}
+            </AuLabel>
+            <AuNativeInput 
+              id="housenumber-select"
+              placeholder={{t "editor-plugins.address.edit.housenumber.placeholder"}}
+              @width="block"  
+              value={{this.newHousenumber}} 
+              @disabled={{not this.canUpdateHousenumber}}
+              {{on 'input' this.updateHousenumber}}
+            />
+          </div>
+          <div class="au-o-grid__item au-u-1-2@medium">
+            <AuLabel for="busnumber-select">
+              {{t "editor-plugins.address.edit.busnumber.label"}}
+            </AuLabel>
+            <AuNativeInput 
+              id="busnumber-select"
+              placeholder={{t "editor-plugins.address.edit.busnumber.placeholder"}}
+              @width="block"  
+              value={{this.newBusnumber}} 
+              @disabled={{not this.canUpdateBusnumber}}
+              {{on 'input' this.updateBusnumber}}
+            />
+          </div>
+        </div>
+        
+        {{#if this.newAddress.isRunning}}
+        {{t "editor-plugins.address.edit.loading"}}
+        <AuLoader @padding="small"/>
+        {{/if}}
+        {{#if this.message}}
+          <AuAlert @skin={{this.message.skin}} @icon={{this.message.icon}} @title={{this.message.title}}>
+            {{this.message.body}}
+          </AuAlert>
+        {{/if}}
+        <AuButton 
+          {{on 'click' this.updateAddressVariable}} 
+          @disabled={{not this.canUpdateAddressVariable}}>
+          {{t "editor-plugins.utils.insert"}}
+        </AuButton>
+        
+      </form>
+      
     </c.content>
   </AuCard>
 {{/if}}

--- a/addon/components/variable-plugin/address/edit.hbs
+++ b/addon/components/variable-plugin/address/edit.hbs
@@ -65,8 +65,7 @@
         </div>
         
         {{#if this.newAddress.isRunning}}
-        {{t "editor-plugins.address.edit.loading"}}
-        <AuLoader @padding="small"/>
+          <LoadingAlert @title={{t "editor-plugins.address.edit.loading"}} @size="small" @skin="info"/>
         {{/if}}
         {{#if this.message}}
           <AuAlert @skin={{this.message.skin}} @icon={{this.message.icon}} @title={{this.message.title}}>

--- a/addon/components/variable-plugin/address/edit.ts
+++ b/addon/components/variable-plugin/address/edit.ts
@@ -1,45 +1,109 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { NodeSelection, SayController } from '@lblod/ember-rdfa-editor';
-import { Address } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 import {
-  fetchAddresses,
+  Address,
+  Street,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
+import {
+  AddressError,
+  fetchMunicipalities,
+  fetchStreets,
   resolveAddress,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/utils/address-helpers';
-import { dropTask, restartableTask, timeout } from 'ember-concurrency';
+import { restartableTask, timeout } from 'ember-concurrency';
 import { localCopy, trackedReset } from 'tracked-toolbox';
+import { trackedTask } from 'ember-resources/util/ember-concurrency';
+import { service } from '@ember/service';
+import IntlService from 'ember-intl/services/intl';
 
 type Args = {
   controller: SayController;
+  defaultMunicipality?: string;
 };
 
 export default class AddressEditComponent extends Component<Args> {
-  @localCopy('currentAddress')
-  selectedAddress?: Address;
+  @service declare intl: IntlService;
 
-  @trackedReset<AddressEditComponent, boolean>({
+  @trackedReset<AddressEditComponent, string | undefined>({
     memo: 'currentAddress',
-    update(component, _key, last) {
-      if (component.currentAddress) {
-        return component.currentAddress.hasHouseNumber;
-      } else {
-        return last;
-      }
+    update(component) {
+      const { currentMunicipality } = component;
+      return currentMunicipality
+        ? currentMunicipality
+        : component.args.defaultMunicipality;
     },
   })
-  includeHouseNumber = true;
+  newMunicipality?: string;
 
-  @action
-  toggleIncludeHouseNumber() {
-    this.includeHouseNumber = !this.includeHouseNumber;
-    this.selectedAddress = undefined;
+  @localCopy('currentStreetName') newStreetName?: string;
+
+  @localCopy('currentHousenumber') newHousenumber?: string;
+
+  @localCopy('currentBusnumber') newBusnumber?: string;
+
+  get message() {
+    const value = this.newAddress.value as Address | Street | undefined;
+    if (
+      this.newAddress.isSuccessful &&
+      value &&
+      !value.sameAs(this.currentAddress)
+    ) {
+      return {
+        skin: 'success',
+        icon: 'check',
+        title: this.intl.t('editor-plugins.address.edit.success.address-found'),
+        body: value.formatted,
+      };
+    } else if (
+      this.newAddress.isError &&
+      this.newAddress.error instanceof AddressError
+    ) {
+      const { error } = this.newAddress;
+      return {
+        skin: 'warning',
+        icon: 'alert-triangle',
+        title: this.intl.t(error.translation, { status: error.status }),
+        body: this.intl.t('editor-plugins.address.edit.errors.contact', {
+          htmlSafe: true,
+          email: 'gelinktnotuleren@vlaanderen.be',
+        }),
+      };
+    } else {
+      return;
+    }
   }
 
   get currentAddress() {
-    return this.selectedAddressVariable?.node.attrs.address as
+    return this.selectedAddressVariable?.node.attrs.value as
       | Address
+      | Street
       | undefined
       | null;
+  }
+
+  get currentMunicipality() {
+    return this.currentAddress?.municipality;
+  }
+
+  get currentStreetName() {
+    return this.currentAddress?.street;
+  }
+
+  get currentHousenumber() {
+    if (this.currentAddress instanceof Address) {
+      return this.currentAddress.housenumber;
+    } else {
+      return;
+    }
+  }
+
+  get currentBusnumber() {
+    if (this.currentAddress instanceof Address) {
+      return this.currentAddress.busnumber;
+    } else {
+      return;
+    }
   }
 
   get selectedAddressVariable() {
@@ -53,44 +117,124 @@ export default class AddressEditComponent extends Component<Args> {
     return;
   }
 
+  get canUpdateStreet() {
+    return !!this.newMunicipality;
+  }
+
+  get canUpdateHousenumber() {
+    return this.newMunicipality && this.newStreetName;
+  }
+
+  get canUpdateBusnumber() {
+    return this.newMunicipality && this.newStreetName && this.newHousenumber;
+  }
+
   get showCard() {
     return !!this.selectedAddressVariable;
   }
 
-  get canUpdate() {
+  get canUpdateAddressVariable() {
     return (
-      !!this.selectedAddress &&
-      !this.selectedAddress.sameAs(
-        this.selectedAddressVariable?.node.attrs.address as Address | undefined,
-      )
+      this.newAddress.isSuccessful &&
+      this.newAddress.value &&
+      !this.currentAddress?.sameAs(this.newAddress.value)
     );
   }
 
-  updateAddressVariable = dropTask(async () => {
-    if (this.selectedAddressVariable && this.selectedAddress) {
-      const { pos } = this.selectedAddressVariable;
-
-      const address =
-        this.includeHouseNumber && this.selectedAddress.hasHouseNumber
-          ? await resolveAddress(this.selectedAddress)
-          : this.selectedAddress;
-      this.controller.withTransaction((tr) => {
-        return tr.setNodeAttribute(pos, 'address', address);
-      });
+  resolveAddressTask = restartableTask(async () => {
+    const { newStreetName, newMunicipality, newHousenumber, newBusnumber } =
+      this;
+    if (newStreetName && newMunicipality) {
+      if (newHousenumber) {
+        // Before trying to resolve the address,
+        // check if the inputs are the same as the current address, if so, no request is necessary.
+        if (
+          this.currentAddress instanceof Address &&
+          this.currentAddress.street === newStreetName &&
+          this.currentAddress.municipality === newMunicipality &&
+          this.currentAddress.housenumber === newHousenumber &&
+          this.currentAddress.busnumber === newBusnumber
+        ) {
+          return this.currentAddress;
+        }
+        // The inputted address is not the same as the current one, so we resolve it with the address register.
+        await timeout(200);
+        return await resolveAddress({
+          street: newStreetName,
+          municipality: newMunicipality,
+          housenumber: newHousenumber,
+          busnumber: newBusnumber,
+        });
+      } else {
+        return new Street({
+          municipality: newMunicipality,
+          street: newStreetName,
+        });
+      }
+    } else {
+      return;
     }
   });
 
+  newAddress = trackedTask(this, this.resolveAddressTask, () => [
+    this.newMunicipality,
+    this.newStreetName,
+    this.newHousenumber,
+    this.newBusnumber,
+  ]);
+
   @action
-  selectAddress(address: Address) {
-    this.selectedAddress = address;
+  updateAddressVariable() {
+    if (this.selectedAddressVariable && this.newAddress.isSuccessful) {
+      const { pos } = this.selectedAddressVariable;
+      this.controller.withTransaction((tr) => {
+        return tr.setNodeAttribute(pos, 'value', this.newAddress.value);
+      });
+    }
+  }
+
+  @action
+  selectMunicipality(municipality: string) {
+    this.newMunicipality = municipality;
+    this.newStreetName = '';
+    this.newHousenumber = '';
+    this.newBusnumber = '';
+  }
+
+  @action
+  selectStreet(street: string) {
+    this.newStreetName = street;
+    this.newHousenumber = '';
+    this.newBusnumber = '';
+  }
+
+  @action
+  updateHousenumber(event: InputEvent) {
+    this.newHousenumber = (event.target as HTMLInputElement).value;
+    this.newBusnumber = '';
+  }
+
+  @action
+  updateBusnumber(event: InputEvent) {
+    this.newBusnumber = (event.target as HTMLInputElement).value;
   }
 
   get controller() {
     return this.args.controller;
   }
 
-  searchAddress = restartableTask(async (term: string) => {
-    await timeout(400);
-    return fetchAddresses(term, this.includeHouseNumber);
+  searchMunicipality = restartableTask(async (term: string) => {
+    await timeout(200);
+    return fetchMunicipalities(term);
+  });
+
+  searchStreet = restartableTask(async (term: string) => {
+    if (this.newMunicipality) {
+      await timeout(200);
+      const streets = await fetchStreets(term, this.newMunicipality);
+      return streets;
+    } else {
+      return [];
+    }
   });
 }

--- a/addon/components/variable-plugin/address/nodeview.ts
+++ b/addon/components/variable-plugin/address/nodeview.ts
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
 import { NodeSelection, PNode, SayController } from '@lblod/ember-rdfa-editor';
 import { action } from '@ember/object';
-import { Address } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/address';
+import {
+  Address,
+  Street,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/address';
 
 type Args = {
   getPos: () => number | undefined;
@@ -14,7 +17,7 @@ export default class AddressNodeviewComponent extends Component<Args> {
   }
 
   get address() {
-    return this.node.attrs.address as Address | null;
+    return this.node.attrs.value as Address | Street | null;
   }
 
   @action

--- a/addon/components/variable-plugin/address/nodeview.ts
+++ b/addon/components/variable-plugin/address/nodeview.ts
@@ -1,10 +1,7 @@
 import Component from '@glimmer/component';
 import { NodeSelection, PNode, SayController } from '@lblod/ember-rdfa-editor';
 import { action } from '@ember/object';
-import {
-  Address,
-  Street,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/address';
+import { Address } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/address';
 
 type Args = {
   getPos: () => number | undefined;
@@ -17,7 +14,7 @@ export default class AddressNodeviewComponent extends Component<Args> {
   }
 
   get address() {
-    return this.node.attrs.value as Address | Street | null;
+    return this.node.attrs.value as Address | null;
   }
 
   @action

--- a/addon/plugins/variable-plugin/utils/address-helpers.ts
+++ b/addon/plugins/variable-plugin/utils/address-helpers.ts
@@ -66,8 +66,8 @@ type AddressDetailResult = {
   huisnummer: string;
   busnummer: string;
   adresPositie: {
-    point: {
-      coordinates: [number, number]; // coordinates in Lambert72
+    geometrie: {
+      gml: string; // coordinates in Lambert72
     };
   };
 };
@@ -167,6 +167,10 @@ export async function resolveStreet(info: StreetInfo) {
         street: unwrap(streetinfo.Thoroughfarename),
         municipality: streetinfo.Municipality,
         zipcode: unwrap(streetinfo.Zipcode),
+        gml: constructLambert72GMLString({
+          x: streetinfo.Location.X_Lambert72,
+          y: streetinfo.Location.Y_Lambert72,
+        }),
       });
     } else {
       throw new AddressError({
@@ -203,6 +207,7 @@ export async function resolveAddress(info: AddressInfo) {
         zipcode: result.postinfo.objectId,
         municipality: result.gemeente.gemeentenaam.geografischeNaam.spelling,
         id: result.identificator.id,
+        gml: result.adresPositie.geometrie.gml,
       });
     } else {
       throw new AddressError({
@@ -246,4 +251,13 @@ export async function searchAddress(
       status: response.status,
     });
   }
+}
+
+type Lambert72Coordinates = {
+  x: number;
+  y: number;
+};
+
+function constructLambert72GMLString({ x, y }: Lambert72Coordinates) {
+  return `<gml:Point srsName="https://www.opengis.net/def/crs/EPSG/0/31370" xmlns:gml="http://www.opengis.net/gml/3.2"><gml:pos>${x} ${y}</gml:pos></gml:Point>`;
 }

--- a/addon/plugins/variable-plugin/variables/address.ts
+++ b/addon/plugins/variable-plugin/variables/address.ts
@@ -1,7 +1,6 @@
 import {
   ADRES,
   EXT,
-  GEO,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import {
   createEmberNodeSpec,
@@ -28,42 +27,67 @@ import {
   typeSpan,
 } from '../utils/dom-constructors';
 
-type Location = {
-  lat_WGS84: number;
-  long_WGS84: number;
-};
+// type Location = {
+//   lat_WGS84: number;
+//   long_WGS84: number;
+// };
+
+export class Street {
+  declare street: string;
+  declare municipality: string;
+
+  constructor(args: Pick<Street, 'municipality' | 'street'>) {
+    Object.assign(this, args);
+  }
+
+  get formatted() {
+    return `${this.street}, ${this.municipality}`;
+  }
+
+  sameAs(other?: unknown) {
+    if (other instanceof Street) {
+      return (
+        this.street === other.street && this.municipality === other.municipality
+      );
+    } else {
+      return false;
+    }
+  }
+}
 export class Address {
+  declare id: string;
   declare street: string;
   declare zipcode: string;
   declare municipality: string;
-  declare location: Location;
-  housenumber?: string | null;
+  declare housenumber: string;
+  declare busnumber?: string | null;
   constructor(
     args: Pick<
       Address,
-      'street' | 'housenumber' | 'zipcode' | 'municipality' | 'location'
+      'street' | 'housenumber' | 'zipcode' | 'municipality' | 'id' | 'busnumber'
     >,
   ) {
     Object.assign(this, args);
   }
 
   get formatted() {
-    const firstPart = this.housenumber
-      ? `${this.street} ${this.housenumber}`
-      : this.street;
+    const firstPart = this.busnumber
+      ? `${this.street} ${this.housenumber} bus ${this.busnumber}`
+      : `${this.street} ${this.housenumber}`;
     const secondPart = `${this.zipcode} ${this.municipality}`;
     return `${firstPart}, ${secondPart}`;
   }
 
-  sameAs(other?: Address | null) {
-    if (other) {
+  sameAs(other?: unknown) {
+    if (other instanceof Address) {
       return (
         this.street === other.street &&
         this.housenumber === other.housenumber &&
+        this.busnumber === other.busnumber &&
         this.zipcode === other.zipcode &&
-        this.municipality === other.municipality &&
-        this.location.lat_WGS84 === other.location.lat_WGS84 &&
-        this.location.long_WGS84 === other.location.long_WGS84
+        this.municipality === other.municipality
+        // this.location.lat_WGS84 === other.location.lat_WGS84 &&
+        // this.location.long_WGS84 === other.location.long_WGS84
       );
     } else {
       return false;
@@ -75,124 +99,122 @@ export class Address {
   }
 }
 
-export class ResolvedAddress extends Address {
-  addressRegisterId: string;
+// const constructLocationNode = (location: Location) => {
+//   return span(
+//     {
+//       property: ADRES('positie').full,
+//       typeof: GEO('Point').full,
+//     },
+//     span({
+//       property: GEO('lat').full,
+//       content: location.lat_WGS84.toString(),
+//     }),
+//     span({
+//       property: GEO('long').full,
+//       content: location.long_WGS84.toString(),
+//     }),
+//   );
+// };
 
-  constructor(
-    args: Pick<
-      ResolvedAddress,
-      | 'street'
-      | 'housenumber'
-      | 'zipcode'
-      | 'municipality'
-      | 'addressRegisterId'
-      | 'location'
-    >,
-  ) {
-    super(args);
-    this.addressRegisterId = args.addressRegisterId;
-  }
-
-  static resolve(address: Address, addressRegisterId: string) {
-    return new ResolvedAddress({
-      addressRegisterId,
-      ...address,
-    });
-  }
-}
-
-const constructLocationNode = (location: Location) => {
-  return span(
-    {
-      property: ADRES('positie').full,
-      typeof: GEO('Point').full,
-    },
-    span({
-      property: GEO('lat').full,
-      content: location.lat_WGS84.toString(),
-    }),
-    span({
-      property: GEO('long').full,
-      content: location.long_WGS84.toString(),
-    }),
+const constructStreetNode = (street: Street) => {
+  return contentSpan(
+    { typeof: ADRES('Adres').full },
+    span(
+      {
+        property: ADRES('heeftStraatnaam').full,
+      },
+      street.street,
+    ),
+    ', ',
+    span(
+      {
+        property: ADRES('gemeentenaam').full,
+      },
+      street.municipality,
+    ),
   );
 };
 
-const constructAddressNode = (address?: Address | ResolvedAddress) => {
-  if (address) {
-    const resource =
-      'addressRegisterId' in address ? address.addressRegisterId : undefined;
-    const houseNumberSpan = address.housenumber
-      ? span(
-          {
-            property: ADRES('huisnummer').full,
-          },
-          address.housenumber,
-        )
-      : '';
-    return contentSpan(
-      { resource, typeof: ADRES('Adres').full },
-      span(
-        {
-          property: ADRES('heeftStraatnaam').full,
-        },
-        address.street,
-      ),
-      address.housenumber ? ' ' : '', //if there is still a housenumber coming after the street, insert a space.
-      houseNumberSpan,
-      ', ',
-      span(
-        {
-          property: ADRES('heeftPostinfo').full,
-          typeof: ADRES('Postinfo').full,
-        },
+const constructAddressNode = (address: Address) => {
+  const busnumberNode = address.busnumber
+    ? [
+        ' bus',
         span(
           {
-            property: ADRES('postcode').full,
+            property: ADRES('busnummer').full,
           },
-          address.zipcode,
+          address.busnumber,
         ),
-      ),
-      ' ',
+      ]
+    : [];
+  return contentSpan(
+    { resource: address.id, typeof: ADRES('Adres').full },
+    span(
+      {
+        property: ADRES('heeftStraatnaam').full,
+      },
+      address.street,
+    ),
+    ' ',
+    span(
+      {
+        property: ADRES('huisnummer').full,
+      },
+      address.housenumber,
+    ),
+    ...busnumberNode,
+    ', ',
+    span(
+      {
+        property: ADRES('heeftPostinfo').full,
+        typeof: ADRES('Postinfo').full,
+      },
       span(
         {
-          property: ADRES('gemeentenaam').full,
+          property: ADRES('postcode').full,
         },
-        address.municipality,
+        address.zipcode,
       ),
-      constructLocationNode(address.location),
-    );
-  } else {
-    return contentSpan({}, 'Voeg adres in');
-  }
+    ),
+    ' ',
+    span(
+      {
+        property: ADRES('gemeentenaam').full,
+      },
+      address.municipality,
+    ),
+    // constructLocationNode(address.location),
+  );
 };
 
-const parseLocationNode = (locationNode: Element): Location | undefined => {
-  const lat_WGS84 = findChildWithRdfaAttribute(
-    locationNode,
-    'property',
-    GEO('lat'),
-  )?.getAttribute('content');
-  const long_WGS84 = findChildWithRdfaAttribute(
-    locationNode,
-    'property',
-    GEO('long'),
-  )?.getAttribute('content');
-  if (lat_WGS84 && long_WGS84) {
-    const lat_WGS84_number = parseFloat(lat_WGS84);
-    const long_WGS84_number = parseFloat(long_WGS84);
-    if (!isNaN(lat_WGS84_number) && !isNaN(long_WGS84_number)) {
-      return {
-        lat_WGS84: lat_WGS84_number,
-        long_WGS84: long_WGS84_number,
-      };
-    }
-  }
-  return;
-};
+// const parseLocationNode = (locationNode: Element): Location | undefined => {
+//   const lat_WGS84 = findChildWithRdfaAttribute(
+//     locationNode,
+//     'property',
+//     GEO('lat'),
+//   )?.getAttribute('content');
+//   const long_WGS84 = findChildWithRdfaAttribute(
+//     locationNode,
+//     'property',
+//     GEO('long'),
+//   )?.getAttribute('content');
+//   if (lat_WGS84 && long_WGS84) {
+//     const lat_WGS84_number = parseFloat(lat_WGS84);
+//     const long_WGS84_number = parseFloat(long_WGS84);
+//     if (!isNaN(lat_WGS84_number) && !isNaN(long_WGS84_number)) {
+//       return {
+//         lat_WGS84: lat_WGS84_number,
+//         long_WGS84: long_WGS84_number,
+//       };
+//     }
+//   }
+//   return;
+// };
 
-const parseAddressNode = (addressNode: Element): Address | undefined => {
-  const addressRegisterId = addressNode.getAttribute('resource');
+const parseAddressNode = (
+  addressNode: Element,
+): Address | Street | undefined => {
+  const id = addressNode.getAttribute('resource');
   const street = findChildWithRdfaAttribute(
     addressNode,
     'property',
@@ -202,6 +224,11 @@ const parseAddressNode = (addressNode: Element): Address | undefined => {
     addressNode,
     'property',
     ADRES('huisnummer'),
+  )?.textContent;
+  const busnumber = findChildWithRdfaAttribute(
+    addressNode,
+    'property',
+    ADRES('busnummer'),
   )?.textContent;
   const postInfoNode = findChildWithRdfaAttribute(
     addressNode,
@@ -217,29 +244,27 @@ const parseAddressNode = (addressNode: Element): Address | undefined => {
     'property',
     ADRES('gemeentenaam'),
   )?.textContent;
-  const locationNode = findChildWithRdfaAttribute(
-    addressNode,
-    'property',
-    ADRES('positie'),
-  );
-  const location = locationNode && parseLocationNode(locationNode);
-  if (street && zipcode && municipality && location) {
-    if (addressRegisterId) {
-      return new ResolvedAddress({
-        addressRegisterId,
+  // const locationNode = findChildWithRdfaAttribute(
+  //   addressNode,
+  //   'property',
+  //   ADRES('positie'),
+  // );
+  // const location = locationNode && parseLocationNode(locationNode);
+  if (street && municipality) {
+    if (id && zipcode && housenumber) {
+      return new Address({
+        id,
         street,
         housenumber,
         zipcode,
         municipality,
-        location,
+        busnumber,
+        // location,
       });
     } else {
-      return new Address({
+      return new Street({
         street,
-        housenumber,
-        zipcode,
         municipality,
-        location,
       });
     }
   } else {
@@ -271,7 +296,7 @@ const parseDOM = [
             variableInstance ?? `http://data.lblod.info/variables/${uuidv4()}`,
           mappingResource,
           label,
-          address: parseAddressNode(addressNode),
+          value: parseAddressNode(addressNode),
         };
       }
 
@@ -281,7 +306,17 @@ const parseDOM = [
 ];
 
 const toDOM = (node: PNode): DOMOutputSpec => {
-  const { mappingResource, variableInstance, label, address } = node.attrs;
+  const { mappingResource, variableInstance, label, value } = node.attrs;
+  let contentNode: DOMOutputSpec;
+  if (value) {
+    if (value instanceof Address) {
+      contentNode = constructAddressNode(value);
+    } else {
+      contentNode = constructStreetNode(value);
+    }
+  } else {
+    contentNode = contentSpan({}, 'Voeg adres in');
+  }
   return mappingSpan(
     mappingResource,
     {
@@ -289,7 +324,7 @@ const toDOM = (node: PNode): DOMOutputSpec => {
     },
     instanceSpan(variableInstance),
     typeSpan('address'),
-    constructAddressNode(address),
+    contentNode,
   );
 };
 
@@ -310,7 +345,7 @@ const emberNodeConfig: EmberNodeConfig = {
     label: {
       default: 'adres',
     },
-    address: {
+    value: {
       default: null,
     },
   },

--- a/addon/utils/constants.ts
+++ b/addon/utils/constants.ts
@@ -27,3 +27,7 @@ export const GENERIEK = namespace(
   'generiek',
 );
 export const GEO = namespace('http://www.w3.org/2003/01/geo/wgs84_pos#', 'geo');
+export const GEOSPARQL = namespace(
+  'http://www.opengis.net/ont/geosparql#',
+  'geosparql',
+);

--- a/app/components/loading-alert.js
+++ b/app/components/loading-alert.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/loading-alert';

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -126,7 +126,7 @@
                 @plugin={{this.citationPlugin}}
                 @config={{this.config.citation}}
               />
-              <VariablePlugin::Address::Edit @controller={{this.controller}}/>
+              <VariablePlugin::Address::Edit @controller={{this.controller}} @defaultMunicipality="Gent"/>
               <ImportSnippetPlugin::Card @controller={{this.controller}} />
               <RdfaDatePlugin::Card
                 @controller={{this.controller}}

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -91,7 +91,7 @@
               @controller={{this.controller}}
               @options={{this.config.date}}
             />
-            <VariablePlugin::Address::Edit @controller={{this.controller}}/>
+            <VariablePlugin::Address::Edit @controller={{this.controller}} @defaultMunicipality="Destelbergen"/>
             <VariablePlugin::Codelist::Edit @controller={{this.controller}} @options={{this.codelistOptions}}/>
             <VariablePlugin::Location::Edit @controller={{this.controller}} @options={{this.locationOptions}}/>
             <TemplateCommentsPlugin::EditCard

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -91,7 +91,7 @@
               @controller={{this.controller}}
               @options={{this.config.date}}
             />
-            <VariablePlugin::Address::Edit @controller={{this.controller}} @defaultMunicipality="Destelbergen"/>
+            <VariablePlugin::Address::Edit @controller={{this.controller}} @defaultMunicipality="Gent"/>
             <VariablePlugin::Codelist::Edit @controller={{this.controller}} @options={{this.codelistOptions}}/>
             <VariablePlugin::Location::Edit @controller={{this.controller}} @options={{this.locationOptions}}/>
             <TemplateCommentsPlugin::EditCard

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -316,10 +316,29 @@ editor-plugins:
     insert: Insert address
     edit:
       title: Search for an address
-      no-results: No addresses found
-      search-message: Type to search
-      include-housenumber: Include housenumber
-      placeholder-with-number: Street housenumber, municipality
-      placeholder-without-number: Street, municipality
+      municipality:
+        label: Municipality
+        placeholder: Municipality
+        search-message: Type to search for a municipality
+        no-results: No municipalities found
+      street:
+        label: Street
+        placeholder: Street
+        search-message: Type to search for a street
+        no-results: No streets found
+      housenumber:
+        label: Housenumber
+        placeholder: Housenumber
+      busnumber:
+        label: Busnumber
+        placeholder: Busnumber
+      loading: Resolving address.
+      success:
+        address-found: Address found.
+      errors:
+        address-not-found: We could not resolve the provided address
+        http-error: "Something went wrong while resolving this address, status code: {status}."
+        contact: In case of persisting issues, contact <a href="mailto:{email}">{email}</a>.
     nodeview:
       placeholder: Insert address
+    

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -319,10 +319,29 @@ editor-plugins:
     insert: Adres invoegen
     edit:
       title: Zoek een adres
-      no-results: Geen adressen gevonden
-      search-message: Typ om te zoeken
-      include-housenumber: Inclusief huisnummer
-      placeholder-with-number: Straatnaam huisnummer, gemeente
-      placeholder-without-number: Straatnaam, gemeente
+      municipality:
+        label: Gemeente
+        placeholder: Gemeente
+        search-message: Typ om een gemeente op te zoeken
+        no-results: Geen gemeenten gevonden
+      street:
+        label: Straatnaam
+        placeholder: Straatnaam
+        search-message: Typ om een straatnaam op te zoeken
+        no-results: Geen straatnamen gevonden
+      housenumber:
+        label: Huisnummer
+        placeholder: Huisnummer
+      busnumber:
+        label: Busnummer
+        placeholder: Busnummer
+      loading: Adres aan het opzoeken.
+      success:
+        address-found: Adres gevonden.
+      errors:
+        address-not-found: We konden het adres niet terugvinden.
+        http-error: "Er is iets mis gelopen bij het opvragen van dit adres, statuscode: {status}."
+        contact: Bij blijvende problemen, contacteer <a href="mailto:{email}">{email}</a>.
     nodeview:
       placeholder: Voeg adres in
+    


### PR DESCRIPTION
### Overview
This PR attempts to improve the UX and UI when editing an address variable.
It includes the following:
- The UI of the address-edit card has been updated to provide seperate fields for the municipality, streetname, housenumber and busnumber.
  - The municipality can be prefilled with a default value
  - Both the municipality and streetname fields are implemented using `ember-powerselect` and provide auto-completion
  - Both the housenumber and busnumber are simple input fields, each time these are updated, the address is resolved using the address register (https://docs.basisregisters.vlaanderen.be/) (with a delay), to validate if the address exists.

#### How editing an address variable works:
1. First, the user can select a municipality using the muncipality dropdown menu. This field can already be prefilled if desired. The autocomplete of this menu is implemented by querying the location register API (https://geo.api.vlaanderen.be/geolocation). This API accepts a free-form string and can return a list of municipalities based on the provided input. Note: this API will always return the main municipality. If the user inputs a sub-municipality (e.g. Oostakker), they will get prompted with the main municipality (e.g. Gent).
2. Once a municipality has been selected, the user can select a street located in that municipality. The autocomplete of this menu is implemented by quering the address register API (https://api.basisregisters.vlaanderen.be/v2/adresmatch). This API accepts a municipality and streetname, and can return a list of streetnames that match.
3. Once both the municipality and street have been selected, the user can optionally input a housenumber and busnumber. When any of these fields are updated, a request (with a delay) is sent to the address register (https://api.basisregisters.vlaanderen.be/v2/adresmatch) in order to check if the address exists. Based on the response of this request, the user gets to see a success or error message.
4. Once the necessary fields are filled in, the user can insert the new address.


##### connected issues and PRs:
Jira: https://binnenland.atlassian.net/browse/GN-4263?atlOrigin=eyJpIjoiYzQ3NDdlNWViMTQ5NDMwYWE1YTQ0YmJlZjg3MWMzZjUiLCJwIjoiaiJ9

### How to test/reproduce
1. Insert an address variable and select it
2. Follow the steps described above in order to update the address variable
3. When selecting an address variable that already has a value, the edit fields should be prefilled
4. Check the correctness of translations
5. Input a wrong address to check if the error messages work

### Challenges/uncertainties
- At the moment, inclusion of coordinates has been disabled. The address register provides Lambert72 coordinates instead of the WGS84 coordinates provided by the location register. The address register only provides coordinates for full addresses (not for streets without a housenumber)
- When inserting a street (and municipality) without a housenumber, no zipcode is inserted. The address register only provides zipcodes for full addresses.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations

### TODO

- [x]  re-enable the coordinates feature
