### PR TITLE
Use modifiers in number-variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- refactor number-variable: component now uses modifiers for keyboard navigation (arrow keys and enter)
 ## [11.2.0] - 2023-09-04
 ### Added
 - ember-modifier is now explicitely a peerDependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor number-variable: component now uses modifiers for keyboard navigation (arrow keys and enter)
 - Bumps `@lblod/ember-rdfa-editor` from 5.2.0 to 5.3.0
 
-### Changed
-- Bumps `@lblod/ember-rdfa-editor` from 5.2.0 to 5.3.0
-
 ## [11.3.0] - 2023-09-06
 ### Changed
 - CI: move changelog check to seperate CI pipeline

--- a/addon/components/variable-plugin/number/nodeview.hbs
+++ b/addon/components/variable-plugin/number/nodeview.hbs
@@ -7,7 +7,7 @@
     @iconAlignment='right'
     class='variable'
     {{velcro.hook}}
-    {{on 'click' this.selectThisNode}}
+    {{select-node-on-click @controller @getPos}}
   >
     {{#if this.formattedNumber}}
       {{this.formattedNumber}}
@@ -32,19 +32,18 @@
         @standOut={{true}} as |card|
       >
         <card.content>
-          {{!-- template-lint-disable no-down-event-binding --}}
+          {{! template-lint-disable no-down-event-binding }}
           <AuNativeInput
             value={{this.inputNumber}}
             placeholder={{t 'variable.number.type-number'}}
             {{did-insert this.focus}}
             {{on 'input' this.onInputNumberChange}}
-            {{on 'keyup' this.leaveOnEnter}}
-            {{on 'keyup' this.leaveWithArrows}}
-            {{on 'keydown' this.setPosBeforeKeypress}}
+            {{leave-with-arrow-keys @controller @getPos}}
+            {{leave-on-enter-key @controller @getPos}}
           />
           <AuToggleSwitch
-            @identifier="writtenNumber"
-            @name="writtenNumber"
+            @identifier='writtenNumber'
+            @name='writtenNumber'
             @checked={{this.writtenNumber}}
             @onChange={{this.changeWrittenNumber}}
             @label={{t 'variable.number.written-number-label'}}

--- a/addon/components/variable-plugin/number/nodeview.ts
+++ b/addon/components/variable-plugin/number/nodeview.ts
@@ -1,11 +1,9 @@
 import Component from '@glimmer/component';
 import {
   DecorationSource,
-  NodeSelection,
   PNode,
   SayController,
   SayView,
-  TextSelection,
 } from '@lblod/ember-rdfa-editor';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';

--- a/addon/components/variable-plugin/number/nodeview.ts
+++ b/addon/components/variable-plugin/number/nodeview.ts
@@ -38,6 +38,7 @@ export default class NumberNodeviewComponent extends Component<Args> {
   get node() {
     return this.args.node;
   }
+
   get formattedNumber() {
     const value = this.node.attrs.value as string;
 
@@ -108,61 +109,5 @@ export default class NumberNodeviewComponent extends Component<Args> {
     if (!this.errorMessage) {
       this.args.updateAttribute('value', this.inputNumber);
     }
-  }
-
-  @action
-  selectThisNode() {
-    const tr = this.args.controller.activeEditorState.tr;
-    tr.setSelection(
-      NodeSelection.create(
-        this.args.controller.activeEditorState.doc,
-        this.args.getPos() as number,
-      ),
-    );
-    this.args.controller.activeEditorView.dispatch(tr);
-  }
-
-  @action
-  leaveOnEnter(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
-      this.selectAfterNode();
-    }
-  }
-
-  @action setPosBeforeKeypress(event: KeyboardEvent) {
-    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
-      this.cursorPositionKeyDown = (
-        event.target as HTMLInputElement
-      ).selectionStart;
-    }
-  }
-  @action leaveWithArrows(event: KeyboardEvent) {
-    const finalPos = (event.target as HTMLInputElement).value.length;
-    if (event.key === 'ArrowRight' && this.cursorPositionKeyDown === finalPos) {
-      this.selectAfterNode();
-    }
-    if (event.key === 'ArrowLeft' && this.cursorPositionKeyDown === 0) {
-      this.selectBeforeNode();
-    }
-    this.cursorPositionKeyDown = null;
-  }
-
-  setSelectionAt(pos: number) {
-    const tr = this.args.controller.activeEditorState.tr;
-    tr.setSelection(
-      TextSelection.create(this.args.controller.activeEditorState.doc, pos),
-    );
-    this.args.controller.focus();
-    this.args.controller.activeEditorView.dispatch(tr);
-  }
-
-  selectAfterNode() {
-    this.setSelectionAt(
-      (this.args.getPos() as number) + this.args.node.nodeSize,
-    );
-  }
-
-  selectBeforeNode() {
-    this.setSelectionAt(this.args.getPos() as number);
   }
 }


### PR DESCRIPTION
### Overview
See https://github.com/lblod/ember-rdfa-editor/pull/962
this refactors the code to use some new modifiers defined in the editor repo.

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor/pull/962

### Setup
`npm link` the editor repo and `npm link @lblod/ember-rdfa-editor` this repo. the `ember serve` this repo.

### How to test/reproduce
add a number variable
make sure nothing of functionality changed for arrow keys (left/right) and pressing enter. Arrow keys should let you go out of the number variable, enter should set the cursor behind the number variable node.

### Challenges/uncertainties
- 