### PR TITLE
GN-4524: date variable - fix config option to disable custom format 

### DIFF
--- a/.changeset/tough-planes-smell.md
+++ b/.changeset/tough-planes-smell.md
@@ -1,0 +1,6 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+- Bugfix: `allowCustomFormat` for rdfa-date variable will now disable custom formats if set to false.
+- No changes for old documents: date variables in old documents will allow custom formats, which is the default.

--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ get dateOptions(){
 	- `key`: A **unique** identifier used for identification in the internal code. 
 	- `dateFormat`: The date format used when this is selected.
 	- `dateTimeFormat`: The datetime format to use when this is selected. Used when the user selects "Include time".
-- `allowCustomFormat`: true/false, determines if the option to insert a fully custom format is available.
+- `allowCustomFormat`: true by default, determines if the option to insert a fully custom format is available for newly created date nodes.
 
 The syntax of formats can be found at [date-fns](https://date-fns.org/v2.29.3/docs/format).
 

--- a/addon/components/variable-plugin/date/edit.hbs
+++ b/addon/components/variable-plugin/date/edit.hbs
@@ -56,16 +56,18 @@
               />
             </AuFormRow>
           {{/each}}
-          <AuFormRow>
-            <AuControlRadio
-              @label={{t "date-plugin.card.custom-date" }}
-              @identifier="custom"
-              @name="dateFormat"
-              @value="custom"
-              checked={{eq this.dateFormatType "custom"}}
-              @onChange={{this.setDateFormatFromKey}}
-            />
-          </AuFormRow>
+          {{#if this.isCustomAllowed}}
+            <AuFormRow>
+              <AuControlRadio
+                @label={{t "date-plugin.card.custom-date" }}
+                @identifier="custom"
+                @name="dateFormat"
+                @value="custom"
+                checked={{eq this.dateFormatType "custom"}}
+                @onChange={{this.setDateFormatFromKey}}
+              />
+            </AuFormRow>
+          {{/if}}  
           {{#if (eq this.dateFormatType "custom")}}
             <AuFormRow @alignment="post">
               <AuButton @skin="secondary" @icon="info-circle"

--- a/addon/components/variable-plugin/date/edit.ts
+++ b/addon/components/variable-plugin/date/edit.ts
@@ -125,6 +125,13 @@ export default class DateEditComponent extends Component<Args> {
     return unwrapOr(false, this.selectedDateNode?.attrs.custom as boolean);
   }
 
+  get isCustomAllowed(): boolean {
+    return unwrapOr(
+      true,
+      this.selectedDateNode?.attrs.customAllowed as boolean,
+    );
+  }
+
   get dateFormatType(): string {
     if (this.isCustom) {
       return 'custom';

--- a/addon/plugins/variable-plugin/variables/date.ts
+++ b/addon/plugins/variable-plugin/variables/date.ts
@@ -65,6 +65,7 @@ const parseDOM = [
           onlyDate,
           format: node.dataset.format,
           custom: node.dataset.custom === 'true',
+          customAllowed: node.dataset.customAllowed !== 'false',
         };
       }
       return false;
@@ -96,6 +97,7 @@ const parseDOM = [
           value: value,
           format: format,
           custom: dateNode?.dataset.custom === 'true',
+          customAllowed: dateNode?.dataset.customAllowed !== 'false',
           label,
         };
       }
@@ -108,8 +110,15 @@ const parseDOM = [
 const serialize = (node: PNode, state: EditorState) => {
   const t = getTranslationFunction(state);
 
-  const { value, onlyDate, format, mappingResource, custom, label } =
-    node.attrs;
+  const {
+    value,
+    onlyDate,
+    format,
+    mappingResource,
+    custom,
+    customAllowed,
+    label,
+  } = node.attrs;
   const datatype = onlyDate ? XSD('date') : XSD('dateTime');
   let humanReadableDate: string;
   if (value) {
@@ -130,6 +139,7 @@ const serialize = (node: PNode, state: EditorState) => {
     datatype: datatype.prefixed,
     'data-format': format as string,
     'data-custom': custom ? 'true' : 'false',
+    'data-custom-allowed': customAllowed ? 'true' : 'false',
     ...(!!value && { content: value as string }),
   };
   return mappingSpan(
@@ -163,6 +173,9 @@ const emberNodeConfig = (options: DateOptions): EmberNodeConfig => ({
     },
     custom: {
       default: false,
+    },
+    customAllowed: {
+      default: options.allowCustomFormat,
     },
     label: { default: null },
   },


### PR DESCRIPTION
### Overview
The config and readme already included the option `allowCustomFormat`, but this did not do anything. This PR fixes so that if `allowCustomFormat` is set to `false`, a custom format can't be used.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4524

### How to test/reproduce
Change the config (depending on your test). 
If `allowCustomFormat` is set to false, the radio button `custom format` should be disabled.
If the config option is missing (or set to true), the radio button should work.
In all older documents the date variable should always allow custom format (e.g. export and import some html of an older editor version, like the dev version) 

### Challenges/uncertainties
- The default for this is set to true by default everywhere. This follows how it was before: regardless of the config option, custom formats were allowed. This makes this a non-breaking change.

- the customAllowed boolean is added to the dataset instead of as rdfa, because this info for specifically for the editor UI and not meant as data to be published. 