### PR TITLE
Update `@lblod/ember-rdfa-editor` to version 6.0.0

### DIFF
--- a/.changeset/seven-trainers-wink.md
+++ b/.changeset/seven-trainers-wink.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': major
+---
+
+Addition of @glint/template to peerDependencies

--- a/.changeset/shaggy-kiwis-talk.md
+++ b/.changeset/shaggy-kiwis-talk.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': major
+---
+
+Update @lblod/ember-rdfa-editor to 6.0.0 and increase peerdependency requirement to ^6.0.0

--- a/addon/plugins/rdfa-date-plugin/nodes/date.ts
+++ b/addon/plugins/rdfa-date-plugin/nodes/date.ts
@@ -21,11 +21,12 @@ import {
   typeSpan,
 } from '../../variable-plugin/utils/dom-constructors';
 import { span } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/dom-output-spec-helpers';
-
+import DateComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/rdfa-date-plugin/date';
+import type { ComponentLike } from '@glint/template';
 const emberNodeConfig = (options: DateOptions): EmberNodeConfig => ({
   name: 'date',
   group: 'inline variable',
-  componentPath: 'rdfa-date-plugin/date',
+  component: DateComponent as unknown as ComponentLike,
   inline: true,
   selectable: true,
   draggable: false,

--- a/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
+++ b/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
@@ -10,13 +10,14 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/utils';
 import { emberApplicationPluginKey } from '@lblod/ember-rdfa-editor/plugins/ember-application';
 import IntlService from 'ember-intl/services/intl';
-
+import TableOfContentsComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/table-of-contents-plugin/ember-nodes/table-of-contents';
+import type { ComponentLike } from '@glint/template';
 export const emberNodeConfig: (
   config: TableOfContentsConfig,
 ) => EmberNodeConfig = (config) => {
   return {
     name: 'table-of-contents',
-    componentPath: 'table-of-contents-plugin/ember-nodes/table-of-contents',
+    component: TableOfContentsComponent as unknown as ComponentLike,
     inline: false,
     group: 'table_of_contents',
     atom: true,

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -1,3 +1,5 @@
+import type { ComponentLike } from '@glint/template';
+import TemplateCommentsComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/template-comments-plugin/template-comment';
 import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { hasRDFaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 import {
@@ -9,7 +11,7 @@ import {
 export const emberNodeConfig: () => EmberNodeConfig = () => {
   return {
     name: 'template-comment',
-    componentPath: 'template-comments-plugin/template-comment',
+    component: TemplateCommentsComponent as unknown as ComponentLike,
     inline: false,
     group: 'block',
     content: '(paragraph|list)+',

--- a/addon/plugins/variable-plugin/variables/address.ts
+++ b/addon/plugins/variable-plugin/variables/address.ts
@@ -28,6 +28,8 @@ import {
   mappingSpan,
   typeSpan,
 } from '../utils/dom-constructors';
+import AddressNodeviewComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/nodeview';
+import type { ComponentLike } from '@glint/template';
 
 export class Address {
   declare id?: string;
@@ -266,7 +268,7 @@ const toDOM = (node: PNode): DOMOutputSpec => {
 
 const emberNodeConfig: EmberNodeConfig = {
   name: 'address',
-  componentPath: 'variable-plugin/address/nodeview',
+  component: AddressNodeviewComponent as unknown as ComponentLike,
   inline: true,
   group: 'inline variable',
   content: 'inline*',

--- a/addon/plugins/variable-plugin/variables/codelist.ts
+++ b/addon/plugins/variable-plugin/variables/codelist.ts
@@ -23,6 +23,8 @@ import {
   typeSpan,
 } from '../utils/dom-constructors';
 import { span } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/dom-output-spec-helpers';
+import VariableNodeViewComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/variable/nodeview';
+import type { ComponentLike } from '@glint/template';
 
 const CONTENT_SELECTOR = `span[property~='${EXT('content').prefixed}'],
                           span[property~='${EXT('content').full}']`;
@@ -100,7 +102,7 @@ const toDOM = (node: PNode): DOMOutputSpec => {
 
 const emberNodeConfig: EmberNodeConfig = {
   name: 'codelist',
-  componentPath: 'variable-plugin/variable/nodeview',
+  component: VariableNodeViewComponent as unknown as ComponentLike,
   inline: true,
   group: 'inline variable',
   content: 'inline*',

--- a/addon/plugins/variable-plugin/variables/location.ts
+++ b/addon/plugins/variable-plugin/variables/location.ts
@@ -20,6 +20,8 @@ import {
   sourceSpan,
   typeSpan,
 } from '../utils/dom-constructors';
+import LocationNodeViewComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/nodeview';
+import type { ComponentLike } from '@glint/template';
 
 const CONTENT_SELECTOR = `span[property~='${EXT('content').prefixed}'],
                           span[property~='${EXT('content').full}']`;
@@ -71,7 +73,7 @@ const toDOM = (node: PNode): DOMOutputSpec => {
 
 const emberNodeConfig: EmberNodeConfig = {
   name: 'location',
-  componentPath: 'variable-plugin/location/nodeview',
+  component: LocationNodeViewComponent as unknown as ComponentLike,
   inline: true,
   group: 'inline variable',
   content: 'inline*',

--- a/addon/plugins/variable-plugin/variables/number.ts
+++ b/addon/plugins/variable-plugin/variables/number.ts
@@ -24,6 +24,8 @@ import {
   mappingSpan,
   typeSpan,
 } from '../utils/dom-constructors';
+import NumberNodeviewComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/number/nodeview';
+import type { ComponentLike } from '@glint/template';
 
 const CONTENT_SELECTOR = `span[property~='${EXT('content').prefixed}'],
                           span[property~='${EXT('content').full}']`;
@@ -113,7 +115,7 @@ const toDOM = (node: PNode): DOMOutputSpec => {
 
 const emberNodeConfig: EmberNodeConfig = {
   name: 'number',
-  componentPath: 'variable-plugin/number/nodeview',
+  component: NumberNodeviewComponent as unknown as ComponentLike,
   inline: true,
   group: 'inline variable',
   content: 'inline*',

--- a/addon/plugins/variable-plugin/variables/text.ts
+++ b/addon/plugins/variable-plugin/variables/text.ts
@@ -18,6 +18,8 @@ import {
   typeSpan,
   mappingSpan,
 } from '../utils/dom-constructors';
+import VariableNodeViewComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/variable/nodeview';
+import type { ComponentLike } from '@glint/template';
 
 const CONTENT_SELECTOR = `span[property~='${EXT('content').prefixed}'],
                           span[property~='${EXT('content').full}']`;
@@ -66,7 +68,7 @@ const toDOM = (node: PNode): DOMOutputSpec => {
 
 const emberNodeConfig: EmberNodeConfig = {
   name: 'text-variable',
-  componentPath: 'variable-plugin/variable/nodeview',
+  component: VariableNodeViewComponent as unknown as ComponentLike,
   inline: true,
   group: 'inline variable',
   content: 'inline*',

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
         "@embroider/test-setup": "^3.0.1",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@lblod/ember-rdfa-editor": "^5.3.0",
+        "@glint/template": "^1.1.0",
+        "@lblod/ember-rdfa-editor": "^6.0.0",
         "@rdfjs/types": "^1.1.0",
         "@release-it/keep-a-changelog": "^3.1.0",
         "@tsconfig/ember": "^3.0.0",
@@ -131,7 +132,8 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^2.4.2",
-        "@lblod/ember-rdfa-editor": "^5.3.0",
+        "@glint/template": "^1.1.0",
+        "@lblod/ember-rdfa-editor": "^6.0.0",
         "ember-concurrency": "^2.3.7",
         "ember-data": "^3.28.0 || ^4.0.0",
         "ember-modifier": "^3.2.7",
@@ -4037,10 +4039,9 @@
       }
     },
     "node_modules/@glint/template": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@glint/template/-/template-1.0.2.tgz",
-      "integrity": "sha512-kFWfJrS7XM0NjC5YSN0CWA9FiN0mhUvWVlQ2O7YRz/uhrO8+TVYNLst0WKELRbfCXbdI7wyYQkazNgz6FoL9CA==",
-      "peer": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@glint/template/-/template-1.1.0.tgz",
+      "integrity": "sha512-gK4tifrw7mIMYECzGeG5jrez2lY0TlwE584cnoYOFhzxXKrsuungdiebd7LDwjvfQpImQd1JUSQr3u/uF/XYJg=="
     },
     "node_modules/@graphy/core.data.factory": {
       "version": "4.3.4",
@@ -4187,9 +4188,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-5.3.0.tgz",
-      "integrity": "sha512-5iebh6G7iuP0z0ps17TqdoWwPQXVV4qLEciR1ZctL92Gyumt5SoVsTW/RclcoxrBtj3P3puc8PDdIHoAMUkHSg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-6.0.0.tgz",
+      "integrity": "sha512-+VqXZoZz7I4rPVmXoUV6NBN3KASf5nFq4n/4rp7M3odwWQPgAuhv5Tp1SCDCY7lL9jb/SZevOM821k8MmKzbrA==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.1.1",
@@ -4249,6 +4250,7 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^2.4.2",
+        "@glint/template": "^1.1.0",
         "ember-cli-sass": "^11.0.1",
         "ember-modifier": "^3.2.7"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@lblod/ember-rdfa-editor-lblod-plugins",
   "version": "12.0.0",
   "description": "Ember addon providing lblod specific plugins for the ember-rdfa-editor",
-  "keywords": ["ember-addon", "ember-rdfa-editor"],
+  "keywords": [
+    "ember-addon",
+    "ember-rdfa-editor"
+  ],
   "repository": "https://github.com/lblod/ember-rdfa-editor-lblod-plugins.git",
   "license": "MIT",
   "author": "vlaanderen.be",
@@ -67,7 +70,8 @@
     "@embroider/test-setup": "^3.0.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@lblod/ember-rdfa-editor": "^5.3.0",
+    "@glint/template": "^1.1.0",
+    "@lblod/ember-rdfa-editor": "^6.0.0",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^3.1.0",
     "@tsconfig/ember": "^3.0.0",
@@ -108,12 +112,12 @@
     "broccoli-asset-rev": "^3.0.0",
     "changesets-release-it-plugin": "^0.1.1",
     "ember-cli": "~4.12.0",
-    "ember-cli-typescript": "^5.2.1",
     "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
+    "ember-cli-typescript": "^5.2.1",
     "ember-data": "^4.12.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-functions-as-helper-polyfill": "^2.1.1",
@@ -146,11 +150,12 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.2",
-    "@lblod/ember-rdfa-editor": "^5.3.0",
+    "@glint/template": "^1.1.0",
+    "@lblod/ember-rdfa-editor": "^6.0.0",
     "ember-concurrency": "^2.3.7",
+    "ember-data": "^3.28.0 || ^4.0.0",
     "ember-modifier": "^3.2.7",
-    "ember-source": "^3.28.0 || ^4.0.0",
-    "ember-data": "^3.28.0 || ^4.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0"
   },
   "overrides": {
     "ember-intl": {


### PR DESCRIPTION
### Overview
This PR updates the `@lblod/ember-rdfa-editor` package to version 6.0.0. Version 6.0.0 of the editor is a breaking release which includes changes to the ember-node API (the `component` helper is no longer used). 

Specifically, this PR includes the following changes:
- Update to `@lblod/ember-rdfa-editor` 6.0.0
- Increase the ``@lblod/ember-rdfa-editor` peer-dependency semver range to `^6.0.0`
- Addition of the `@glint/template` package
- Addition of `@glint/template` to this project peer-dependencies (see https://typed-ember.gitbook.io/glint/troubleshooting/migrating#glint-template-peer)
- Update the ember-nodes of this project to respect the new API

### How to test/reproduce
- npm start
- ensure that all ember-nodes work as before

### Checks PR readiness
- [x] changelog
- [x] npm lint
