### PR TITLE
GN-4538: Show empty search result when there are no streets

### DIFF
--- a/.changeset/thin-shoes-train.md
+++ b/.changeset/thin-shoes-train.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+GN-4538: Display correctly that there are no streets when searching in the address plugin

--- a/addon/plugins/variable-plugin/utils/address-helpers.ts
+++ b/addon/plugins/variable-plugin/utils/address-helpers.ts
@@ -22,7 +22,7 @@ type StreetSearchResult = {
       gemeente: {
         gemeentenaam: { geografischeNaam: { spelling: string } };
       };
-      straatnaam: {
+      straatnaam?: {
         straatnaam: {
           geografischeNaam: { spelling: string };
         };
@@ -135,9 +135,11 @@ export async function fetchStreets(term: string, municipality: string) {
   });
   if (result.ok) {
     const jsonResult = (await result.json()) as StreetSearchResult;
-    const streetnames = jsonResult.adresMatches.map((entry) => {
-      return entry.straatnaam.straatnaam.geografischeNaam.spelling;
-    });
+
+    const streetnames = jsonResult.adresMatches
+      .map((entry) => entry.straatnaam?.straatnaam.geografischeNaam.spelling)
+      .filter(Boolean);
+
     return streetnames;
   } else {
     throw new AddressError({


### PR DESCRIPTION
### Overview

GN-4538: Show empty search result when there are no streets

Issue was caused by `straatnaam` field not existing in the response when there are no streets found.

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4538


### Setup

1. Checkout
2. `npm run start`

### How to test/reproduce

1. Insert address
2. Try to search for an existing street e.g. Drongenstationstraat in Gent
3. Select the result
4. Now search for non-existing street
5. Observe that you see "no streets found" notification instead of the results of previous search


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check if dummy app is correctly updated
- [X] Check cancel/go-back flows
- [X] changelog
- [X] npm lint
- [X] no new deprecations
