### PR TITLE
GN-4501: Fail gracefully when house number does not exist

### DIFF
--- a/.changeset/clean-rats-wash.md
+++ b/.changeset/clean-rats-wash.md
@@ -1,0 +1,8 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+GN-4501: Fail gracefully when house number does not exist
+
+When house number does not exist provide user with an alternative of inserting  
+address with just the street information.

--- a/addon/plugins/variable-plugin/utils/address-helpers.ts
+++ b/addon/plugins/variable-plugin/utils/address-helpers.ts
@@ -75,14 +75,20 @@ type AddressDetailResult = {
 export class AddressError extends Error {
   translation: string;
   status?: number;
+  alternativeAddress?: Address;
   constructor({
     message,
     translation,
     status,
-  }: Pick<AddressError, 'message' | 'translation' | 'status'>) {
+    alternativeAddress,
+  }: Pick<
+    AddressError,
+    'message' | 'translation' | 'status' | 'alternativeAddress'
+  >) {
     super(message);
     this.translation = translation;
     this.status = status;
+    this.alternativeAddress = alternativeAddress;
   }
 }
 
@@ -217,9 +223,15 @@ export async function resolveAddress(info: AddressInfo) {
       });
     }
   } else {
+    const alternativeAddress = await resolveStreet({
+      street: info.street,
+      municipality: info.municipality,
+    });
+
     throw new AddressError({
       translation: 'editor-plugins.address.edit.errors.address-not-found',
       message: `Could not find address in address register`,
+      alternativeAddress,
     });
   }
 }

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -371,6 +371,8 @@ editor-plugins:
         address-found: Address found.
       errors:
         address-not-found: We could not resolve the provided address
+        address-not-found-short: Address not found
+        alternative-address: "Provide another input or proceed with the following address: {address}"
         http-error: "Something went wrong while resolving this address, status code: {status}."
         contact: In case of persisting issues, contact <a href="mailto:{email}">{email}</a>.
     nodeview:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -375,6 +375,8 @@ editor-plugins:
         address-found: Adres gevonden.
       errors:
         address-not-found: We konden het adres niet terugvinden.
+        address-not-found-short: Adres niet gevonden
+        alternative-address: "Geef nog een invoer op of ga verder met het volgende adres: {address}"
         http-error: "Er is iets mis gelopen bij het opvragen van dit adres, statuscode: {status}."
         contact: Bij blijvende problemen, contacteer <a href="mailto:{email}">{email}</a>.
     nodeview:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -376,7 +376,7 @@ editor-plugins:
       errors:
         address-not-found: We konden het adres niet terugvinden.
         address-not-found-short: Adres niet gevonden
-        alternative-address: "Geef nog een invoer op of ga verder met het volgende adres: {address}"
+        alternative-address: "Geef een ander adres op of ga verder met het volgende adres: {address}"
         http-error: "Er is iets mis gelopen bij het opvragen van dit adres, statuscode: {status}."
         contact: Bij blijvende problemen, contacteer <a href="mailto:{email}">{email}</a>.
     nodeview:


### PR DESCRIPTION
### Overview

Instead of telling the user that there is no address, offer the user to use just the street for the address.

#### Connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4501


### Setup

1. Checkout
2. `npm run start`

### How to test/reproduce

Have a look at the video

https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/e15f890f-bb94-413e-a094-d300e9d02384

### Challenges/uncertainties

I've chosen to use more general language when offering user to just use the street, ticket asks for 

> This housenumber doesn’t exist in the selected street, provide another housenumber or proceed without adding a housenumber

But this text will not work, if the house number was correct but the user is now trying to enter bus number. So I went with a more generic notice.

<img width="308" alt="CleanShot 2023-09-28 at 17 25 07@2x" src="https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/095c42c2-e305-4293-aa11-127c6c0392f2">


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check if dummy app is correctly updated
- [X] Check cancel/go-back flows
- [X] changelog
- [X] npm lint
- [X] no new deprecations
