### PR TITLE
GN-4505 Export instantiateUuids and improve memoization function

### DIFF
--- a/.changeset/afraid-falcons-walk.md
+++ b/.changeset/afraid-falcons-walk.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Export standard-template-plugin's uuid instantiation function

--- a/addon/plugins/standard-template-plugin/index.ts
+++ b/addon/plugins/standard-template-plugin/index.ts
@@ -11,6 +11,8 @@ import {
   besluitArticleStructure,
 } from './utils/nodes';
 
+export { default as instantiateUuids } from './utils/instantiate-uuids';
+
 export const besluitNodes = {
   besluit,
   besluit_title,

--- a/addon/plugins/standard-template-plugin/utils/instantiate-uuids.ts
+++ b/addon/plugins/standard-template-plugin/utils/instantiate-uuids.ts
@@ -17,7 +17,8 @@ import { v4 as uuidv4 } from 'uuid';
  */
 
 export default function instantiateUuids(templateString: string) {
-  const generateBoundUuid = memoize(uuidv4) as (...args: unknown[]) => string;
+  // We're not interested in the args in this case, we just use them to memoize
+  const generateBoundUuid = memoize((..._args: unknown[]) => uuidv4());
 
   const determineFunction = (string: string) => {
     switch (string) {
@@ -31,18 +32,9 @@ export default function instantiateUuids(templateString: string) {
   };
   return templateString.replace(
     /\$\{(generateUuid|generateBoundUuid)\(([^()]*)\)\}/g,
-    (string) => {
-      const match = /\$\{(generateUuid|generateBoundUuid)\(([^()]*)\)\}/.exec(
-        string,
-      );
-      if (match) {
-        const functionName = match[1];
-        const functionArgs = match[2];
-        const func = determineFunction(functionName);
-        return functionArgs ? func(functionArgs) : func();
-      } else {
-        return string;
-      }
+    (_match, functionName, functionArgs) => {
+      const func = determineFunction(functionName);
+      return functionArgs ? func(functionArgs) : func();
     },
   );
 }

--- a/addon/utils/memoize.ts
+++ b/addon/utils/memoize.ts
@@ -1,8 +1,16 @@
-export default function memoize(func: (...a: unknown[]) => unknown) {
-  const cache: Record<string, unknown> = {};
+/**
+ * Return memoized version of the passed function.
+ * Memoization is done on the JSON stringified arguments, passing no args, undefined, or any number
+ * of only undefined arguments does not do any caching.
+ */
+export default function memoize<T>(func: (...a: unknown[]) => T) {
+  const cache: Record<string, T> = {};
   return (...args: unknown[]) => {
+    if (args.length === 0 || args.every((arg) => arg === undefined)) {
+      return func(...args);
+    }
     const serializedArgs = JSON.stringify(args);
-    cache[serializedArgs] = cache[serializedArgs] || func(args);
+    cache[serializedArgs] = cache[serializedArgs] || func(...args);
     return cache[serializedArgs];
   };
 }


### PR DESCRIPTION
### Overview
Export `instantiateUuids` for downstream use, improve typing of `memoize` util as well as how it handles non-existent arguments.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4505
https://github.com/lblod/frontend-gelinkt-notuleren/pull/586
https://github.com/lblod/frontend-reglementaire-bijlage/pull/192

### Setup
Needs PR version of GN to test, otherwise the library function is not used

### How to test/reproduce
Instantiate a regulatory statement and inspect to verify uuids.

### Challenges/uncertainties
It was unclear whether having separate `generateUuids` and `generateBoundUuids` functions was preferable to having just one function with an optional argument. Switching to just one overloaded function is trivial, but it's unclear if the current `generateBoundUuids` is used elsewhere already or not.

### Checks PR readiness
- [x] Check if dummy app is correctly updated
- [x] changelog
- [x] npm lint
- [x] no new deprecations
