### PR TITLE
Drop usage of component-helper

### DIFF
--- a/.changeset/clever-pets-press.md
+++ b/.changeset/clever-pets-press.md
@@ -1,0 +1,54 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': major
+---
+
+Remove usage of `component` helper in preparation of embroider-compatibility.
+
+This removal also causes a change in the variable-plugin insert-component API, the insert-components now need to be passed directly (instead of their path). 
+
+Before:
+
+```typescript
+get variableTypes(): VariableConfig[] {
+  return [
+    {
+      label: 'text',
+      component: {
+        path: 'variable-plugin/text/insert',
+      },
+    },
+    {
+      label: 'location',
+      component: {
+        path: 'variable-plugin/location/insert',
+        options: {
+          endpoint: 'https://dev.roadsigns.lblod.info/sparql',
+        },
+      },
+    },
+  ];
+}
+```
+
+After:
+
+```typescript
+import TextVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/text/insert';
+import LocationInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/insert';
+...
+get variableTypes() {
+  return [
+    {
+      label: 'text',
+      component: TextVariableInsertComponent,
+    },
+    {
+      label: 'location',
+      component: LocationInsertComponent,
+      options: {
+        endpoint: 'https://dev.roadsigns.lblod.info/sparql',
+      },
+    },
+  ];
+}
+```

--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ The `variable-plugin/insert-variable-card` can be easily configured: it expects 
 - `controller`: An instance of the `SayController` class
 - `variableTypes`: A list of `VariableConfig` objects. With each `VariableConfig` containing:
   - the `label` which should be displayed in the variable-select dropdown
-  - the `path` to the insert-variable component
+  - the `component`: class of the component which should be displayed upon selecting the variable type.
   - _optionally_ an `options` argument object which should be passed to the insert-variable component.
 
 * The `VariableConfig` type is defined as follows:
@@ -570,10 +570,8 @@ The `variable-plugin/insert-variable-card` can be easily configured: it expects 
 ```js
  type VariableConfig = {
    label: string;
-   component: {
-     path: string;
-     options?: unknown;
-   };
+   component: ComponentLike;
+   options?: unknown;
  };
 ```
 
