### PR TITLE
GN-4534: Citation insert card filter enhancement

### DIFF
--- a/.changeset/new-ears-clap.md
+++ b/.changeset/new-ears-clap.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+GN-4534: Citation insert card filter enhancement

--- a/addon/components/citation-plugin/citation-card.ts
+++ b/addon/components/citation-plugin/citation-card.ts
@@ -121,6 +121,10 @@ export default class CitationCardComponent extends Component<Args> {
     this.cardText = (event.target as HTMLInputElement).value;
   }
 
+  get governmentName() {
+    return this.config.defaultDecisionsGovernmentName;
+  }
+
   resourceSearch = restartableTask(async () => {
     await timeout(100);
     this.error = null;
@@ -131,6 +135,7 @@ export default class CitationCardComponent extends Component<Args> {
       const words = this.searchText.match(/\S+/g) || [];
       const filter = {
         type: unwrapOr('', this.selectedLegislationTypeUri),
+        governmentName: this.governmentName,
       };
       const results = await fetchLegalDocuments({
         words: words,


### PR DESCRIPTION
If the `defaultDecisionsGovernmentName` is present provide it in `filter` to `fetchLegalDocuments`

### Overview

Inline search for citation plugin insert card did not pass provided `defaultDecisionsGovernmentName` to the query. It does now.

#### Connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4534

### Setup

1. Checkout
2. `npm run start`

### How to test/reproduce

1. Go to "Besluit Sample", try typing `besluit jaar` (inside motivering)
1. Observe that documents appearing in the citation insert card in the sidepanel are for Edegem only


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
