### PR TITLE
GN-4517: Reduce possible CSS conflicts

### DIFF
--- a/.changeset/tricky-needles-shake.md
+++ b/.changeset/tricky-needles-shake.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+GN-4517: Reduce possible CSS conflicts

--- a/addon/components/decision-plugin/decision-plugin-card.hbs
+++ b/addon/components/decision-plugin/decision-plugin-card.hbs
@@ -1,5 +1,5 @@
 {{#if this.canInsertTitle}}
-  <AuAlert class="validation-alert" @skin="warning" @closable={{false}} @icon="alert-triangle" @title={{t "besluit-plugin.missing-title-warning"}}>
+  <AuAlert class="say-validation-alert" @skin="warning" @closable={{false}} @icon="alert-triangle" @title={{t "besluit-plugin.missing-title-warning"}}>
     <AuButton @iconAlignment="left" @skin="link-secondary" @disabled={{not this.canInsertTitle}} {{on 'click'
       this.insertTitle}}>
       {{t "besluit-plugin.insert.decision-title"}}
@@ -7,7 +7,7 @@
   </AuAlert>
 {{/if}}
 {{#if this.canInsertMotivation}}
-  <AuAlert class="validation-alert" @skin="warning" @closable={{false}} @icon="alert-triangle" @title={{t "besluit-plugin.missing-motivation-warning"}}>
+  <AuAlert class="say-validation-alert" @skin="warning" @closable={{false}} @icon="alert-triangle" @title={{t "besluit-plugin.missing-motivation-warning"}}>
     <AuButton @iconAlignment="left" @skin="link-secondary" @disabled={{not this.canInsertMotivation}} {{on 'click'
       this.insertMotivation}}>
       {{t "besluit-plugin.insert.motivation"}}
@@ -15,7 +15,7 @@
   </AuAlert>
 {{/if}}
 {{#if this.missingArticleBlock}}
-  <AuAlert class="validation-alert" @skin="warning" @closable={{false}} @icon="alert-triangle" @title={{t "besluit-plugin.missing-article-block-warning"}}>
+  <AuAlert class="say-validation-alert" @skin="warning" @closable={{false}} @icon="alert-triangle" @title={{t "besluit-plugin.missing-article-block-warning"}}>
     <AuButton @iconAlignment="left" @skin="link-secondary" @disabled={{not this.missingArticleBlock}} {{on 'click'
       this.insertArticleBlock}}>
       {{t "besluit-plugin.insert.article-block"}}

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
@@ -2,8 +2,8 @@
   {{t 'snippet-plugin.snippet-list.modal.subtitle'}}
 </AuHeading>
 {{#if @snippetLists.length}}
-  <div class="snippet-lists-table">
-    <AuTable class="snippet-lists-table">
+  <div class="say-snippet-lists-table">
+    <AuTable class="say-snippet-lists-table">
       <:header>
         <tr>
           <th class="selectColumn">{{t 'snippet-plugin.snippet-list.modal.table.select'}}</th>

--- a/addon/components/template-comments-plugin/template-comment.hbs
+++ b/addon/components/template-comments-plugin/template-comment.hbs
@@ -3,11 +3,11 @@
   @title={{t 'template-comments-plugin.long-title'}}
   @skin='info'
   @icon='circle-info'
-  class='template-comment {{
+  class='say-template-comment {{
     if this.selectionInside 'ProseMirror-selectednode'
-  }} default-cursor'
+  }} say-default-cursor'
 >
-  <div class='text-cursor'>
+  <div class='say-text-cursor'>
     {{yield}}
   </div>
 </AuAlert>

--- a/addon/components/variable-plugin/number/insert.hbs
+++ b/addon/components/variable-plugin/number/insert.hbs
@@ -2,7 +2,7 @@
 <AuFormRow>
   <VariablePlugin::Utils::LabelInput @label={{this.label}} @updateLabel={{this.updateLabel}}/>
 </AuFormRow>
-<div class='number-settings'>
+<div class='say-number-settings'>
   <AuFormRow>
     {{#let (unique-id) as |id|}}
       <AuLabel for={{id}}>

--- a/app/styles/besluit-plugin.scss
+++ b/app/styles/besluit-plugin.scss
@@ -1,4 +1,4 @@
-.validation-alert .au-c-button {
+.say-validation-alert .au-c-button {
     padding: 0;
 }
 

--- a/app/styles/date-plugin.scss
+++ b/app/styles/date-plugin.scss
@@ -1,23 +1,3 @@
-
-span.date {
-  border-radius: 0.3rem;
-  margin-right: 0.5rem !important;
-  padding: 0 0.2rem !important;
-  line-height: 1.2rem !important;
-  transition: border 0.1s ease-in-out, background-color 0.1s ease-in-out;
-
-  &::selection {
-    background-color: var(--au-blue-200);
-  }
-
-  user-select: none;
-}
-
-span.date.ProseMirror-selectednode {
-  background-color: var(--au-blue-200);
-  outline: 2px solid var(--au-blue-500);
-}
-
 #date-plugin-time-info-tooltip {
   z-index: 3;
 }

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -71,7 +71,7 @@
   }
 }
 
-.snippet-lists-table {
+.say-snippet-lists-table {
   .au-c-table-wrapper {
     margin-top: 20px;
     margin-right: 100px;

--- a/app/styles/template-comments-plugin.scss
+++ b/app/styles/template-comments-plugin.scss
@@ -1,6 +1,6 @@
 @import "ember-appuniversum";
 
-.template-comment {
+.say-template-comment {
   color: var(--au-blue-900);
 
   .au-c-alert__content {
@@ -31,10 +31,10 @@
   }
 }
 
-.default-cursor {
+.say-default-cursor {
   cursor: default;
 }
 
-.text-cursor {
+.say-text-cursor {
   cursor: text;
 }

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -78,7 +78,7 @@
   }
 }
 
-.number-settings {
+.say-number-settings {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: 1fr;
@@ -125,5 +125,5 @@
   // add top padding starting from second element
   * :not(*:nth-child(1)) {
     margin-top: 5px;
-  } 
+  }
 }


### PR DESCRIPTION
### Overview

* Mostly add `say-` prefix for CSS classes that sound like they are too generic.
* Remove unused `span.date` class

#### Connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4517


### Setup

1. Checkout

### How to test/reproduce

Make sure classes are still applying where they should be
### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
