### PR TITLE
GN-4330: allow per-instance config of single/multi-select styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - GN-4442: template comments can move up and down over the *whole* document
 
+### Added
+- GN4470: ability to specifly single/multi-select per codelist instance
+
 ## [11.0.0] - 2023-08-22
 
 ### Added

--- a/addon/components/variable-plugin/codelist/edit.ts
+++ b/addon/components/variable-plugin/codelist/edit.ts
@@ -72,7 +72,11 @@ export default class CodelistEditComponent extends Component<Args> {
   });
 
   get multiSelect() {
-    return this.codelistOptions.value?.type === MULTI_SELECT_CODELIST_TYPE;
+    const localStyle = this.selectedCodelist.value?.node.attrs.selectionStyle;
+    if (localStyle) {
+      return localStyle === 'multi';
+    } else
+      return this.codelistOptions.value?.type === MULTI_SELECT_CODELIST_TYPE;
   }
 
   @action

--- a/addon/components/variable-plugin/codelist/edit.ts
+++ b/addon/components/variable-plugin/codelist/edit.ts
@@ -72,7 +72,8 @@ export default class CodelistEditComponent extends Component<Args> {
   });
 
   get multiSelect() {
-    const localStyle = this.selectedCodelist.value?.node.attrs.selectionStyle;
+    const localStyle = this.selectedCodelist.value?.node.attrs
+      .selectionStyle as string;
     if (localStyle) {
       return localStyle === 'multi';
     } else

--- a/addon/components/variable-plugin/codelist/insert.hbs
+++ b/addon/components/variable-plugin/codelist/insert.hbs
@@ -8,6 +8,16 @@
 >
   {{codelist.label}}
 </PowerSelect>
+<PowerSelect
+  @allowClear={{false}}
+  @searchEnabled={{false}}
+  @options={{this.selectionStyles}}
+  @selected={{this.selectedStyle}}
+  @onChange={{this.selectStyle}}
+  as |style|
+>
+  {{style.label}}
+</PowerSelect>
 <AuFormRow>
   <VariablePlugin::Utils::LabelInput 
     @label={{this.label}}

--- a/addon/components/variable-plugin/codelist/insert.hbs
+++ b/addon/components/variable-plugin/codelist/insert.hbs
@@ -1,12 +1,12 @@
 <PowerSelect
   @allowClear={{false}}
   @searchEnabled={{false}}
-  @options={{this.subtypes.value}}
-  @selected={{this.selectedSubtype}}
-  @onChange={{this.updateSubtype}}
-  as |subtype|
+  @options={{this.codelistData.value}}
+  @selected={{this.selectedCodelist}}
+  @onChange={{this.selectCodelist}}
+  as |codelist|
 >
-  {{subtype.label}}
+  {{codelist.label}}
 </PowerSelect>
 <AuFormRow>
   <VariablePlugin::Utils::LabelInput 
@@ -16,7 +16,7 @@
 </AuFormRow>
 <AuButton
   {{on 'click' this.insert}}
-  @disabled={{not this.selectedSubtype}}
+  @disabled={{not this.selectedCodelist}}
 >
   {{t 'variable-plugin.button'}}
 </AuButton>

--- a/addon/components/variable-plugin/codelist/insert.ts
+++ b/addon/components/variable-plugin/codelist/insert.ts
@@ -19,12 +19,16 @@ type Args = {
   controller: SayController;
   options: CodelistInsertOptions;
 };
+interface SelectStyle {
+  label: string;
+  value: string;
+}
 
 export default class CodelistInsertComponent extends Component<Args> {
+  @service declare intl: IntlService;
   @tracked selectedCodelist?: CodeList;
   @tracked label?: string;
-
-  @service declare intl: IntlService;
+  @tracked selectedStyleValue: string = 'single';
 
   get controller() {
     return this.args.controller;
@@ -42,6 +46,23 @@ export default class CodelistInsertComponent extends Component<Args> {
     return this.args.options.endpoint;
   }
 
+  get selectionStyles() {
+    const singleSelect = {
+      label: this.intl.t('variable.codelist.single-select'),
+      value: 'single',
+    };
+    const multiSelect = {
+      label: this.intl.t('variable.codelist.multi-select'),
+      value: 'multi',
+    };
+    return [singleSelect, multiSelect];
+  }
+
+  get selectedStyle() {
+    return this.selectionStyles.find(
+      (style) => style.value === this.selectedStyleValue,
+    );
+  }
   codelistData = trackedFunction(this, async () => {
     return fetchCodeListsByPublisher(this.endpoint, this.publisher);
   });
@@ -80,5 +101,9 @@ export default class CodelistInsertComponent extends Component<Args> {
   @action
   selectCodelist(codelist: CodeList) {
     this.selectedCodelist = codelist;
+  }
+  @action
+  selectStyle(style: SelectStyle) {
+    this.selectedStyleValue = style.value;
   }
 }

--- a/addon/components/variable-plugin/codelist/insert.ts
+++ b/addon/components/variable-plugin/codelist/insert.ts
@@ -21,7 +21,7 @@ type Args = {
 };
 
 export default class CodelistInsertComponent extends Component<Args> {
-  @tracked selectedSubtype?: CodeList;
+  @tracked selectedCodelist?: CodeList;
   @tracked label?: string;
 
   @service declare intl: IntlService;
@@ -42,7 +42,7 @@ export default class CodelistInsertComponent extends Component<Args> {
     return this.args.options.endpoint;
   }
 
-  subtypes = trackedFunction(this, async () => {
+  codelistData = trackedFunction(this, async () => {
     return fetchCodeListsByPublisher(this.endpoint, this.publisher);
   });
   @action
@@ -58,12 +58,12 @@ export default class CodelistInsertComponent extends Component<Args> {
       {
         mappingResource,
         variableInstance,
-        codelistResource: this.selectedSubtype?.uri,
-        label: this.label ?? this.selectedSubtype?.label,
+        codelistResource: this.selectedCodelist?.uri,
+        label: this.label ?? this.selectedCodelist?.label,
         source: this.endpoint,
       },
       this.schema.node('placeholder', {
-        placeholderText: this.selectedSubtype?.label,
+        placeholderText: this.selectedCodelist?.label,
       }),
     );
 
@@ -78,7 +78,7 @@ export default class CodelistInsertComponent extends Component<Args> {
   }
 
   @action
-  updateSubtype(subtype: CodeList) {
-    this.selectedSubtype = subtype;
+  selectCodelist(codelist: CodeList) {
+    this.selectedCodelist = codelist;
   }
 }

--- a/addon/components/variable-plugin/codelist/insert.ts
+++ b/addon/components/variable-plugin/codelist/insert.ts
@@ -82,6 +82,7 @@ export default class CodelistInsertComponent extends Component<Args> {
         codelistResource: this.selectedCodelist?.uri,
         label: this.label ?? this.selectedCodelist?.label,
         source: this.endpoint,
+        selectionStyle: this.selectedStyleValue,
       },
       this.schema.node('placeholder', {
         placeholderText: this.selectedCodelist?.label,

--- a/addon/components/variable-plugin/codelist/insert.ts
+++ b/addon/components/variable-plugin/codelist/insert.ts
@@ -15,10 +15,12 @@ export type CodelistInsertOptions = {
   publisher?: string;
   endpoint: string;
 };
+
 type Args = {
   controller: SayController;
   options: CodelistInsertOptions;
 };
+
 interface SelectStyle {
   label: string;
   value: string;
@@ -63,9 +65,11 @@ export default class CodelistInsertComponent extends Component<Args> {
       (style) => style.value === this.selectedStyleValue,
     );
   }
+
   codelistData = trackedFunction(this, async () => {
     return fetchCodeListsByPublisher(this.endpoint, this.publisher);
   });
+
   @action
   updateLabel(event: InputEvent) {
     this.label = (event.target as HTMLInputElement).value;
@@ -103,6 +107,7 @@ export default class CodelistInsertComponent extends Component<Args> {
   selectCodelist(codelist: CodeList) {
     this.selectedCodelist = codelist;
   }
+
   @action
   selectStyle(style: SelectStyle) {
     this.selectedStyleValue = style.value;

--- a/addon/components/variable-plugin/codelist/insert.ts
+++ b/addon/components/variable-plugin/codelist/insert.ts
@@ -28,7 +28,7 @@ export default class CodelistInsertComponent extends Component<Args> {
   @service declare intl: IntlService;
   @tracked selectedCodelist?: CodeList;
   @tracked label?: string;
-  @tracked selectedStyleValue: string = 'single';
+  @tracked selectedStyleValue = 'single';
 
   get controller() {
     return this.args.controller;

--- a/addon/plugins/variable-plugin/utils/attribute-parsers.ts
+++ b/addon/plugins/variable-plugin/utils/attribute-parsers.ts
@@ -29,3 +29,7 @@ export function parseVariableSource(variableNode: HTMLElement) {
     .find((el) => hasRDFaAttribute(el, 'property', DCT('source')))
     ?.getAttribute('resource');
 }
+
+export function parseSelectionStyle(element: HTMLElement): string | null {
+  return element.dataset.selectionStyle ?? null;
+}

--- a/addon/plugins/variable-plugin/variables/codelist.ts
+++ b/addon/plugins/variable-plugin/variables/codelist.ts
@@ -10,6 +10,7 @@ import { DOMOutputSpec, PNode } from '@lblod/ember-rdfa-editor';
 import {
   isVariable,
   parseLabel,
+  parseSelectionStyle,
   parseVariableInstance,
   parseVariableSource,
   parseVariableType,
@@ -26,9 +27,6 @@ import { span } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/dom-output-sp
 const CONTENT_SELECTOR = `span[property~='${EXT('content').prefixed}'],
                           span[property~='${EXT('content').full}']`;
 
-function parseSelectionStyle(element: HTMLElement): string | null {
-  return element.dataset.selectionStyle ?? null;
-}
 const parseDOM = [
   {
     tag: 'span',

--- a/addon/plugins/variable-plugin/variables/codelist.ts
+++ b/addon/plugins/variable-plugin/variables/codelist.ts
@@ -26,6 +26,9 @@ import { span } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/dom-output-sp
 const CONTENT_SELECTOR = `span[property~='${EXT('content').prefixed}'],
                           span[property~='${EXT('content').full}']`;
 
+function parseSelectionStyle(element: HTMLElement): string | null {
+  return element.dataset.selectionStyle ?? null;
+}
 const parseDOM = [
   {
     tag: 'span',
@@ -43,6 +46,7 @@ const parseDOM = [
 
         const source = parseVariableSource(node);
         const label = parseLabel(node);
+        const selectionStyle = parseSelectionStyle(node);
         const codelistSpan = [...node.children].find((el) =>
           hasRDFaAttribute(el, 'property', EXT('codelist')),
         );
@@ -53,6 +57,7 @@ const parseDOM = [
           variableInstance:
             variableInstance ?? `http://data.lblod.info/variables/${uuidv4()}`,
           mappingResource,
+          selectionStyle,
           codelistResource,
           source,
           label,
@@ -66,8 +71,14 @@ const parseDOM = [
 ];
 
 const toDOM = (node: PNode): DOMOutputSpec => {
-  const { mappingResource, codelistResource, variableInstance, source, label } =
-    node.attrs;
+  const {
+    mappingResource,
+    codelistResource,
+    variableInstance,
+    source,
+    label,
+    selectionStyle,
+  } = node.attrs;
 
   const codelistResourceSpan = codelistResource
     ? span({
@@ -79,6 +90,7 @@ const toDOM = (node: PNode): DOMOutputSpec => {
     mappingResource,
     {
       'data-label': label as string,
+      'data-selection-style': selectionStyle as string,
     },
     instanceSpan(variableInstance),
     typeSpan('codelist'),
@@ -110,6 +122,9 @@ const emberNodeConfig: EmberNodeConfig = {
     },
     label: {
       default: 'codelijst',
+    },
+    selectionStyle: {
+      default: null,
     },
   },
   toDOM,

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -195,6 +195,9 @@ variable:
     error-number-below: The number should be smaller than or equal to {maxValue}
     error-min-bigger-than-max: The minimum should be smaller than the maximum
     written-number-label: Show as words
+  codelist:
+    single-select: Single selection
+    multi-select: Multiple selection
 variable-plugin:
   insert-variable: Insert variable
   button: Insert

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -206,6 +206,9 @@ variable:
     error-number-below: Het getal moet kleiner dan of gelijk zijn aan {maxValue}
     written-number-label: Getal voluit schrijven
     error-min-bigger-than-max: Het minimum moet kleiner zijn dan het maximum
+  codelist:
+    single-select: Enkelvoudige selectie
+    multi-select: Meervoudige selectie
 variable-plugin:
   insert-variable: Voeg variabele in
   button: Voeg in
@@ -359,4 +362,3 @@ editor-plugins:
         contact: Bij blijvende problemen, contacteer <a href="mailto:{email}">{email}</a>.
     nodeview:
       placeholder: Voeg adres in
-    


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Adds a single/multi select config when inserting codelist variables.
Also makes the codelist node save the configuration, and the edit component respect the config
if it exists. If it doesn't, it reverts back to the "selectionStyle" of the codelist as defined
on the remote.

As far as I can tell this is fully backwards compatible.
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

just run

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations