### PR TITLE
GN-4130: Add styles for `data-editor-highlight`

### DIFF
--- a/.changeset/eleven-grapes-greet.md
+++ b/.changeset/eleven-grapes-greet.md
@@ -1,0 +1,8 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+GN-4130: Move styles for `data-editor-highlight` 
+
+Styles that were applied to elements with the `data-editor-highlight` attribute (used by `citation-plugin`) moved from  
+[editor repository](https://github.com/lblod/ember-rdfa-editor/pull/1013) to this repo as part of the `citation-plugin`.

--- a/app/styles/citaten-plugin.scss
+++ b/app/styles/citaten-plugin.scss
@@ -48,3 +48,41 @@
 .citaten--error-code {
   font-family: var(--au-font-tertiary);
 }
+
+// Start: Styling the highlight when detecting search term inside the editor
+@mixin hints($before, $after) {
+  .rdfa-annotations.show-rdfa-blocks [data-editor-highlight=true] {
+    &:before {
+      content: "#{$before}";
+    }
+
+    &:not([contenteditable=""]):after {
+      content: "#{$after}";
+    }
+  }
+}
+
+@include hints("Selecteer de juiste optie", "Actie nodig");
+
+[data--language=en], [lang=en] {
+  @include hints("Select the correct option", "Action required");
+}
+
+.rdfa-annotations {
+  [data-editor-highlight=true]:not([contenteditable=""]) {
+    background-color: var(--au-gray-100);
+    border-bottom: 0.2rem dotted var(--au-gray-300);
+    padding-bottom: 0.2rem;
+    transition: background-color var(--au-transition);
+
+    &::selection {
+      background-color: var(--au-gray-300);
+    }
+
+    &:hover {
+      background-color: var(--au-gray-200);
+    }
+  }
+}
+
+// End: Styling the highlight when detecting search term inside the editor

--- a/app/styles/citaten-plugin.scss
+++ b/app/styles/citaten-plugin.scss
@@ -62,27 +62,144 @@
   }
 }
 
+.rdfa-annotations {
+  &.show-rdfa-blocks {
+    [data-editor-highlight=true] {
+      position: relative;
+      border: 1px solid var(--au-gray-200);
+      display: block !important; // Override inline styles
+      margin: $au-unit-tiny;
+      padding: 0;
+
+      &:before {
+        @include au-font-size(1.2rem, 1.2);
+        font-family: var(--au-font);
+        font-weight: var(--au-medium);
+        letter-spacing: 0.01rem;
+        color: var(--au-gray-600);
+        text-transform: uppercase;
+        pointer-events: none;
+        content: attr(property) ' ' attr(typeof) ' ' attr(data-type);
+        position: relative;
+        right: auto;
+        top: 0;
+        left: 0;
+        display: block;
+        width: 100%;
+        padding: $au-unit-tiny * 0.5;
+        transition: none;
+        border-bottom: 1px solid var(--au-gray-200);
+        background-color: var(--au-gray-100);
+        opacity: 1;
+      }
+
+      &:after {
+        @include au-font-size($say-smallest-font-size, 1.2);
+        font-family: var(--au-font);
+        font-weight: var(--au-regular);
+        letter-spacing: 0.01rem;
+        color: var(--au-gray-600);
+        text-transform: uppercase;
+        pointer-events: none;
+        position: relative;
+        right: auto;
+        bottom: 0;
+        left: 0;
+        display: block;
+        width: 100%;
+        padding: $au-unit-tiny * 0.5;
+        transition: none;
+        border-top: 1px solid var(--au-gray-200);
+        background-color: var(--au-white);
+        opacity: 1;
+        margin: 0;
+      }
+    }
+  }
+
+  [data-editor-highlight=true] {
+    &:not([contenteditable=""]) {
+      background-color: var(--au-gray-100);
+      border-bottom: 0.2rem dotted var(--au-gray-300);
+      padding-bottom: 0.2rem;
+      transition: background-color var(--au-transition);
+
+      &::selection {
+        background-color: var(--au-gray-300);
+      }
+
+      &:hover {
+        background-color: var(--au-gray-200);
+      }
+    }
+  }
+}
+
 @include hints("Selecteer de juiste optie", "Actie nodig");
 
 [data--language=en], [lang=en] {
   @include hints("Select the correct option", "Action required");
 }
 
