### PR TITLE
GN-4454: update template comment styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use one-way-binding in variable label input
 - Use one-way-binding in number variable inputs
+- GN-4454: update template comment text color to lighter gray
 
 ### Fixed
 - GN-4404: ensure number-variable placeholders are consistent

--- a/app/styles/template-comments-plugin.scss
+++ b/app/styles/template-comments-plugin.scss
@@ -27,7 +27,7 @@
   }
 
   &.ProseMirror-selectednode {
-    outline: 2px solid var(--au-blue-500);
+    outline: 2px solid var(--au-outline-color);
   }
 }
 

--- a/app/styles/template-comments-plugin.scss
+++ b/app/styles/template-comments-plugin.scss
@@ -18,7 +18,7 @@
   }
 
   .au-c-alert__message {
-    color: var(--au-gray-900);
+    color: var(--au-gray-700);
 
     p {
       white-space: break-spaces;


### PR DESCRIPTION
### Overview
This PR updates the text color of template comments to a slightly lighter gray in order to improve the visual feedback to users that text inside template comments is different to other text inside the document.

The original idea was to apply an italic style to the text inside template comments. This approach collided with the idea of italic marks inside the editor. This PR tries to approach the problem using a slightly different angle. 

##### connected issues and PRs:
Attempts to solve https://binnenland.atlassian.net/browse/GN-4454?atlOrigin=eyJpIjoiNmM4M2RiMDFmYTkwNDlkMmIwMWI4ODk3Y2U2MmUzZWYiLCJwIjoiaiJ9 (although in a different way).

### How to test/reproduce
Insert a template comment, notice that the text-color inside is lighter than other text in the document.

### Challenges/uncertainties
I'm not complete sure about the choosen gray color. It seemed to me it was well readable and differentiating enough.


### Checks PR readiness
- [ ] changelog
- [ ] npm lint
