### PR TITLE
Enable additional prosemirror plugins in dummy apps

### DIFF
--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -94,6 +94,10 @@ import {
   address,
   addressView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
+import { linkPasteHandler } from '@lblod/ember-rdfa-editor/plugins/link';
+import { firefoxCursorFix } from '@lblod/ember-rdfa-editor/plugins/firefox-cursor-fix';
+import { chromeHacksPlugin } from '@lblod/ember-rdfa-editor/plugins/chrome-hacks-plugin';
+import { lastKeyPressedPlugin } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
 
 export default class BesluitSampleController extends Controller {
   @service declare importRdfaSnippet: importRdfaSnippet;
@@ -283,8 +287,12 @@ export default class BesluitSampleController extends Controller {
     };
   };
   @tracked plugins: Plugin[] = [
+    firefoxCursorFix(),
+    chromeHacksPlugin(),
+    lastKeyPressedPlugin,
     tablePlugin,
     tableKeymap,
+    linkPasteHandler(this.schema.nodes.link),
     this.citationPlugin,
     this.validationPlugin,
     createInvisiblesPlugin(

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -82,6 +82,10 @@ import {
   templateCommentView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-comments-plugin';
 import { getOwner } from '@ember/application';
+import { firefoxCursorFix } from '@lblod/ember-rdfa-editor/plugins/firefox-cursor-fix';
+import { chromeHacksPlugin } from '@lblod/ember-rdfa-editor/plugins/chrome-hacks-plugin';
+import { lastKeyPressedPlugin } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
+import { linkPasteHandler } from '@lblod/ember-rdfa-editor/plugins/link';
 export default class RegulatoryStatementSampleController extends Controller {
   @service declare importRdfaSnippet: ImportRdfaSnippet;
   @service declare intl: IntlService;
@@ -260,8 +264,12 @@ export default class RegulatoryStatementSampleController extends Controller {
     };
   };
   @tracked plugins: Plugin[] = [
+    firefoxCursorFix(),
+    chromeHacksPlugin(),
+    lastKeyPressedPlugin,
     tablePlugin,
     tableKeymap,
+    linkPasteHandler(this.schema.nodes.link),
     createInvisiblesPlugin(
       [space, hardBreak, paragraphInvisible, headingInvisible],
       {


### PR DESCRIPTION
### Overview
This PR enables the following plugins in the dummy applications:
- firefoxCursorFix
- chromeHacksPlugin
- lastKeyPressedPlugin
- linkPasteHandler
