### PR TITLE
Address Variable: add specific variable insert component that includes label logic

### DIFF
--- a/.changeset/violet-hats-sneeze.md
+++ b/.changeset/violet-hats-sneeze.md
@@ -1,0 +1,8 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Added a second address insert `variable-plugin/address/insert-variable`. This replaces the `insert` from before when used inside the `insert-variable-card` dropdown.
+
+- same UI as other variables
+- allows using a custom label

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ This addon includes an insert-component for each of these variable types:
 - `variable-plugin/date/insert`
 - `variable-plugin/location/insert`
 - `variable-plugin/codelist/insert`
-- `variable-plugin/address/insert`
+- `variable-plugin/address/insert-variable`
 
 Each of these components presents a custom UI which allows a user to insert a variable of the corresponding type in a document.
 
@@ -604,6 +604,12 @@ get variableTypes() {
         },
       },
     },
+    {
+      label: 'address',
+      component: {
+        path: 'variable-plugin/address/insert-variable',
+      },
+    },
   ];
 }
 ```
@@ -673,6 +679,12 @@ You can add this edit-component to a template as follows:
 The edit card can be configured with two arguments:
 - An instance of a `SayController` (required)
 - A `defaultMuncipality` which should be used as the default value of the `muncipality` field in the edit-card (optional)
+
+
+You can also add an insert component meant for use outside of `insert-variable-card` by using the `variable-plugin/address/insert` component. This has no label-input and will show a default label.
+```hbs
+  <VariablePlugin::Address::Insert @controller={{this.controller}}/>
+```
 
 ## validation-plugin
 

--- a/addon/components/variable-plugin/address/insert-variable.hbs
+++ b/addon/components/variable-plugin/address/insert-variable.hbs
@@ -1,0 +1,9 @@
+<AuFormRow>
+  <VariablePlugin::Utils::LabelInput 
+    @label={{this.label}} 
+    @updateLabel={{this.updateLabel}}
+  />
+</AuFormRow>
+<AuButton {{on 'click' this.insertAddress}}>
+  {{t 'variable-plugin.button'}}
+</AuButton>

--- a/addon/components/variable-plugin/address/insert-variable.ts
+++ b/addon/components/variable-plugin/address/insert-variable.ts
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+import { replaceSelectionWithAddress } from './utils';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { SayController } from '@lblod/ember-rdfa-editor';
+
+type Args = {
+  controller: SayController;
+};
+
+export default class VariablePluginAddressInsertVariableComponent extends Component<Args> {
+  @tracked label?: string;
+
+  get controller() {
+    return this.args.controller;
+  }
+
+  @action
+  updateLabel(event: InputEvent) {
+    this.label = (event.target as HTMLInputElement).value;
+  }
+
+  @action
+  insertAddress() {
+    replaceSelectionWithAddress(this.controller, this.label);
+  }
+}

--- a/addon/components/variable-plugin/address/insert.ts
+++ b/addon/components/variable-plugin/address/insert.ts
@@ -1,8 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { SayController } from '@lblod/ember-rdfa-editor';
-import { NodeSelection } from '@lblod/ember-rdfa-editor';
-import { v4 as uuidv4 } from 'uuid';
+import { replaceSelectionWithAddress } from './utils';
 
 type Args = {
   controller: SayController;
@@ -13,25 +12,8 @@ export default class InsertAddressComponent extends Component<Args> {
     return this.args.controller;
   }
 
-  get schema() {
-    return this.controller.schema;
-  }
-
   @action
   insertAddress() {
-    const mappingResource = `http://data.lblod.info/mappings/${uuidv4()}`;
-    const variableInstance = `http://data.lblod.info/variables/${uuidv4()}`;
-    this.controller.withTransaction((tr) => {
-      tr.replaceSelectionWith(
-        this.schema.node('address', { mappingResource, variableInstance }),
-      );
-      if (tr.selection.$anchor.nodeBefore) {
-        const resolvedPos = tr.doc.resolve(
-          tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
-        );
-        tr.setSelection(new NodeSelection(resolvedPos));
-      }
-      return tr;
-    });
+    replaceSelectionWithAddress(this.controller);
   }
 }

--- a/addon/components/variable-plugin/address/utils.ts
+++ b/addon/components/variable-plugin/address/utils.ts
@@ -1,0 +1,26 @@
+import { SayController, NodeSelection } from '@lblod/ember-rdfa-editor';
+import { v4 as uuidv4 } from 'uuid';
+
+export function replaceSelectionWithAddress(
+  controller: SayController,
+  label: string,
+) {
+  const mappingResource = `http://data.lblod.info/mappings/${uuidv4()}`;
+  const variableInstance = `http://data.lblod.info/variables/${uuidv4()}`;
+  controller.withTransaction((tr) => {
+    tr.replaceSelectionWith(
+      controller.schema.node('address', {
+        label: label,
+        mappingResource,
+        variableInstance,
+      }),
+    );
+    if (tr.selection.$anchor.nodeBefore) {
+      const resolvedPos = tr.doc.resolve(
+        tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
+      );
+      tr.setSelection(new NodeSelection(resolvedPos));
+    }
+    return tr;
+  });
+}

--- a/addon/components/variable-plugin/address/utils.ts
+++ b/addon/components/variable-plugin/address/utils.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 export function replaceSelectionWithAddress(
   controller: SayController,
-  label: string,
+  label?: string,
 ) {
   const mappingResource = `http://data.lblod.info/mappings/${uuidv4()}`;
   const variableInstance = `http://data.lblod.info/variables/${uuidv4()}`;

--- a/app/components/variable-plugin/address/insert-variable.js
+++ b/app/components/variable-plugin/address/insert-variable.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/insert-variable';

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -191,6 +191,12 @@ export default class RegulatoryStatementSampleController extends Controller {
           options: this.codelistOptions,
         },
       },
+      {
+        label: 'address',
+        component: {
+          path: 'variable-plugin/address/insert-variable',
+        },
+      },
     ];
   }
 


### PR DESCRIPTION
### Overview
Address variable had an insert component for inserting it via the general "insert menu". However, this did not allow adding a label and the button is different from that of other variables.
This adds a specific insert-variable component meant to be used in the variable dropdown component.
- has the same button as other variable inserts
- also allows inputting a label

##### connected issues and PRs:
found while updating embeddable. Not connected ticket.

### How to test/reproduce
The address variable is added to the list of variables in the dropdown.
Add it, see that the button is the same as the others, see that setting a label works.
also look at the other insert button (under the insert menu): see that this still works.

### Challenges/uncertainties
I don't think the default label is translated at this point. This is probably what is getting fixed in #297 
As usual, depending on which one gets finished/reviewed first, this address variable also needs the same translating logic.

general logic is extracted in a `utils.ts` file. Awful name, but it is very close to the usecase (in same folder), so should be fine.
