### PR TITLE
GN-4266: Filter by government name

### DIFF
--- a/.changeset/brave-pigs-sing.md
+++ b/.changeset/brave-pigs-sing.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+GN-4266: Referring to published decisions - filter by government name

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ You need to specify the endpoints for the plugin in the config object
 const citationPluginConfig = {
   endpoint: 'https://codex.opendata.api.vlaanderen.be:8888/sparql',
   decisionsEndpoint: 'https://publicatie.gelinkt-notuleren.vlaanderen.be/sparql',
-  defaultDecisionsGovernmentName: 'Gemeenteraad Edegem'
+  defaultDecisionsGovernmentName: 'Edegem'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ You need to specify the endpoints for the plugin in the config object
 ```js
 const citationPluginConfig = {
   endpoint: 'https://codex.opendata.api.vlaanderen.be:8888/sparql',
-  decisionsEndpoint: 'https://https://publicatie.gelinkt-notuleren.vlaanderen.be/sparql',
+  decisionsEndpoint: 'https://publicatie.gelinkt-notuleren.vlaanderen.be/sparql',
   defaultDecisionsGovernmentName: 'Gemeenteraad Edegem'
 }
 ```

--- a/README.md
+++ b/README.md
@@ -254,13 +254,15 @@ Same goes for the `CitationInsert` component, with which you can directly insert
 
 You need to specify the endpoints for the plugin in the config object
 ```js
-{
-  endpoint: 'https://codex.opendata.api.vlaanderen.be:8888/sparql'
-  decisionsEndpoint: 'https://https://publicatie.gelinkt-notuleren.vlaanderen.be/sparql'
+const citationPluginConfig = {
+  endpoint: 'https://codex.opendata.api.vlaanderen.be:8888/sparql',
+  decisionsEndpoint: 'https://https://publicatie.gelinkt-notuleren.vlaanderen.be/sparql',
+  defaultDecisionsGovernmentName: 'Gemeenteraad Edegem'
 }
 ```
 
-The `decisionsEndpoint` is optional, and is required if you want to display decisions from the Publicatie.
+The `decisionsEndpoint` is optional, and is required if you want to display decisions from the Publicatie.  
+The `defaultDecisionsGovernmentName` is also optional, and is used to filter the decisions from the Publicatie by government name, the government name for the filter can be changed by the user during the search.
 
 
 Make `this.citationPlugin` a tracked reference to the plugin created with the function exported from the package and the wished configuration

--- a/addon/components/citation-plugin/citations/search-modal.hbs
+++ b/addon/components/citation-plugin/citations/search-modal.hbs
@@ -66,6 +66,28 @@
               />
 
               <AuHr @size='large' />
+              {{#if this.isBesluitType}}
+                <AuLabel
+                  class='au-u-margin-top au-margin-bottom-small'
+                  for='search-government'
+                  @inline={{false}}
+                  @required={{false}}
+                  @error={{false}}
+                  @warning={{false}}
+                >
+                  {{t 'citaten-plugin.search.government-search'}}
+                </AuLabel>
+                <AuNativeInput
+                  @icon='search'
+                  @type='text'
+                  @width='block'
+                  @iconAlignment='right'
+                  id='search-government'
+                  value={{this.governmentSearchText}}
+                  placeholder={{t 'citaten-plugin.search.placeholder'}}
+                  {{on 'input' this.setGovernmentSearchText}}
+                />
+              {{/if}}
               {{! Date of document }}
               <AuLabel
                 class='au-u-margin-top au-u-margin-bottom-small'

--- a/addon/components/citation-plugin/citations/search-modal.ts
+++ b/addon/components/citation-plugin/citations/search-modal.ts
@@ -62,6 +62,7 @@ export default class EditorPluginsCitationsSearchModalComponent extends Componen
   @tracked publicationDateFrom: Date | null = null;
   @tracked publicationDateTo: Date | null = null;
   @tracked inputSearchText: string | null = null;
+  @tracked inputGovernmentSearchText: string | null = null;
   minDate = new Date('1930-01-01T12:00:00');
   maxDate = new Date(`${new Date().getFullYear() + 10}-01-01T12:00:00`);
 
@@ -115,6 +116,13 @@ export default class EditorPluginsCitationsSearchModalComponent extends Componen
     return this.inputSearchText ?? this.text;
   }
 
+  get governmentSearchText() {
+    return (
+      this.inputGovernmentSearchText ??
+      this.config.defaultDecisionsGovernmentName
+    );
+  }
+
   resourceSearch = restartableTask(async () => {
     await timeout(500);
     this.error = null;
@@ -129,6 +137,7 @@ export default class EditorPluginsCitationsSearchModalComponent extends Componen
         documentDateTo: getISODate(this.documentDateTo),
         publicationDateFrom: getISODate(this.publicationDateFrom),
         publicationDateTo: getISODate(this.publicationDateTo),
+        governmentName: this.governmentSearchText,
       };
       const results = await fetchLegalDocuments({
         words: words,
@@ -152,6 +161,7 @@ export default class EditorPluginsCitationsSearchModalComponent extends Componen
 
   decisionResource = trackedTask(this, this.resourceSearch, () => [
     this.searchText,
+    this.governmentSearchText,
     this.legislationTypeUri,
     this.pageSize,
     this.pageNumber,
@@ -168,6 +178,11 @@ export default class EditorPluginsCitationsSearchModalComponent extends Componen
   @action
   setInputSearchText(event: InputEvent) {
     this.inputSearchText = (event.target as HTMLInputElement).value;
+  }
+
+  @action
+  setGovernmentSearchText(event: InputEvent) {
+    this.inputGovernmentSearchText = (event.target as HTMLInputElement).value;
   }
 
   @action

--- a/addon/plugins/citation-plugin/index.ts
+++ b/addon/plugins/citation-plugin/index.ts
@@ -140,6 +140,7 @@ export type CitationPluginConfig =
 export type CitationPluginEmberComponentConfig = CitationPluginConfig & {
   endpoint: string;
   decisionsEndpoint?: string;
+  defaultDecisionsGovernmentName?: string;
 };
 
 export function citationPlugin(config: CitationPluginConfig): CitationPlugin {

--- a/addon/plugins/citation-plugin/utils/legal-documents.ts
+++ b/addon/plugins/citation-plugin/utils/legal-documents.ts
@@ -65,6 +65,7 @@ export interface LegalDocumentsQueryFilter {
   documentDateTo?: Option<string>;
   publicationDateFrom?: Option<string>;
   publicationDateTo?: Option<string>;
+  governmentName?: Option<string>;
 }
 
 export type LegalDocumentsQueryConfig = {
@@ -94,6 +95,7 @@ export async function fetchLegalDocuments({
     documentDateTo: filter.documentDateTo || null,
     publicationDateFrom: filter.publicationDateFrom || null,
     publicationDateTo: filter.publicationDateTo || null,
+    governmentName: filter.governmentName || null,
   };
   const stringArguments = JSON.stringify({
     words,

--- a/addon/plugins/citation-plugin/utils/public-decisions.ts
+++ b/addon/plugins/citation-plugin/utils/public-decisions.ts
@@ -42,6 +42,12 @@ const getFilters = ({
     );
   }
 
+  const governmentNameFilter = filter.governmentName?.trim()
+    ? `FILTER (CONTAINS(LCASE(?governmentName), "${replaceDiacriticsInWord(
+        filter.governmentName,
+      ).toLowerCase()}"))`
+    : '';
+
   return `
     ${words
       .map(
@@ -51,7 +57,9 @@ const getFilters = ({
           ).toLowerCase()}"))`,
       )
       .join('\n')}
-    ${documentDateFilter.join('\n')}`;
+    ${documentDateFilter.join('\n')}
+    ${governmentNameFilter}
+    `;
 };
 
 const getCountQuery = ({

--- a/addon/plugins/citation-plugin/utils/public-decisions.ts
+++ b/addon/plugins/citation-plugin/utils/public-decisions.ts
@@ -44,7 +44,7 @@ const getFilters = ({
 
   const governmentNameFilter = filter.governmentName?.trim()
     ? `FILTER (CONTAINS(LCASE(?administrativeUnitName), "${replaceDiacriticsInWord(
-        filter.governmentName,
+        filter.governmentName?.trim(),
       ).toLowerCase()}"))`
     : '';
 
@@ -253,8 +253,6 @@ const getPublicationLink = ({
   treatmentUuid: string;
   decisionsEndpoint: string;
 }) => {
-  console.log({ decisionsEndpoint });
-
   return `https://${
     new URL(decisionsEndpoint).host
   }/${administrativeUnitName}/${administrativeUnitTypeName}/zittingen/${zittingUuid}/uittreksels/${treatmentUuid}`;

--- a/addon/plugins/citation-plugin/utils/public-decisions.ts
+++ b/addon/plugins/citation-plugin/utils/public-decisions.ts
@@ -59,6 +59,7 @@ const getFilters = ({
       .join('\n')}
     ${documentDateFilter.join('\n')}
     ${governmentNameFilter}
+    FILTER(BOUND(?decisionTitle))
     `;
 };
 
@@ -77,29 +78,31 @@ const getCountQuery = ({
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX eli: <http://data.europa.eu/eli/ontology#>
     PREFIX prov: <http://www.w3.org/ns/prov#>
-    PREFIX schema: <http://schema.org/>
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
-    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX dct: <http://purl.org/dc/terms/>
 
     SELECT (COUNT(DISTINCT(?decision)) as ?count) WHERE {
       ?session rdf:type besluit:Zitting;
         mu:uuid ?zittingUuid;
-        (besluit:isGehoudenDoor/mandaat:isTijdspecialisatieVan) ?administrativeUnit;
-        ext:besluitenlijst ?decisionList.
+        (besluit:isGehoudenDoor/mandaat:isTijdspecialisatieVan) ?administrativeUnit.
       ?administrativeUnit skos:prefLabel ?administrativeUnitFullName;
         besluit:bestuurt ?bestuurseenheid.
       ?bestuurseenheid skos:prefLabel ?administrativeUnitName;
         (besluit:classificatie/skos:prefLabel) ?administrativeUnitTypeName.
-      ?decisionList ext:besluitenlijstBesluit ?decision.
-      ?decision eli:title ?decisionTitle.
       OPTIONAL {
-        ?agenda rdf:type besluit:BehandelingVanAgendapunt;
+        ?session besluit:behandelt ?agendaPoint.
+        ?agendaPointTreatment dct:subject ?agendaPoint;
           prov:generated ?decision.
-        ?treatment rdf:type ext:Uittreksel;
-          ext:uittrekselBvap ?agenda;
-          mu:uuid ?treatmentUuida.
+        ?decision eli:title ?decisionTitle.
+      }
+      OPTIONAL {
+        ?session ext:uittreksel ?treatment.
+        ?treatment mu:uuid ?treatmentUuid.
+        ?treatment ext:uittrekselBvap ?agendaPointTreatment.
+        ?agendaPointTreatment prov:generated ?decision.
+        ?decision eli:title ?decisionTitle.
       }
       ${filterString}
     }
@@ -125,29 +128,31 @@ const getQuery = ({
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX eli: <http://data.europa.eu/eli/ontology#>
     PREFIX prov: <http://www.w3.org/ns/prov#>
-    PREFIX schema: <http://schema.org/>
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
-    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX dct: <http://purl.org/dc/terms/>
 
-    SELECT DISTINCT ?administrativeUnitFullName ?administrativeUnitTypeName ?administrativeUnitName ?decision ?decisionTitle ?documentDate ?zittingUuid ?treatmentUuid WHERE {
+    SELECT DISTINCT ?administrativeUnitFullName ?administrativeUnitTypeName ?administrativeUnitName ?documentDate ?decision ?decisionTitle ?zittingUuid ?treatmentUuid WHERE {
       ?session rdf:type besluit:Zitting;
         mu:uuid ?zittingUuid;
-        (besluit:isGehoudenDoor/mandaat:isTijdspecialisatieVan) ?administrativeUnit;
-        ext:besluitenlijst ?decisionList.
+        (besluit:isGehoudenDoor/mandaat:isTijdspecialisatieVan) ?administrativeUnit.
       ?administrativeUnit skos:prefLabel ?administrativeUnitFullName;
         besluit:bestuurt ?bestuurseenheid.
       ?bestuurseenheid skos:prefLabel ?administrativeUnitName;
         (besluit:classificatie/skos:prefLabel) ?administrativeUnitTypeName.
-      ?decisionList ext:besluitenlijstBesluit ?decision.
-      ?decision eli:title ?decisionTitle.
       OPTIONAL {
-        ?agenda rdf:type besluit:BehandelingVanAgendapunt;
+        ?session besluit:behandelt ?agendaPoint.
+        ?agendaPointTreatment dct:subject ?agendaPoint;
           prov:generated ?decision.
-        ?treatment rdf:type ext:Uittreksel;
-          ext:uittrekselBvap ?agenda;
-          mu:uuid ?treatmentUuid.
+        ?decision eli:title ?decisionTitle.
+      }
+      OPTIONAL {
+        ?session ext:uittreksel ?treatment.
+        ?treatment mu:uuid ?treatmentUuid.
+        ?treatment ext:uittrekselBvap ?agendaPointTreatment.
+        ?agendaPointTreatment prov:generated ?decision.
+        ?decision eli:title ?decisionTitle.
       }
       ${filterString}
     }

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -253,6 +253,7 @@ export default class BesluitSampleController extends Controller {
         endpoint: 'https://codex.opendata.api.vlaanderen.be:8888/sparql',
         decisionsEndpoint:
           'https://publicatie.gelinkt-notuleren.lblod.info/sparql',
+        defaultDecisionsGovernmentName: 'Gemeenteraad Edegem',
       },
       roadsignRegulation: {
         endpoint: 'https://dev.roadsigns.lblod.info/sparql',

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -253,7 +253,7 @@ export default class BesluitSampleController extends Controller {
         endpoint: 'https://codex.opendata.api.vlaanderen.be:8888/sparql',
         decisionsEndpoint:
           'https://publicatie.gelinkt-notuleren.lblod.info/sparql',
-        defaultDecisionsGovernmentName: 'Gemeenteraad Edegem',
+        defaultDecisionsGovernmentName: 'Edegem',
       },
       roadsignRegulation: {
         endpoint: 'https://dev.roadsigns.lblod.info/sparql',

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -69,6 +69,7 @@ citaten-plugin:
     title: Insert reference
   search:
     term: Search term
+    government-search: Filter by government
     advanced: Advanced search
     type: Type of document
     placeholder: Type to search

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -70,6 +70,7 @@ citaten-plugin:
     title: Citeeropschrift invoegen
   search:
     term: Zoekterm
+    government-search: Filter op overheid
     advanced: Uitgebreid zoeken
     type: Type van document
     placeholder: Typ om te zoeken

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -70,7 +70,7 @@ citaten-plugin:
     title: Citeeropschrift invoegen
   search:
     term: Zoekterm
-    government-search: Filter op overheid
+    government-search: Filter op bestuursorgaan
     advanced: Uitgebreid zoeken
     type: Type van document
     placeholder: Typ om te zoeken


### PR DESCRIPTION
### Overview

Builds on top of https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/275 to add filter by government name. 

#### Connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4266


### Setup

1. Checkout
2. `npm run start`

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

See the video

https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/5e896602-71aa-441f-80ce-09f60475569e



### Challenges/uncertainties

Instead of providing a dropdown to select a government I decided it's better to allow user to enter the name, this absolves out from figuring out how to fetch the correct names. It also allows user to provide the default filter easier, as there is no need to map from a government ID to a government name.


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