@@ -591,49 +589,44 @@ To allows users to insert variables into a document, add the following to the ed
 `this.controller` is an instance of `SayController` and `this.variableTypes` is the list of `VariableConfig` objects which should be defined in your controller/component class:
 
 ```js
+import TextVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/text/insert';
+import NumberInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/number/insert';
+import DateInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/date/insert-variable';
+import LocationInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/insert';
+import CodelistInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/codelist/insert';
+import VariablePluginAddressInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/insert-variable';
+...
 get variableTypes() {
   return [
     {
       label: 'text',
-      component: {
-        path: 'variable-plugin/text/insert',
-      },
+      component: TextVariableInsertComponent,
     },
     {
       label: 'number',
-      component: {
-        path: 'variable-plugin/number/insert',
-      },
+      component: NumberInsertComponent,
     },
     {
       label: 'date',
-      component: {
-        path: 'variable-plugin/date/insert',
-      },
+      component: DateInsertVariableComponent
     },
     {
       label: 'location',
-      component: {
-        path: 'variable-plugin/location/insert',
-        options: {
-          endpoint: 'https://dev.roadsigns.lblod.info/sparql',
-        },
+      component: LocationInsertComponent,
+      options: {
+        endpoint: 'https://dev.roadsigns.lblod.info/sparql',
       },
     },
     {
       label: 'codelist',
-      component: {
-        path: 'variable-plugin/codelist/insert',
-        options: {
-          endpoint: 'https://dev.roadsigns.lblod.info/sparql',
-        },
+      component: CodelistInsertComponent,
+      options: {
+        endpoint: 'https://dev.roadsigns.lblod.info/sparql',
       },
     },
     {
       label: 'address',
-      component: {
-        path: 'variable-plugin/address/insert-variable',
-      },
+      component: VariablePluginAddressInsertVariableComponent,
     },
   ];
 }

--- a/addon/components/variable-plugin/insert-variable-card.hbs
+++ b/addon/components/variable-plugin/insert-variable-card.hbs
@@ -25,11 +25,10 @@
         {{variable.label}}
       </PowerSelect>
       {{#if this.selectedVariable}}
-        {{component 
-          this.selectedVariable.component.path 
-          controller=this.controller 
-          options=this.selectedVariable.component.options
-        }}
+        <this.selectedVariable.component
+          @controller={{this.controller}}
+          @options={{this.selectedVariable.options}}
+        />
       {{/if}}
     </c.content>
   </AuCard>

--- a/addon/components/variable-plugin/insert-variable-card.ts
+++ b/addon/components/variable-plugin/insert-variable-card.ts
@@ -5,11 +5,10 @@ import { NodeSelection, SayController } from '@lblod/ember-rdfa-editor';
 import { hasGroups } from '@lblod/ember-rdfa-editor/utils/node-utils';
 import { inject as service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
-import { ComponentLike } from '@glint/template';
 
 export type VariableConfig = {
   label: string;
-  component: ComponentLike;
+  component: typeof Component;
   options?: unknown;
 };
 

--- a/addon/components/variable-plugin/insert-variable-card.ts
+++ b/addon/components/variable-plugin/insert-variable-card.ts
@@ -5,13 +5,12 @@ import { NodeSelection, SayController } from '@lblod/ember-rdfa-editor';
 import { hasGroups } from '@lblod/ember-rdfa-editor/utils/node-utils';
 import { inject as service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
+import { ComponentLike } from '@glint/template';
 
 export type VariableConfig = {
   label: string;
-  component: {
-    path: string;
-    options?: unknown;
-  };
+  component: ComponentLike;
+  options?: unknown;
 };
 
 type Args = {

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -87,7 +87,6 @@ import {
   dateView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/date';
 import TextVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/text/insert';
-import { ComponentLike } from '@glint/template';
 import NumberInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/number/insert';
 import DateInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/date/insert-variable';
 import LocationInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/insert';
@@ -186,30 +185,29 @@ export default class RegulatoryStatementSampleController extends Controller {
     return [
       {
         label: 'text',
-        component: TextVariableInsertComponent as unknown as ComponentLike,
+        component: TextVariableInsertComponent,
       },
       {
         label: 'number',
-        component: NumberInsertComponent as unknown as ComponentLike,
+        component: NumberInsertComponent,
       },
       {
         label: 'date',
-        component: DateInsertVariableComponent as unknown as ComponentLike,
+        component: DateInsertVariableComponent,
       },
       {
         label: 'location',
-        component: LocationInsertComponent as unknown as ComponentLike,
+        component: LocationInsertComponent,
         options: this.locationOptions,
       },
       {
         label: 'codelist',
-        component: CodelistInsertComponent as unknown as ComponentLike,
+        component: CodelistInsertComponent,
         options: this.codelistOptions,
       },
       {
         label: 'address',
-        component:
-          VariablePluginAddressInsertVariableComponent as unknown as ComponentLike,
+        component: VariablePluginAddressInsertVariableComponent,
       },
     ];
   }

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -86,6 +86,13 @@ import {
   date,
   dateView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/date';
+import TextVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/text/insert';
+import { ComponentLike } from '@glint/template';
+import NumberInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/number/insert';
+import DateInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/date/insert-variable';
+import LocationInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/insert';
+import CodelistInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/codelist/insert';
+import VariablePluginAddressInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/insert-variable';
 export default class RegulatoryStatementSampleController extends Controller {
   @service declare importRdfaSnippet: ImportRdfaSnippet;
   @service declare intl: IntlService;
@@ -179,41 +186,30 @@ export default class RegulatoryStatementSampleController extends Controller {
     return [
       {
         label: 'text',
-        component: {
-          path: 'variable-plugin/text/insert',
-        },
+        component: TextVariableInsertComponent as unknown as ComponentLike,
       },
       {
         label: 'number',
-        component: {
-          path: 'variable-plugin/number/insert',
-        },
+        component: NumberInsertComponent as unknown as ComponentLike,
       },
       {
         label: 'date',
-        component: {
-          path: 'variable-plugin/date/insert-variable',
-        },
+        component: DateInsertVariableComponent as unknown as ComponentLike,
       },
       {
         label: 'location',
-        component: {
-          path: 'variable-plugin/location/insert',
-          options: this.locationOptions,
-        },
+        component: LocationInsertComponent as unknown as ComponentLike,
+        options: this.locationOptions,
       },
       {
         label: 'codelist',
-        component: {
-          path: 'variable-plugin/codelist/insert',
-          options: this.codelistOptions,
-        },
+        component: CodelistInsertComponent as unknown as ComponentLike,
+        options: this.codelistOptions,
       },
       {
         label: 'address',
-        component: {
-          path: 'variable-plugin/address/insert-variable',
-        },
+        component:
+          VariablePluginAddressInsertVariableComponent as unknown as ComponentLike,
       },
     ];
   }


### PR DESCRIPTION
### Overview
This PR drops all usages of the dynamic `component` helper in this package in preparation for embroider-compatibility.

This removal also causes a change in the variable-plugin insert-component API, the insert-components now need to be passed directly (instead of their path). 

Before:

```typescript
get variableTypes(): VariableConfig[] {
  return [
    {
      label: 'text',
      component: {
        path: 'variable-plugin/text/insert',
      },
    },
    {
      label: 'location',
      component: {
        path: 'variable-plugin/location/insert',
        options: {
          endpoint: 'https://dev.roadsigns.lblod.info/sparql',
        },
      },
    },
  ];
}
```

After:

```typescript
import TextVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/text/insert';
import LocationInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/insert';
...
get variableTypes() {
  return [
    {
      label: 'text',
      component: TextVariableInsertComponent,
    },
    {
      label: 'location',
      component: LocationInsertComponent,
      options: {
        endpoint: 'https://dev.roadsigns.lblod.info/sparql',
      },
    },
  ];
}
```

### How to test/reproduce
- Start the dummy app
- Visit the regulatory statements page
- Check if inserting variables still works as expected


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
