### PR TITLE
Add ember-modifier as peerDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- ember-modifier is now explicitely a peerDependency
 ## [11.1.0] - 2023-08-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,8 @@
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^2.4.2",
         "@lblod/ember-rdfa-editor": "^5.2.0",
-        "ember-concurrency": "^2.3.7"
+        "ember-concurrency": "^2.3.7",
+        "ember-modifier": "^3.2.7"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -17207,7 +17208,8 @@
     },
     "node_modules/ember-modifier": {
       "version": "3.2.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
         "ember-cli-normalize-entity-name": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,8 @@
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.2",
     "@lblod/ember-rdfa-editor": "^5.2.0",
-    "ember-concurrency": "^2.3.7"
+    "ember-concurrency": "^2.3.7",
+    "ember-modifier": "^3.2.7"
   },
   "overrides": {
     "ember-intl": {


### PR DESCRIPTION
### Overview
ember-modifier was aleady used before in number-variable. This adds this dependency to peerDependencies, to make it more explicit that this package is required. 

I tested if stuff still worked, but not sure if this is correct :shrug: 
Note that I took the version used by other packages, as this is likely the version that was used during coding. There does exists a newer version of ember-modifier.