### PR TITLE
GN-4502: allow municipality and street field of address plugin to be cleared

### DIFF
--- a/.changeset/nine-otters-behave.md
+++ b/.changeset/nine-otters-behave.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Allow municipality and street fields of address-variable to be cleared when editing

--- a/addon/components/variable-plugin/address/edit.hbs
+++ b/addon/components/variable-plugin/address/edit.hbs
@@ -11,6 +11,7 @@
           @searchMessage={{t "editor-plugins.address.edit.municipality.search-message"}}
           @noMatchesMessage={{t "editor-plugins.address.edit.municipality.no-results"}}
           @placeholder={{t "editor-plugins.address.edit.municipality.placeholder"}}
+          @allowClear={{true}}
           @renderInPlace={{true}}
           @searchEnabled={{true}}
           @search={{perform this.searchMunicipality}}
@@ -27,6 +28,7 @@
           @searchMessage={{t "editor-plugins.address.edit.street.search-message"}}
           @noMatchesMessage={{t "editor-plugins.address.edit.street.no-results"}}
           @placeholder={{t "editor-plugins.address.edit.street.placeholder"}}
+          @allowClear={{true}}
           @renderInPlace={{true}}
           @searchEnabled={{true}}
           @search={{perform this.searchStreet}}
@@ -40,11 +42,11 @@
             <AuLabel for="housenumber-select">
               {{t "editor-plugins.address.edit.housenumber.label"}}
             </AuLabel>
-            <AuNativeInput 
+            <AuNativeInput
               id="housenumber-select"
               placeholder={{t "editor-plugins.address.edit.housenumber.placeholder"}}
-              @width="block"  
-              value={{this.newHousenumber}} 
+              @width="block"
+              value={{this.newHousenumber}}
               @disabled={{not this.canUpdateHousenumber}}
               {{on 'input' this.updateHousenumber}}
             />
@@ -53,17 +55,17 @@
             <AuLabel for="busnumber-select">
               {{t "editor-plugins.address.edit.busnumber.label"}}
             </AuLabel>
-            <AuNativeInput 
+            <AuNativeInput
               id="busnumber-select"
               placeholder={{t "editor-plugins.address.edit.busnumber.placeholder"}}
-              @width="block"  
-              value={{this.newBusnumber}} 
+              @width="block"
+              value={{this.newBusnumber}}
               @disabled={{not this.canUpdateBusnumber}}
               {{on 'input' this.updateBusnumber}}
             />
           </div>
         </div>
-        
+
         {{#if this.newAddress.isRunning}}
           <LoadingAlert @title={{t "editor-plugins.address.edit.loading"}} @size="small" @skin="info"/>
         {{/if}}
@@ -72,14 +74,14 @@
             {{this.message.body}}
           </AuAlert>
         {{/if}}
-        <AuButton 
-          {{on 'click' this.updateAddressVariable}} 
+        <AuButton
+          {{on 'click' this.updateAddressVariable}}
           @disabled={{not this.canUpdateAddressVariable}}>
           {{t "editor-plugins.utils.insert"}}
         </AuButton>
-        
+
       </form>
-      
+
     </c.content>
   </AuCard>
 {{/if}}


### PR DESCRIPTION
### Overview
This PR ensures that users are able to clear the municipality and street inputs when editing an address variable. This is implemented by passing the `allowClear` argument to the `power-select` components.

##### connected issues and PRs:
[GN-4502](https://binnenland.atlassian.net/browse/GN-4502?atlOrigin=eyJpIjoiMzRhYzI1NjI3Nzc3NDQ3M2I3ZDkyMjVkZTcyZDIwYjIiLCJwIjoiaiJ9)

### How to test/reproduce
- Insert an address variable and select it
- Notice that when the street/municipality fields are filled out, you can clear their value
- When clearing the street input, the housenumber and busnumber fields should also be cleared
- When clearing the municipality input, all other fields should also be cleared

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] changelog
- [x] npm lint
- [x] no new deprecations
