### PR TITLE
Move changelog check to seperate CI pipeline

### DIFF
--- a/.woodpecker/.changelog.yml
+++ b/.woodpecker/.changelog.yml
@@ -1,0 +1,9 @@
+steps:
+  changelog:
+    image: danlynn/ember-cli:4.8.0
+    commands:
+      - git fetch origin master
+      - git diff -wb --name-only origin/master..HEAD | grep CHANGELOG.md
+when:
+  event: pull_request
+  evaluate: 'not (CI_COMMIT_PULL_REQUEST_LABELS contains "dependabot")'

--- a/.woodpecker/.test.yml
+++ b/.woodpecker/.test.yml
@@ -1,12 +1,4 @@
 steps:
-  changelog:
-    image: danlynn/ember-cli:4.8.0
-    commands:
-      - git fetch origin master
-      - git diff -wb --name-only origin/master..HEAD | grep CHANGELOG.md
-    when:
-      event: pull_request
-      evaluate: 'not (CI_COMMIT_PULL_REQUEST_LABELS contains "dependabot")'
   install:
     image: danlynn/ember-cli:4.8.0
     commands:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CI: move changelog check to seperate CI pipeline
+
 ## [11.2.0] - 2023-09-04
 ### Added
 - ember-modifier is now explicitely a peerDependency


### PR DESCRIPTION
### Overview
This PR moves the changelog check to a seperate CI pipeline. This ensures that the main CI pipeline still runs even if a changelog change is missing, as some PRs do not require a changelog change.