-.rdfa-annotations {
-  [data-editor-highlight=true]:not([contenteditable=""]) {
-    background-color: var(--au-gray-100);
-    border-bottom: 0.2rem dotted var(--au-gray-300);
-    padding-bottom: 0.2rem;
-    transition: background-color var(--au-transition);
+.rdfa-annotations-hover:not(.show-rdfa-blocks) {
+  [data-editor-highlight="true"] {
+    &:not(ol):not(ul):not(li):not(span) {
+      position: relative;
 
-    &::selection {
-      background-color: var(--au-gray-300);
+      &:before {
+        height: 100%;
+        top: 0;
+      }
     }
 
-    &:hover {
-      background-color: var(--au-gray-200);
+    &:not([contenteditable='']) {
+      &:hover {
+        border-bottom-color: tint($au-gray-600, 20);
+      }
+
+      &:before {
+        @include au-font-size(1.2rem, 1.2);
+        position: absolute;
+        transition: opacity $au-easing 0.5s, left $au-easing 0.2s;
+        right: calc(100% + #{$au-unit-large});
+        opacity: 0;
+        display: block;
+        margin-top: 0.2rem;
+        padding-right: $au-unit + $au-unit-small;
+        margin-right: -$au-unit + $au-unit-tiny;
+        width: $au-unit-huge * 1.5;
+        font-family: var(--au-font);
+        font-weight: var(--au-medium);
+        letter-spacing: 0.01rem;
+        text-transform: uppercase;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--au-gray-600);
+        pointer-events: none;
+        overflow: hidden;
+        min-height: 2rem;
+        border-right: 1px dashed var(--au-gray-300);
+        border-top: 1px dashed var(--au-gray-300);
+        z-index: var(--au-z-index-gamma);
+        background: var(--au-white) linear-gradient(
+            to right,
+            $au-white,
+            $au-white calc(100% - #{$au-unit + $au-unit-tiny}),
+            transparent calc(100% - #{$au-unit + $au-unit-tiny}),
+            transparent 100%
+        );
+      }
     }
   }
+
+  @include mq($until: 1280px) {
+    [data-editor-highlight='true'] {
+      &:before {
+        display: none !important;
+      }
+    }
+  }
+
 }
 
 // End: Styling the highlight when detecting search term inside the editor


### PR DESCRIPTION
### Overview

GN-4130: Move styles for `data-editor-highlight` 

Styles that were applied to elements with the `data-editor-highlight` attribute (used by `citation-plugin`) moved from [editor repository](https://github.com/lblod/ember-rdfa-editor/pull/1013) to [ember-rdfa-editor-lblod-plugins](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/343) as part of the `citation-plugin`.

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4130

### Setup
1. Checkout https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/343
2. Checkout https://github.com/lblod/ember-rdfa-editor/pull/1013
3. Build `ember-rdfa-editor`
4. `yalc publish` the `ember-rdfa-editor`
5. `yalc add @lblod/ember-rdfa-editor` inside `ember-rdfa-editor-lblod-plugins`

### How to test/reproduce

Confirm that styling is still shown correctly for inline citation search, note the styles on "hello" word in the below screenshot

<img width="118" alt="CleanShot 2023-11-02 at 11 21 27@2x" src="https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/a6b7edaa-2e3b-4135-9c00-b649b0571f00">

### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check if dummy app is correctly updated
- [X] Check cancel/go-back flows
- [X] changelog
- [X] npm lint
- [X] no new deprecations
