### PR TITLE
GN-4322: Add ORDER to snippet list query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - GN-4442: template comments can move up and down over the *whole* document
+- GN-4322: Add ORDER to snippet list query 
 
 ## [11.0.0] - 2023-08-22
 

--- a/addon/plugins/snippet-plugin/utils/fetch-data.ts
+++ b/addon/plugins/snippet-plugin/utils/fetch-data.ts
@@ -128,7 +128,9 @@ const buildSnippetListFetchQuery = ({
               ? `FILTER (CONTAINS(LCASE(?label), "${name.toLowerCase()}"))`
               : ''
           }
-        }`;
+        }
+        ORDER BY DESC(?createdOn)
+        `;
 };
 
 export const fetchSnippets = async ({

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -235,8 +235,9 @@ export default class RegulatoryStatementSampleController extends Controller {
         interactive: true,
       },
       snippet: {
-        endpoint: 'https://dev.reglementairebijlagen.lblod.info',
+        endpoint: 'https://dev.reglementairebijlagen.lblod.info/sparql',
       },
+      assignedSnippetListsIds: [],
     };
   }
 

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -100,6 +100,7 @@
             <AuHr/>
             <SnippetPlugin::SnippetListSelect
               @config={{this.config.snippet}}
+              @assignedSnippetListsIds={{this.config.assignedSnippetListsIds}}
             />
           </Sidebar>
           {{/if}}


### PR DESCRIPTION
### Overview

Add ORDER to snippet list query

#### Connected issues and PRs:

Leftover from https://binnenland.atlassian.net/browse/GN-4322


### Setup
 
1. Checkout
2. `ember serve`

### How to test/reproduce

Observe that snippet lists shown in `Manage snippet lists` modal are ordered by `createdOn` 

![CleanShot 2023-08-29 at 14 16 50@2x](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/e006f557-766a-4a9b-94dc-83127c4f31c0)




### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
