### PR TITLE
Make plugins follow document language where applicable (show as words & placeholders)

### DIFF
--- a/.changeset/khaki-schools-clap.md
+++ b/.changeset/khaki-schools-clap.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Using "show as words" for a number variable will convert the number to a string in the language in the document, instead of always showing Dutch.

--- a/.changeset/smart-fireants-sniff.md
+++ b/.changeset/smart-fireants-sniff.md
@@ -1,0 +1,11 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+For article-structure plugin
+
+- The `StructureSpec`'s `constructor` now also contains the optional argument `state` (an EditorState)
+- The existing structures' placeholders are translated using the document language
+  - This is only the case if emberApplication plugin is configured.
+    **Recommended change**: activate emberApplication plugin
+  - Will fallback to translating based on browser locale (=old logic) if emberApplication plugin is not configured

--- a/.changeset/swift-penguins-roll.md
+++ b/.changeset/swift-penguins-roll.md
@@ -1,0 +1,11 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+For decision-plugin and standard-template-plugin
+
+Make use of `state` argument to translate placeholders based on document language instead of browser locale
+Depending on the place where placeholders are defined either of the following logic happens:
+
+- will always use document language
+- will use document language if emberApplication plugin is active. If not, defaults to browser locale (like before)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ export type StructureSpec = {
     number?: number;
     intl?: IntlService;
     content?: PNode | Fragment;
+    state?: EditorState;
   }) => {
     node: PNode;
     selectionConfig: {

--- a/addon/components/document-title-plugin/insert-title-card.ts
+++ b/addon/components/document-title-plugin/insert-title-card.ts
@@ -17,6 +17,7 @@ export default class InsertTitleCardComponent extends Component<Args> {
       insertDocumentTitle({
         placeholder: this.intl.t(
           'document-title-plugin.document-title-placeholder',
+          { locale: this.args.controller.documentLanguage },
         ),
       }),
       {
@@ -31,6 +32,7 @@ export default class InsertTitleCardComponent extends Component<Args> {
       insertDocumentTitle({
         placeholder: this.intl.t(
           'document-title-plugin.document-title-placeholder',
+          { locale: this.args.controller.documentLanguage },
         ),
       }),
       {

--- a/addon/components/variable-plugin/number/nodeview.ts
+++ b/addon/components/variable-plugin/number/nodeview.ts
@@ -63,7 +63,7 @@ export default class NumberNodeviewComponent extends Component<Args> {
     if (!this.writtenNumber) {
       return value;
     } else {
-      return numberToWords(Number(value), { lang: 'nl' });
+      return numberToWords(Number(value), { lang: this.documentLanguage });
     }
   }
 

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -32,7 +32,7 @@ const insertStructure = (
     }
     if (dispatch) {
       const { node: newStructureNode, selectionConfig } =
-        structureSpec.constructor({ schema, intl, content });
+        structureSpec.constructor({ schema, intl, content, state });
       const transaction = state.tr;
 
       transaction.replaceWith(

--- a/addon/plugins/article-structure-plugin/commands/move-selected-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/move-selected-structure.ts
@@ -59,7 +59,8 @@ const moveSelectedStructure = (
           schema.node(schema.nodes['placeholder'], {
             placeholderText: translationWithDocLang(
               'article-structure-plugin.placeholder.generic.body',
-              intl?.t('article-structure-plugin.placeholder.generic.body') || '',
+              intl?.t('article-structure-plugin.placeholder.generic.body') ||
+                '',
             ),
           }),
         );

--- a/addon/plugins/article-structure-plugin/commands/move-selected-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/move-selected-structure.ts
@@ -14,6 +14,7 @@ import { findNodes } from '@lblod/ember-rdfa-editor/utils/position-utils';
 import IntlService from 'ember-intl/services/intl';
 import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 const moveSelectedStructure = (
   options: ArticleStructurePluginOptions,
   direction: 'up' | 'down',
@@ -52,11 +53,13 @@ const moveSelectedStructure = (
       );
       const parent = doc.resolve(currentStructure.pos).parent;
       if (parent.childCount === 1) {
+        const translationWithDocLang = getTranslationFunction(state);
         transaction.insert(
           currentStructure.pos,
           schema.node(schema.nodes['placeholder'], {
-            placeholderText: intl.t(
+            placeholderText: translationWithDocLang(
               'article-structure-plugin.placeholder.generic.body',
+              intl?.t('article-structure-plugin.placeholder.generic.body') || '',
             ),
           }),
         );

--- a/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
+++ b/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
@@ -41,6 +41,7 @@ const wrapStructureContent = (
         schema,
         content: contentToWrap,
         intl,
+        state,
       });
     } catch (e) {
       return false;

--- a/addon/plugins/article-structure-plugin/index.ts
+++ b/addon/plugins/article-structure-plugin/index.ts
@@ -25,6 +25,7 @@ export type StructureSpec = {
     number?: number;
     intl?: IntlService;
     content?: PNode | Fragment;
+    state?: EditorState;
   }) => {
     node: PNode;
     selectionConfig: {

--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -7,6 +7,7 @@ import {
   XSD,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { hasRDFaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 
 const PLACEHOLDERS = {
   body: 'article-structure-plugin.placeholder.paragraph.body',
@@ -25,8 +26,9 @@ export const articleParagraphSpec: StructureSpec = {
   },
   continuous: false,
   noUnwrap: true,
-  constructor: ({ schema, number, intl }) => {
+  constructor: ({ schema, number, intl, state }) => {
     const numberConverted = number?.toString() ?? '1';
+    const translationWithDocLang = getTranslationFunction(state);
     const node = schema.node(
       `article_paragraph`,
       {
@@ -37,7 +39,10 @@ export const articleParagraphSpec: StructureSpec = {
         'paragraph',
         {},
         schema.node('placeholder', {
-          placeholderText: intl?.t(PLACEHOLDERS.body),
+          placeholderText: translationWithDocLang(
+            PLACEHOLDERS.body,
+            intl?.t(PLACEHOLDERS.body) || '',
+          ),
         }),
       ),
     );

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -13,6 +13,7 @@ import {
   XSD,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 
 const PLACEHOLDERS = {
   title: 'article-structure-plugin.placeholder.article.heading',
@@ -30,8 +31,9 @@ export const articleSpec: StructureSpec = {
     removeWithContent: 'article-structure-plugin.remove-with-content.article',
   },
   continuous: true,
-  constructor: ({ schema, number, content, intl }) => {
+  constructor: ({ schema, number, content, intl, state }) => {
     const numberConverted = number?.toString() ?? '1';
+    const translationWithDocLang = getTranslationFunction(state);
     const node = schema.node(
       `article`,
       { resource: `http://data.lblod.info/articles/${uuid()}` },
@@ -40,7 +42,10 @@ export const articleSpec: StructureSpec = {
           'article_header',
           { level: 4, number: numberConverted },
           schema.node('placeholder', {
-            placeholderText: intl?.t(PLACEHOLDERS.title),
+            placeholderText: translationWithDocLang(
+              PLACEHOLDERS.title,
+              intl?.t(PLACEHOLDERS.title) || '',
+            ),
           }),
         ),
         schema.node(
@@ -51,7 +56,10 @@ export const articleSpec: StructureSpec = {
               'paragraph',
               {},
               schema.node('placeholder', {
-                placeholderText: intl?.t(PLACEHOLDERS.body),
+                placeholderText: translationWithDocLang(
+                  PLACEHOLDERS.body,
+                  intl?.t(PLACEHOLDERS.body) || '',
+                ),
               }),
             ),
         ),

--- a/addon/plugins/article-structure-plugin/structures/chapter.ts
+++ b/addon/plugins/article-structure-plugin/structures/chapter.ts
@@ -7,6 +7,7 @@ import {
 import { v4 as uuid } from 'uuid';
 import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 
 const PLACEHOLDERS = {
   title: 'article-structure-plugin.placeholder.chapter.heading',
@@ -24,8 +25,9 @@ export const chapterSpec: StructureSpec = {
     remove: 'article-structure-plugin.remove.chapter',
     removeWithContent: 'article-structure-plugin.remove-with-content.chapter',
   },
-  constructor: ({ schema, number, content, intl }) => {
+  constructor: ({ schema, number, content, intl, state }) => {
     const numberConverted = romanize(number ?? 1);
+    const translationWithDocLang = getTranslationFunction(state);
     const node = schema.node(
       `chapter`,
       { resource: `http://data.lblod.info/chapters/${uuid()}` },
@@ -34,7 +36,10 @@ export const chapterSpec: StructureSpec = {
           'structure_header',
           { level: 4, number: numberConverted },
           schema.node('placeholder', {
-            placeholderText: intl?.t(PLACEHOLDERS.title),
+            placeholderText: translationWithDocLang(
+              PLACEHOLDERS.title,
+              intl?.t(PLACEHOLDERS.title) || '',
+            ),
           }),
         ),
         schema.node(
@@ -45,7 +50,10 @@ export const chapterSpec: StructureSpec = {
               'paragraph',
               {},
               schema.node('placeholder', {
-                placeholderText: intl?.t(PLACEHOLDERS.body),
+                placeholderText: translationWithDocLang(
+                  PLACEHOLDERS.body,
+                  intl?.t(PLACEHOLDERS.body) || '',
+                ),
               }),
             ),
         ),

--- a/addon/plugins/article-structure-plugin/structures/section.ts
+++ b/addon/plugins/article-structure-plugin/structures/section.ts
@@ -7,6 +7,7 @@ import { v4 as uuid } from 'uuid';
 import { StructureSpec } from '..';
 import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 
 const PLACEHOLDERS = {
   title: 'article-structure-plugin.placeholder.section.heading',
@@ -24,8 +25,9 @@ export const sectionSpec: StructureSpec = {
     remove: 'article-structure-plugin.remove.section',
     removeWithContent: 'article-structure-plugin.remove-with-content.section',
   },
-  constructor: ({ schema, number, content, intl }) => {
+  constructor: ({ schema, number, content, intl, state }) => {
     const numberConverted = romanize(number || 1);
+    const translationWithDocLang = getTranslationFunction(state);
     const node = schema.node(
       `section`,
       { resource: `http://data.lblod.info/sections/${uuid()}` },
@@ -34,7 +36,10 @@ export const sectionSpec: StructureSpec = {
           'structure_header',
           { level: 5, number: numberConverted },
           schema.node('placeholder', {
-            placeholderText: intl?.t(PLACEHOLDERS.title),
+            placeholderText: translationWithDocLang(
+              PLACEHOLDERS.title,
+              intl?.t(PLACEHOLDERS.title) || '',
+            ),
           }),
         ),
         schema.node(
@@ -45,7 +50,10 @@ export const sectionSpec: StructureSpec = {
               'paragraph',
               {},
               schema.node('placeholder', {
-                placeholderText: intl?.t(PLACEHOLDERS.body),
+                placeholderText: translationWithDocLang(
+                  PLACEHOLDERS.body,
+                  intl?.t(PLACEHOLDERS.body) || '',
+                ),
               }),
             ),
         ),

--- a/addon/plugins/article-structure-plugin/structures/subsection.ts
+++ b/addon/plugins/article-structure-plugin/structures/subsection.ts
@@ -7,6 +7,7 @@ import {
 import { v4 as uuid } from 'uuid';
 import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 
 const PLACEHOLDERS = {
   title: 'article-structure-plugin.placeholder.subsection.heading',
@@ -26,8 +27,9 @@ export const subsectionSpec: StructureSpec = {
     removeWithContent:
       'article-structure-plugin.remove-with-content.subsection',
   },
-  constructor: ({ schema, number, intl, content }) => {
+  constructor: ({ schema, number, intl, content, state }) => {
     const numberConverted = romanize(number ?? 1);
+    const translationWithDocLang = getTranslationFunction(state);
     const node = schema.node(
       `subsection`,
       { resource: `http://data.lblod.info/subsections/${uuid()}` },
@@ -36,7 +38,10 @@ export const subsectionSpec: StructureSpec = {
           'structure_header',
           { level: 6, number: numberConverted },
           schema.node('placeholder', {
-            placeholderText: intl?.t(PLACEHOLDERS.title),
+            placeholderText: translationWithDocLang(
+              PLACEHOLDERS.title,
+              intl?.t(PLACEHOLDERS.title) || '',
+            ),
           }),
         ),
         schema.node(
@@ -47,7 +52,10 @@ export const subsectionSpec: StructureSpec = {
               'paragraph',
               {},
               schema.node('placeholder', {
-                placeholderText: intl?.t(PLACEHOLDERS.body),
+                placeholderText: translationWithDocLang(
+                  PLACEHOLDERS.body,
+                  intl?.t(PLACEHOLDERS.body) || '',
+                ),
               }),
             ),
         ),

--- a/addon/plugins/article-structure-plugin/structures/title.ts
+++ b/addon/plugins/article-structure-plugin/structures/title.ts
@@ -7,6 +7,7 @@ import {
 import { v4 as uuid } from 'uuid';
 import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 
 const PLACEHOLDERS = {
   heading: 'article-structure-plugin.placeholder.generic.heading',
@@ -24,8 +25,9 @@ export const titleSpec: StructureSpec = {
     remove: 'article-structure-plugin.remove.title',
     removeWithContent: 'article-structure-plugin.remove-with-content.title',
   },
-  constructor: ({ schema, number, content, intl }) => {
+  constructor: ({ schema, number, content, intl, state }) => {
     const numberConverted = romanize(number ?? 1);
+    const translationWithDocLang = getTranslationFunction(state);
     const node = schema.node(
       `title`,
       { resource: `http://data.lblod.info/titles/${uuid()}` },
@@ -34,7 +36,10 @@ export const titleSpec: StructureSpec = {
           'structure_header',
           { level: 3, number: numberConverted },
           schema.node('placeholder', {
-            placeholderText: intl?.t(PLACEHOLDERS.heading),
+            placeholderText: translationWithDocLang(
+              PLACEHOLDERS.heading,
+              intl?.t(PLACEHOLDERS.heading) || '',
+            ),
           }),
         ),
         schema.node(
@@ -45,7 +50,10 @@ export const titleSpec: StructureSpec = {
               'paragraph',
               {},
               schema.node('placeholder', {
-                placeholderText: intl?.t(PLACEHOLDERS.body),
+                placeholderText: translationWithDocLang(
+                  PLACEHOLDERS.body,
+                  intl?.t(PLACEHOLDERS.body) || '',
+                ),
               }),
             ),
         ),

--- a/addon/plugins/decision-plugin/commands/insert-motivation.ts
+++ b/addon/plugins/decision-plugin/commands/insert-motivation.ts
@@ -9,6 +9,7 @@ import { isNone } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { transactionCompliesWithShapes } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/validation/utils/transaction-complies-with-shapes';
 import { findInsertionPosInAncestorOfType } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/find-insertion-pos-in-ancestor-of-type';
 import IntlService from 'ember-intl/services/intl';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 
 interface InsertMotivationArgs {
   intl: IntlService;
@@ -20,13 +21,17 @@ export default function insertMotivation({
   validateShapes,
 }: InsertMotivationArgs): Command {
   return function (state: EditorState, dispatch?: (tr: Transaction) => void) {
+    const translationWithDocLang = getTranslationFunction(state);
     const { selection, schema } = state;
     const nodeToInsert = schema.node('motivering', { __rdfaId: uuid() }, [
       schema.node(
         'paragraph',
         null,
         schema.node('placeholder', {
-          placeholderText: intl.t('besluit-plugin.placeholder.government-body'),
+          placeholderText: translationWithDocLang(
+            'besluit-plugin.placeholder.government-body',
+            intl.t('besluit-plugin.placeholder.government-body'),
+          ),
         }),
       ),
       schema.node(
@@ -40,8 +45,9 @@ export default function insertMotivation({
         schema.node('list_item', null, [
           schema.node('paragraph', null, [
             schema.node('placeholder', {
-              placeholderText: intl.t(
+              placeholderText: translationWithDocLang(
                 'besluit-plugin.placeholder.legal-jurisdiction',
+                intl.t('besluit-plugin.placeholder.legal-jurisdiction'),
               ),
             }),
           ]),
@@ -52,14 +58,22 @@ export default function insertMotivation({
         {
           level: 5,
         },
-        [schema.text(intl.t('besluit-plugin.text.legal-context'))],
+        [
+          schema.text(
+            translationWithDocLang(
+              'besluit-plugin.text.legal-context',
+              intl.t('besluit-plugin.text.legal-context'),
+            ),
+          ),
+        ],
       ),
       schema.node('bullet_list', null, [
         schema.node('list_item', null, [
           schema.node('paragraph', null, [
             schema.node('placeholder', {
-              placeholderText: intl.t(
+              placeholderText: translationWithDocLang(
                 'besluit-plugin.placeholder.insert-legal-context',
+                intl.t('besluit-plugin.placeholder.insert-legal-context'),
               ),
             }),
           ]),
@@ -70,14 +84,22 @@ export default function insertMotivation({
         {
           level: 5,
         },
-        [schema.text(intl.t('besluit-plugin.text.factual-context'))],
+        [
+          schema.text(
+            translationWithDocLang(
+              'besluit-plugin.text.factual-context',
+              intl.t('besluit-plugin.text.factual-context'),
+            ),
+          ),
+        ],
       ),
       schema.node('bullet_list', null, [
         schema.node('list_item', null, [
           schema.node('paragraph', null, [
             schema.node('placeholder', {
-              placeholderText: intl.t(
+              placeholderText: translationWithDocLang(
                 'besluit-plugin.placeholder.insert-factual-context',
+                intl.t('besluit-plugin.placeholder.insert-factual-context'),
               ),
             }),
           ]),

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -205,7 +205,9 @@ export const besluitArticleStructure: StructureSpec = {
               schema.node('placeholder', {
                 placeholderText: translationWithDocLang(
                   'article-structure-plugin.placeholder.article.body',
-                  intl?.t('article-structure-plugin.placeholder.article.body') || '',
+                  intl?.t(
+                    'article-structure-plugin.placeholder.article.body',
+                  ) || '',
                 ),
               }),
             ),

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -15,6 +15,7 @@ import { hasRDFaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/n
 import { StructureSpec } from '../../article-structure-plugin';
 import { v4 as uuid } from 'uuid';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 
 export const besluit_title: NodeSpec = {
   content: 'paragraph+',
@@ -180,7 +181,8 @@ export const besluitArticleStructure: StructureSpec = {
     remove: 'article-structure-plugin.remove.article',
   },
   limitTo: 'besluit',
-  constructor: ({ schema, number, content, intl }) => {
+  constructor: ({ schema, number, content, intl, state }) => {
+    const translationWithDocLang = getTranslationFunction(state);
     const numberConverted = number?.toString() ?? '1';
     const node = schema.node(
       `besluit_article`,
@@ -201,8 +203,9 @@ export const besluitArticleStructure: StructureSpec = {
               'paragraph',
               {},
               schema.node('placeholder', {
-                placeholderText: intl?.t(
+                placeholderText: translationWithDocLang(
                   'article-structure-plugin.placeholder.article.body',
+                  intl?.t('article-structure-plugin.placeholder.article.body') || '',
                 ),
               }),
             ),

--- a/addon/plugins/variable-plugin/utils/number-to-words.ts
+++ b/addon/plugins/variable-plugin/utils/number-to-words.ts
@@ -2,14 +2,19 @@ import n2words from 'n2words';
 
 /**
  * Wrapper around the `n2words` function which catches possible errors thrown by n2words.
+ * If an invalid `lang` is used, `nl` is used by default.
  * If `n2words` throws an error (because of inability to convert the number),
  * this function displays the error as a warning and returns the provided number as a string.
  */
 export function numberToWords(number: number, options: { lang: string }) {
   try {
     return n2words(number, options);
-  } catch (e) {
-    console.warn(e);
-    return number.toString();
+  } catch {
+    try {
+      return n2words(number, { ...options, lang: 'nl' });
+    } catch (e) {
+      console.warn(e);
+      return number.toString();
+    }
   }
 }

--- a/addon/plugins/variable-plugin/variables/number.ts
+++ b/addon/plugins/variable-plugin/variables/number.ts
@@ -73,7 +73,7 @@ const parseDOM = [
 
 const serialize = (node: PNode, state: EditorState): DOMOutputSpec => {
   const t = getTranslationFunction(state);
-
+  const docLang = state.doc.attrs.lang as string;
   const {
     mappingResource,
     variableInstance,
@@ -88,7 +88,7 @@ const serialize = (node: PNode, state: EditorState): DOMOutputSpec => {
 
   if (isNumber(value)) {
     if (writtenNumber) {
-      humanReadableContent = numberToWords(Number(value), { lang: 'nl' });
+      humanReadableContent = numberToWords(Number(value), { lang: docLang });
     } else {
       humanReadableContent = value as string;
     }

--- a/addon/utils/translation.ts
+++ b/addon/utils/translation.ts
@@ -2,12 +2,16 @@ import type { EditorState } from '@lblod/ember-rdfa-editor';
 import IntlService, { type TOptions } from 'ember-intl/services/intl';
 import { emberApplicationPluginKey } from '@lblod/ember-rdfa-editor/plugins/ember-application';
 
-export const getTranslationFunction = (state: EditorState) => {
-  const intl = emberApplicationPluginKey
-    .getState(state)
-    ?.application.lookup('service:intl') as IntlService | undefined;
+/* Get a function that will translate the string through `intl` based on the document language
+   or returns the fallback string if no state is provided or emberApplication plugin is not found */
+export const getTranslationFunction = (state?: EditorState) => {
+  const intl =
+    state &&
+    (emberApplicationPluginKey
+      .getState(state)
+      ?.application.lookup('service:intl') as IntlService | undefined);
 
-  const locale = state.doc.attrs.lang as string;
+  const locale = state?.doc.attrs.lang as string;
 
   return (key: string, fallback: string, options?: TOptions) => {
     if (!intl) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "ember-resources": "^6.1.1",
         "ember-velcro": "^2.1.0",
         "fetch-sparql-endpoint": "^3.0.0",
-        "n2words": "^1.16.4",
+        "n2words": "^1.18.0",
         "process": "0.11.10",
         "rdf-ext": "^2.1.0",
         "rdf-validate-shacl": "^0.4.5",
@@ -25228,11 +25228,11 @@
       "license": "ISC"
     },
     "node_modules/n2words": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/n2words/-/n2words-1.16.4.tgz",
-      "integrity": "sha512-t4wGZkLxQpByjWwuN5cJWTBUHer82g3bGUDaK00YJZicQPUYcI9i6eu3KMDg/awLIkTKeH5IQ866lGy+c02d2g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/n2words/-/n2words-1.18.0.tgz",
+      "integrity": "sha512-FZFNFQhwRDcshGtRrnA4GTabwI9hHow1QndIf10YzFdvKaC3DQsFVN7h2MnjX6hJQLH+vO0ET+K5yN8hBaTW8A==",
       "engines": {
-        "node": "16 || >=18"
+        "node": "16 || 18 || >=20"
       }
     },
     "node_modules/n3": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ember-resources": "^6.1.1",
     "ember-velcro": "^2.1.0",
     "fetch-sparql-endpoint": "^3.0.0",
-    "n2words": "^1.16.4",
+    "n2words": "^1.18.0",
     "process": "0.11.10",
     "rdf-ext": "^2.1.0",
     "rdf-validate-shacl": "^0.4.5",


### PR DESCRIPTION
### Overview
There was a ticket for already partially using document language for plugins: https://binnenland.atlassian.net/browse/GN-4450

This fixes all other instances where translations still had to happen.
The clue is that anything that shows up in the document (part of the "reading" experience") should be in the language of the document.

Number variable: interestingly, a very recent n2words added support for a general language as locale. So no special logic needed for that
Placeholders: placeholders are part of the document and are translated with doc language.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4424

### How to test/reproduce
- Check if number as words translates based on the doc language
- Check if placeholders follow this language (e.g. article structures, decision structures).
- This PR is a bit rushed, so I might have missed some plugins that should still change to document language. Part of testing is checking if this PR fixes all instances so the linked issue can indeed be closed.

### Challenges/uncertainties
- The name for artikel, hoofdstuk, sectie etc are not translated and shouldn't. These are used specifically in regexes and are linked to official names for legal documents. So changing these would need more insight if that is correct and changes to the regexes.
- I tried to make this as non-breaking as possible
  - The code uses a new plugin that might not be configured. If this is the case, old logic is used (translating with browser locale).
  - This does meant `intl` still has to be passed. However, notice that this is anyway needed to give a default translation and removing that parameter means changing the `StructureSpec` api (which would be a breaking change)
  - `StructureSpec` gets an extra parameter, but old parameters are not changed, which keeps backwards compatibility with article-structure's old logic. In theory a user of this plugin could have specified their own `StructureSpec`s.