### PR TITLE
Update article structure plugin to support rdfa editing

### DIFF
--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -14,8 +14,6 @@ import { findInsertionRange } from '@lblod/ember-rdfa-editor-lblod-plugins/utils
 import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { Backlink } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 
-const wrappingResources = [SAY('body').prefixed, SAY('body').full];
-
 const insertStructure = (
   structureSpec: StructureSpec,
   intl: IntlService,
@@ -41,7 +39,7 @@ const insertStructure = (
         | Backlink[]
         | undefined;
       const resource = backlinks?.find((backlink) =>
-        wrappingResources.includes(backlink.predicate),
+        SAY('body').matches(backlink.predicate),
       )?.subject;
       const {
         node: newStructureNode,
@@ -76,7 +74,8 @@ const insertStructure = (
           resource,
           property: {
             type: 'external',
-            predicate: SAY('hasPart').prefixed,
+            predicate: (structureSpec.relationshipPredicate ?? SAY('hasPart'))
+              .prefixed,
             object: {
               type: 'resource',
               resource: newResource,

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -66,7 +66,7 @@ const insertStructure = (
       }
 
       transaction.scrollIntoView();
-      recalculateStructureNumbers(transaction, structureSpec);
+      recalculateStructureNumbers(transaction, schema, structureSpec);
 
       if (resource) {
         const newState = state.apply(transaction);

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -4,11 +4,16 @@ import {
   NodeSelection,
   TextSelection,
 } from '@lblod/ember-rdfa-editor';
+import { addProperty } from '@lblod/ember-rdfa-editor/commands';
 import recalculateStructureNumbers from './recalculate-structure-numbers';
 import { StructureSpec } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
 import wrapStructureContent from './wrap-structure-content';
 import IntlService from 'ember-intl/services/intl';
 import { findInsertionRange } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/_private/find-insertion-range';
+import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { Backlink } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
+
+const wrappingResources = [SAY('body').prefixed, SAY('body').full];
 
 const insertStructure = (
   structureSpec: StructureSpec,
@@ -31,9 +36,18 @@ const insertStructure = (
       return false;
     }
     if (dispatch) {
-      const { node: newStructureNode, selectionConfig } =
-        structureSpec.constructor({ schema, intl, content, state });
-      const transaction = state.tr;
+      const backlinks = insertionRange.containerNode.attrs?.backlinks as
+        | Backlink[]
+        | undefined;
+      const resource = backlinks?.find((backlink) =>
+        wrappingResources.includes(backlink.predicate),
+      )?.subject;
+      const {
+        node: newStructureNode,
+        selectionConfig,
+        newResource,
+      } = structureSpec.constructor({ schema, intl, content, state });
+      let transaction = state.tr;
 
       transaction.replaceWith(
         insertionRange.from,
@@ -53,6 +67,25 @@ const insertStructure = (
       transaction.setSelection(newSelection);
       transaction.scrollIntoView();
       recalculateStructureNumbers(transaction, structureSpec);
+
+      if (resource) {
+        const newState = state.apply(transaction);
+        addProperty({
+          resource,
+          property: {
+            type: 'external',
+            predicate: SAY('hasPart').prefixed,
+            object: {
+              type: 'resource',
+              resource: newResource,
+            },
+          },
+          transaction,
+        })(newState, (newTransaction) => {
+          transaction = newTransaction;
+        });
+      }
+
       dispatch(transaction);
     }
     return true;

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -4,6 +4,7 @@ import {
   NodeSelection,
   TextSelection,
 } from '@lblod/ember-rdfa-editor';
+import { getNodeByRdfaId } from '@lblod/ember-rdfa-editor/plugins/rdfa-info';
 import { addProperty } from '@lblod/ember-rdfa-editor/commands';
 import recalculateStructureNumbers from './recalculate-structure-numbers';
 import { StructureSpec } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
@@ -54,17 +55,18 @@ const insertStructure = (
         insertionRange.to,
         newStructureNode,
       );
-      const newSelection =
-        selectionConfig.type === 'node'
-          ? NodeSelection.create(
-              transaction.doc,
-              insertionRange.from + selectionConfig.relativePos,
-            )
-          : TextSelection.create(
-              transaction.doc,
-              insertionRange.from + selectionConfig.relativePos,
-            );
-      transaction.setSelection(newSelection);
+      const target = getNodeByRdfaId(
+        state.apply(transaction),
+        selectionConfig.rdfaId,
+      );
+      if (target) {
+        const newSelection =
+          selectionConfig.type === 'node'
+            ? NodeSelection.create(transaction.doc, target.pos)
+            : TextSelection.create(transaction.doc, target.pos + 1);
+        transaction.setSelection(newSelection);
+      }
+
       transaction.scrollIntoView();
       recalculateStructureNumbers(transaction, structureSpec);
 

--- a/addon/plugins/article-structure-plugin/commands/move-selected-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/move-selected-structure.ts
@@ -15,6 +15,7 @@ import IntlService from 'ember-intl/services/intl';
 import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
+
 const moveSelectedStructure = (
   options: ArticleStructurePluginOptions,
   direction: 'up' | 'down',
@@ -77,7 +78,7 @@ const moveSelectedStructure = (
         : TextSelection.create(transaction.doc, newSelectionPos);
       transaction.setSelection(newSelection);
       transaction.scrollIntoView();
-      recalculateStructureNumbers(transaction, currentStructureSpec);
+      recalculateStructureNumbers(transaction, schema, currentStructureSpec);
       dispatch(transaction);
     }
     return true;

--- a/addon/plugins/article-structure-plugin/commands/recalculate-structure-numbers.ts
+++ b/addon/plugins/article-structure-plugin/commands/recalculate-structure-numbers.ts
@@ -1,8 +1,41 @@
-import { PNode, Transaction } from '@lblod/ember-rdfa-editor';
+import { PNode, Schema, Transaction } from '@lblod/ember-rdfa-editor';
+import { Property } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
+import { findNodeByRdfaId } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
+import type { Resource } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import { ELI } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { StructureSpec } from '..';
+
+function updateNumber(
+  transaction: Transaction,
+  schema: Schema,
+  node: PNode,
+  number: string,
+  numberPredicate?: Resource,
+) {
+  const properties = node.attrs?.properties as Property[] | undefined;
+  const numberProp =
+    properties &&
+    properties.find((prop) =>
+      (numberPredicate ?? ELI('number')).matches(prop.predicate),
+    );
+  const numberRdfaId =
+    numberProp?.type === 'external' &&
+    numberProp.object.type === 'literal' &&
+    numberProp.object.rdfaId;
+  const numberNode =
+    numberRdfaId && findNodeByRdfaId(transaction.doc, numberRdfaId);
+  if (numberNode) {
+    transaction.replaceWith(
+      numberNode.pos,
+      numberNode.pos + numberNode.value.nodeSize,
+      schema.text(number),
+    );
+  }
+}
 
 export default function recalculateStructureNumbers(
   transaction: Transaction,
+  schema: Schema,
   ...structureSpecs: StructureSpec[]
 ) {
   const doc = transaction.doc;
@@ -17,7 +50,17 @@ export default function recalculateStructureNumbers(
           indices[i] = 1;
           contexts[i] = parent;
         }
-        spec.updateNumber({ number: indices[i], pos, transaction });
+        if ('convertNumber' in spec.updateNumber) {
+          updateNumber(
+            transaction,
+            schema,
+            node,
+            spec.updateNumber.convertNumber(indices[i]),
+            spec.updateNumber.numberPredicate,
+          );
+        } else {
+          spec.updateNumber({ transaction, pos, number: indices[i] });
+        }
         indices[i] += 1;
       }
     });

--- a/addon/plugins/article-structure-plugin/commands/recalculate-structure-numbers.ts
+++ b/addon/plugins/article-structure-plugin/commands/recalculate-structure-numbers.ts
@@ -26,8 +26,8 @@ function updateNumber(
     numberRdfaId && findNodeByRdfaId(transaction.doc, numberRdfaId);
   if (numberNode) {
     transaction.replaceWith(
-      numberNode.pos,
-      numberNode.pos + numberNode.value.nodeSize,
+      numberNode.pos + 1,
+      numberNode.pos + numberNode.value.nodeSize - 1,
       schema.text(number),
     );
   }

--- a/addon/plugins/article-structure-plugin/commands/remove-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/remove-structure.ts
@@ -11,7 +11,7 @@ const removeStructure = (
       const { pos, node } = structure;
       const transaction = state.tr;
       transaction.replace(pos, pos + node.nodeSize);
-      recalculateStructureNumbers(transaction, ...options);
+      recalculateStructureNumbers(transaction, state.schema, ...options);
       dispatch(transaction);
     }
     return true;

--- a/addon/plugins/article-structure-plugin/commands/unwrap-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/unwrap-structure.ts
@@ -30,7 +30,7 @@ const unwrapStructure = (
     if (dispatch) {
       const transaction = state.tr;
       transaction.replaceWith(pos, pos + node.nodeSize, contentToUnwrap);
-      recalculateStructureNumbers(transaction, ...options);
+      recalculateStructureNumbers(transaction, state.schema, ...options);
       dispatch(transaction);
     }
     return true;

--- a/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
+++ b/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
@@ -67,13 +67,13 @@ const wrapStructureContent = (
       if (resource) {
         const newState = state.apply(transaction);
         addProperty({
-          resource,
+          resource: newResource,
           property: {
             type: 'external',
             predicate: SAY('hasPart').prefixed,
             object: {
               type: 'resource',
-              resource: newResource,
+              resource,
             },
           },
           transaction,

--- a/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
+++ b/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
@@ -65,7 +65,7 @@ const wrapStructureContent = (
       }
 
       transaction.scrollIntoView();
-      recalculateStructureNumbers(transaction, structureSpec);
+      recalculateStructureNumbers(transaction, schema, structureSpec);
 
       if (resource) {
         const newState = state.apply(transaction);

--- a/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
+++ b/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
@@ -73,7 +73,8 @@ const wrapStructureContent = (
           resource: newResource,
           property: {
             type: 'external',
-            predicate: SAY('hasPart').prefixed,
+            predicate: (structureSpec.relationshipPredicate ?? SAY('hasPart'))
+              .prefixed,
             object: {
               type: 'resource',
               resource,

--- a/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
+++ b/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
@@ -1,5 +1,6 @@
 import {
   Command,
+  Fragment,
   NodeSelection,
   NodeType,
   PNode,
@@ -7,9 +8,14 @@ import {
   Selection,
   TextSelection,
 } from '@lblod/ember-rdfa-editor';
-import { StructureSpec } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
+import { addProperty } from '@lblod/ember-rdfa-editor/commands';
+import {
+  SpecConstructorResult,
+  StructureSpec,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin';
 import IntlService from 'ember-intl/services/intl';
 import recalculateStructureNumbers from './recalculate-structure-numbers';
+import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 
 const wrapStructureContent = (
   structureSpec: StructureSpec,
@@ -20,7 +26,7 @@ const wrapStructureContent = (
       return false;
     }
     const { selection, schema } = state;
-    const container = findInsertionContainer(
+    const [container, resource] = findInsertionContainer(
       selection,
       schema.nodes[structureSpec.name],
       schema,
@@ -29,26 +35,20 @@ const wrapStructureContent = (
       return false;
     }
     const contentToWrap = container.node;
-    let result: {
-      node: PNode;
-      selectionConfig: {
-        relativePos: number;
-        type: 'node' | 'text';
-      };
-    };
-    try {
-      result = structureSpec.constructor({
-        schema,
-        content: contentToWrap,
-        intl,
-        state,
-      });
-    } catch (e) {
-      return false;
-    }
-    const { node: wrappingNode, selectionConfig } = result;
+    let result: SpecConstructorResult;
     if (dispatch) {
-      const transaction = state.tr;
+      try {
+        result = structureSpec.constructor({
+          schema,
+          content: contentToWrap,
+          intl,
+          state,
+        });
+      } catch (e) {
+        return false;
+      }
+      const { node: wrappingNode, selectionConfig, newResource } = result;
+      let transaction = state.tr;
       transaction.replaceWith(container.from, container.to, wrappingNode);
       const newSelection =
         selectionConfig.type === 'node'
@@ -63,102 +63,129 @@ const wrapStructureContent = (
       transaction.setSelection(newSelection);
       transaction.scrollIntoView();
       recalculateStructureNumbers(transaction, structureSpec);
+
+      if (resource) {
+        const newState = state.apply(transaction);
+        addProperty({
+          resource,
+          property: {
+            type: 'external',
+            predicate: SAY('hasPart').prefixed,
+            object: {
+              type: 'resource',
+              resource: newResource,
+            },
+          },
+          transaction,
+        })(newState, (newTransaction) => {
+          transaction = newTransaction;
+        });
+      }
       dispatch(transaction);
     }
     return true;
   };
 };
 
+type ContainerNode = { node: PNode | Fragment; from: number; to: number };
 function findInsertionContainer(
   selection: Selection,
   nodeType: NodeType,
   schema: Schema,
-) {
+): [ContainerNode | null, string | undefined] {
   const { $from } = selection;
+  let container: ContainerNode | null = null;
+  let resource: string | undefined;
+  // Loop from current depth to top looking for a container and resource URI
   for (let currentDepth = $from.depth; currentDepth >= 0; currentDepth--) {
     const currentAncestor = $from.node(currentDepth);
-    const pos = currentDepth > 0 ? $from.before(currentDepth) : -1;
-
-    // Simple like for like replacement from 0th index
-    if (
-      currentAncestor.canReplaceWith(0, currentAncestor.childCount, nodeType)
-    ) {
-      return {
-        node: currentAncestor.content,
-        from: pos + 1,
-        to: pos + currentAncestor.nodeSize - 1,
-      };
+    if (!resource) {
+      resource = currentAncestor.attrs?.resource as string | undefined;
     }
+    if (!container) {
+      const pos = currentDepth > 0 ? $from.before(currentDepth) : -1;
 
-    const currentAncestorParent = $from.node(currentDepth - 1);
-    const currentAncestorIndexInParent = $from.index(currentDepth - 1);
+      // Simple like for like replacement from 0th index
+      if (
+        currentAncestor.canReplaceWith(0, currentAncestor.childCount, nodeType)
+      ) {
+        container = {
+          node: currentAncestor.content,
+          from: pos + 1,
+          to: pos + currentAncestor.nodeSize - 1,
+        };
+      }
 
-    if (!currentAncestorParent) {
-      return null;
-    }
+      const currentAncestorParent = $from.node(currentDepth - 1);
+      const currentAncestorIndexInParent = $from.index(currentDepth - 1);
 
-    // Sometimes we might not be able to replace from 0th index, but we can try to go one
-    // level up and attempt to replace `currentAncestor` as a child of its parent
-    if (
-      currentAncestorParent.canReplaceWith(
-        currentAncestorIndexInParent,
-        currentAncestorIndexInParent + 1,
-        nodeType,
-      )
-    ) {
-      return {
-        node: currentAncestor,
-        from: pos,
-        to: pos + currentAncestor.nodeSize - 1,
-      };
-    }
+      if (!currentAncestorParent) {
+        break;
+      }
 
-    /**
-     * Special case when we reach `doc` node, but cannot replace the content.
-     * e.g. we reached doc, and it contains "document_title article article",
-     * we might not be able to wrap single `article`, depending on the `content` definition,
-     * of the `doc`. We try to find sibling nodes of same type and try
-     * to wrap them all together, that includes the content that might be between them.
-     */
-    if (currentAncestorParent.type.spec === schema.nodes.doc.spec) {
-      const doc = currentAncestorParent;
+      // Sometimes we might not be able to replace from 0th index, but we can try to go one
+      // level up and attempt to replace `currentAncestor` as a child of its parent
+      if (
+        currentAncestorParent.canReplaceWith(
+          currentAncestorIndexInParent,
+          currentAncestorIndexInParent + 1,
+          nodeType,
+        )
+      ) {
+        container = {
+          node: currentAncestor,
+          from: pos,
+          to: pos + currentAncestor.nodeSize - 1,
+        };
+      }
 
-      let firstOfTypePosition: null | number = null;
-      let lastOfTypePosition: null | number = null;
+      /**
+       * Special case when we reach `doc` node, but cannot replace the content.
+       * e.g. we reached doc, and it contains "document_title article article",
+       * we might not be able to wrap single `article`, depending on the `content` definition,
+       * of the `doc`. We try to find sibling nodes of same type and try
+       * to wrap them all together, that includes the content that might be between them.
+       */
+      if (currentAncestorParent.type.spec === schema.nodes.doc.spec) {
+        const doc = currentAncestorParent;
 
-      currentAncestorParent.forEach((node, pos) => {
-        if (node.type === currentAncestor.type) {
-          if (!firstOfTypePosition) {
-            firstOfTypePosition = pos;
+        let firstOfTypePosition: null | number = null;
+        let lastOfTypePosition: null | number = null;
+
+        currentAncestorParent.forEach((node, pos) => {
+          if (node.type === currentAncestor.type) {
+            if (!firstOfTypePosition) {
+              firstOfTypePosition = pos;
+            }
+
+            lastOfTypePosition = pos;
           }
+        });
 
-          lastOfTypePosition = pos;
-        }
-      });
+        if (firstOfTypePosition !== null && lastOfTypePosition !== null) {
+          const from = firstOfTypePosition;
+          const to = doc.resolve(lastOfTypePosition).end();
 
-      if (firstOfTypePosition !== null && lastOfTypePosition !== null) {
-        const from = firstOfTypePosition;
-        const to = doc.resolve(lastOfTypePosition).end();
+          const node = doc.cut(from, to).content;
 
-        const node = doc.cut(from, to).content;
-
-        if (
-          currentAncestorParent.canReplaceWith(
-            doc.resolve(from).index(),
-            doc.resolve(to).index(),
-            nodeType,
-          )
-        ) {
-          return {
-            node,
-            from,
-            to,
-          };
+          if (
+            currentAncestorParent.canReplaceWith(
+              doc.resolve(from).index(),
+              doc.resolve(to).index(),
+              nodeType,
+            )
+          ) {
+            container = {
+              node,
+              from,
+              to,
+            };
+          }
         }
       }
     }
   }
-  return null;
+  return [container, resource];
 }
 
 export default wrapStructureContent;

--- a/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
+++ b/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
@@ -8,6 +8,7 @@ import {
   Selection,
   TextSelection,
 } from '@lblod/ember-rdfa-editor';
+import { getNodeByRdfaId } from '@lblod/ember-rdfa-editor/plugins/rdfa-info';
 import { addProperty } from '@lblod/ember-rdfa-editor/commands';
 import {
   SpecConstructorResult,
@@ -50,17 +51,19 @@ const wrapStructureContent = (
       const { node: wrappingNode, selectionConfig, newResource } = result;
       let transaction = state.tr;
       transaction.replaceWith(container.from, container.to, wrappingNode);
-      const newSelection =
-        selectionConfig.type === 'node'
-          ? NodeSelection.create(
-              transaction.doc,
-              container.from + 1 + selectionConfig.relativePos,
-            )
-          : TextSelection.create(
-              transaction.doc,
-              container.from + 1 + selectionConfig.relativePos,
-            );
-      transaction.setSelection(newSelection);
+
+      const target = getNodeByRdfaId(
+        state.apply(transaction),
+        selectionConfig.rdfaId,
+      );
+      if (target) {
+        const newSelection =
+          selectionConfig.type === 'node'
+            ? NodeSelection.create(transaction.doc, target.pos)
+            : TextSelection.create(transaction.doc, target.pos + 1);
+        transaction.setSelection(newSelection);
+      }
+
       transaction.scrollIntoView();
       recalculateStructureNumbers(transaction, structureSpec);
 

--- a/addon/plugins/article-structure-plugin/index.ts
+++ b/addon/plugins/article-structure-plugin/index.ts
@@ -6,6 +6,7 @@ import {
   Transaction,
 } from '@lblod/ember-rdfa-editor';
 import IntlService from 'ember-intl/services/intl';
+import type { Resource } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 
 export type SpecName = string;
 
@@ -45,6 +46,7 @@ export type StructureSpec = {
   continuous: boolean;
   limitTo?: string;
   noUnwrap?: boolean;
+  relationshipPredicate?: Resource;
 };
 
 export type ArticleStructurePluginOptions = StructureSpec[];

--- a/addon/plugins/article-structure-plugin/index.ts
+++ b/addon/plugins/article-structure-plugin/index.ts
@@ -37,11 +37,16 @@ export type StructureSpec = {
     content?: PNode | Fragment;
     state?: EditorState;
   }) => SpecConstructorResult;
-  updateNumber: (args: {
-    number: number;
-    pos: number;
-    transaction: Transaction;
-  }) => Transaction;
+  updateNumber:
+    | {
+        numberPredicate?: Resource;
+        convertNumber: (number: number) => string;
+      }
+    | ((args: {
+        number: number;
+        pos: number;
+        transaction: Transaction;
+      }) => Transaction);
   content?: (args: { pos: number; state: EditorState }) => Fragment;
   continuous: boolean;
   limitTo?: string;

--- a/addon/plugins/article-structure-plugin/index.ts
+++ b/addon/plugins/article-structure-plugin/index.ts
@@ -12,7 +12,7 @@ export type SpecName = string;
 export type SpecConstructorResult = {
   node: PNode;
   selectionConfig: {
-    relativePos: number;
+    rdfaId: string;
     type: 'node' | 'text';
   };
   newResource: string;

--- a/addon/plugins/article-structure-plugin/index.ts
+++ b/addon/plugins/article-structure-plugin/index.ts
@@ -9,6 +9,15 @@ import IntlService from 'ember-intl/services/intl';
 
 export type SpecName = string;
 
+export type SpecConstructorResult = {
+  node: PNode;
+  selectionConfig: {
+    relativePos: number;
+    type: 'node' | 'text';
+  };
+  newResource: string;
+};
+
 export type StructureSpec = {
   name: SpecName;
   translations: {
@@ -26,13 +35,7 @@ export type StructureSpec = {
     intl?: IntlService;
     content?: PNode | Fragment;
     state?: EditorState;
-  }) => {
-    node: PNode;
-    selectionConfig: {
-      relativePos: number;
-      type: 'node' | 'text';
-    };
-  };
+  }) => SpecConstructorResult;
   updateNumber: (args: {
     number: number;
     pos: number;

--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -112,9 +112,8 @@ export const articleParagraphSpec: StructureSpec = {
       newResource: resource,
     };
   },
-  updateNumber: ({ number, pos, transaction }) => {
-    const numberConverted = number.toString();
-    return transaction.setNodeAttribute(pos, 'number', numberConverted);
+  updateNumber: {
+    convertNumber: (number) => number.toString(),
   },
 };
 

--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -1,13 +1,22 @@
-import { Fragment, NodeSpec } from '@lblod/ember-rdfa-editor';
+import { Fragment, NodeSpec, RdfaAttrs } from '@lblod/ember-rdfa-editor';
+import {
+  getRdfaAttrs,
+  rdfaAttrSpec,
+  renderRdfaAware,
+} from '@lblod/ember-rdfa-editor/core/schema';
 import { StructureSpec } from '..';
 import { v4 as uuid } from 'uuid';
 import {
   ELI,
+  RDF,
   SAY,
-  XSD,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
-import { hasRDFaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import {
+  hasParsedRDFaAttribute,
+  hasRDFaAttribute,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
+import { constructStructureBodyNodeSpec } from '../utils/structure';
 
 const PLACEHOLDERS = {
   body: 'article-structure-plugin.placeholder.paragraph.body',
@@ -26,27 +35,82 @@ export const articleParagraphSpec: StructureSpec = {
   },
   continuous: false,
   noUnwrap: true,
+  relationshipPredicate: SAY('hasParagraph'),
   constructor: ({ schema, number, intl, state }) => {
     const numberConverted = number?.toString() ?? '1';
     const translationWithDocLang = getTranslationFunction(state);
-    const node = schema.node(
-      `article_paragraph`,
-      {
-        resource: `http://data.lblod.info/paragraphs/${uuid()}`,
-        number: numberConverted,
-      },
+    const paragraphRdfaId = uuid();
+    const numberRdfaId = uuid();
+    const bodyRdfaId = uuid();
+    const resource = `http://data.lblod.info/paragraphs/${paragraphRdfaId}`;
+    const paragraphAttrs: RdfaAttrs = {
+      __rdfaId: paragraphRdfaId,
+      rdfaNodeType: 'resource',
+      resource,
+      properties: [
+        {
+          type: 'external',
+          predicate: ELI('number').prefixed,
+          object: { type: 'literal', rdfaId: numberRdfaId },
+        },
+        {
+          type: 'external',
+          predicate: SAY('body').prefixed,
+          object: { type: 'literal', rdfaId: bodyRdfaId },
+        },
+      ],
+      backlinks: [],
+    };
+    const numberAttrs: RdfaAttrs = {
+      __rdfaId: numberRdfaId,
+      rdfaNodeType: 'literal',
+      backlinks: [
+        {
+          predicate: ELI('number').prefixed,
+          subject: resource,
+        },
+      ],
+    };
+    const bodyAttrs: RdfaAttrs = {
+      __rdfaId: bodyRdfaId,
+      rdfaNodeType: 'literal',
+      backlinks: [
+        {
+          predicate: SAY('body').prefixed,
+          subject: resource,
+        },
+      ],
+    };
+    const node = schema.node(`article_paragraph`, paragraphAttrs, [
+      schema.node('article_paragraph_number', {}, [
+        schema.text('§'),
+        schema.node(
+          'structure_header_number',
+          numberAttrs,
+          schema.text(numberConverted),
+        ),
+        schema.text('. '),
+      ]),
       schema.node(
-        'paragraph',
-        {},
-        schema.node('placeholder', {
-          placeholderText: translationWithDocLang(
-            PLACEHOLDERS.body,
-            intl?.t(PLACEHOLDERS.body) || '',
-          ),
-        }),
+        'article_paragraph_body',
+        bodyAttrs,
+        schema.node(
+          'paragraph',
+          {},
+          schema.node('placeholder', {
+            placeholderText: translationWithDocLang(
+              PLACEHOLDERS.body,
+              intl?.t(PLACEHOLDERS.body) || '',
+            ),
+          }),
+        ),
       ),
-    );
-    return { node, selectionConfig: { relativePos: 1, type: 'node' } };
+    ]);
+    return {
+      node,
+      selectionConfig: { rdfaId: bodyRdfaId, type: 'node' },
+      newResource: resource,
+    };
   },
   updateNumber: ({ number, pos, transaction }) => {
     const numberConverted = number.toString();
@@ -54,70 +118,73 @@ export const articleParagraphSpec: StructureSpec = {
   },
 };
 
-const contentSelector = `span[property~='${SAY('body').prefixed}'],
-                         span[property~='${SAY('body').full}']`;
+export const article_paragraph_body = constructStructureBodyNodeSpec({
+  tag: 'span',
+  content: 'block*',
+  context: 'article_paragraph/',
+});
+
+export const article_paragraph_number: NodeSpec = {
+  content: 'text* structure_header_number text*',
+  inline: false,
+  editable: false,
+  toDOM(node) {
+    return ['span', node.attrs, 0];
+  },
+  parseDOM: [
+    {
+      tag: 'span',
+      context: 'article_paragraph/',
+      getAttrs(element: HTMLElement) {
+        if (element.querySelector(`[property~="${ELI('number').prefixed}"]`)) {
+          return {};
+        }
+        return false;
+      },
+    },
+  ],
+};
 
 export const article_paragraph: NodeSpec = {
-  content: 'block*',
+  content: 'article_paragraph_number article_paragraph_body',
   inline: false,
   isolating: true,
+  editable: true,
   defining: true,
   attrs: {
+    ...rdfaAttrSpec,
     typeof: {
       default: SAY('Paragraph').prefixed,
     },
-    property: {
-      default: SAY('hasParagraph').prefixed,
-    },
-    resource: {},
     number: {
       default: '1',
     },
   },
   toDOM(node) {
-    return [
-      'div',
-      {
-        property: node.attrs.property as string,
-        typeof: node.attrs.typeof as string,
-        resource: node.attrs.resource as string,
+    return renderRdfaAware({
+      renderable: node,
+      tag: 'div',
+      contentContainerTag: 'span',
+      rdfaContainerTag: 'span',
+      attrs: {
+        ...node.attrs,
+        class: 'say-editable',
       },
-      ['span', { contenteditable: false }, '§'],
-      [
-        'span',
-        {
-          property: ELI('number').prefixed,
-          datatype: XSD('integer').prefixed,
-          contenteditable: false,
-        },
-        node.attrs.number,
-      ],
-      ['span', { contenteditable: false }, '. '],
-      ['span', { property: SAY('body').prefixed }, 0],
-    ];
+      content: 0,
+    });
   },
   parseDOM: [
     {
       tag: 'div',
+      context: 'article/article_body/',
       getAttrs(element: HTMLElement) {
-        const numberSpan = element.querySelector(`
-        span[property~='${ELI('number').prefixed}'],
-        span[property~='${ELI('number').full}']`);
-        if (
-          hasRDFaAttribute(element, 'property', SAY('hasParagraph')) &&
-          hasRDFaAttribute(element, 'typeof', SAY('Paragraph')) &&
-          element.getAttribute('resource') &&
-          element.querySelector(contentSelector) &&
-          numberSpan
-        ) {
-          return {
-            resource: element.getAttribute('resource'),
-            number: numberSpan.textContent,
-          };
+        const rdfaAttrs = getRdfaAttrs(element);
+        if (hasParsedRDFaAttribute(rdfaAttrs, RDF('type'), SAY('Paragraph'))) {
+          return rdfaAttrs;
         }
         return false;
       },
-      contentElement: contentSelector,
+      contentElement: '[data-content-container~="true"]',
     },
     // Parsing rule for backwards compatibility (when content was not inside seperate say:body div)
     {

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -39,7 +39,7 @@ export const articleSpec: StructureSpec = {
     const titleRdfaId = uuid();
     const headingRdfaId = uuid();
     const numberRdfaId = uuid();
-    const bodyUuid = uuid();
+    const bodyRdfaId = uuid();
     const resource = `http://data.lblod.info/articles/${articleUuid}`;
     const titleText = translationWithDocLang(
       PLACEHOLDERS.title,
@@ -68,13 +68,13 @@ export const articleSpec: StructureSpec = {
         {
           type: 'external',
           predicate: SAY('body').prefixed,
-          object: { type: 'literal', rdfaId: bodyUuid },
+          object: { type: 'literal', rdfaId: bodyRdfaId },
         },
       ],
       backlinks: [],
     };
     const bodyAttrs: RdfaAttrs = {
-      __rdfaId: bodyUuid,
+      __rdfaId: bodyRdfaId,
       rdfaNodeType: 'literal',
       backlinks: [
         {
@@ -110,15 +110,13 @@ export const articleSpec: StructureSpec = {
           ),
       ),
     ]);
-    const selectionConfig: {
-      relativePos: number;
-      type: 'text' | 'node';
-    } = content
-      ? { relativePos: 5, type: 'text' }
-      : { relativePos: 6, type: 'node' };
+
     return {
       node,
-      selectionConfig,
+      selectionConfig: {
+        type: content ? 'text' : 'node',
+        rdfaId: bodyRdfaId,
+      },
       newResource: resource,
     };
   },

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -37,6 +37,7 @@ export const articleSpec: StructureSpec = {
     const translationWithDocLang = getTranslationFunction(state);
     const articleUuid = uuid();
     const titleRdfaId = uuid();
+    const headingRdfaId = uuid();
     const bodyUuid = uuid();
     const resource = `http://data.lblod.info/articles/${articleUuid}`;
     const titleText = translationWithDocLang(
@@ -54,9 +55,9 @@ export const articleSpec: StructureSpec = {
           object: numberConverted,
         },
         {
-          type: 'attribute',
+          type: 'external',
           predicate: SAY('heading').prefixed,
-          object: `Artikel ${numberConverted}: ${titleText}`,
+          object: { type: 'literal', rdfaId: headingRdfaId },
         },
         {
           type: 'external',
@@ -87,6 +88,7 @@ export const articleSpec: StructureSpec = {
         backlinkResource: resource,
         titleRdfaId,
         titleText,
+        headingRdfaId,
         number: numberConverted,
         headerType: 'article_header',
       }),

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -38,6 +38,7 @@ export const articleSpec: StructureSpec = {
     const articleUuid = uuid();
     const titleRdfaId = uuid();
     const headingRdfaId = uuid();
+    const numberRdfaId = uuid();
     const bodyUuid = uuid();
     const resource = `http://data.lblod.info/articles/${articleUuid}`;
     const titleText = translationWithDocLang(
@@ -50,9 +51,9 @@ export const articleSpec: StructureSpec = {
       resource,
       properties: [
         {
-          type: 'attribute',
+          type: 'external',
           predicate: ELI('number').prefixed,
-          object: numberConverted,
+          object: { type: 'literal', rdfaId: numberRdfaId },
         },
         {
           type: 'external',
@@ -89,6 +90,7 @@ export const articleSpec: StructureSpec = {
         titleRdfaId,
         titleText,
         headingRdfaId,
+        numberRdfaId,
         number: numberConverted,
         headerType: 'article_header',
       }),
@@ -141,19 +143,6 @@ export const article_header = constructStructureHeaderNodeSpec({
     const { number } = node.attrs;
     return `Artikel ${number as string}: ${node.textContent}`;
   },
-  numberContentDOM: (number) => [
-    'Artikel ',
-    [
-      'span',
-      {
-        property: ELI('number').prefixed,
-        datatype: XSD('string').prefixed,
-        contenteditable: false,
-      },
-      number,
-    ],
-    ['span', { contenteditable: false }, ': '],
-  ],
 });
 
 export const article_body = constructStructureBodyNodeSpec({

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -119,9 +119,8 @@ export const articleSpec: StructureSpec = {
       newResource: resource,
     };
   },
-  updateNumber: ({ number, pos, transaction }) => {
-    const numberConverted = number.toString();
-    return transaction.setNodeAttribute(pos + 1, 'number', numberConverted);
+  updateNumber: {
+    convertNumber: (number) => number.toString(),
   },
   content: ({ pos, state }) => {
     const node = unwrap(state.doc.nodeAt(pos));

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -1,10 +1,11 @@
-import { NodeSpec, PNode } from '@lblod/ember-rdfa-editor';
+import { PNode, RdfaAttrs } from '@lblod/ember-rdfa-editor';
 import { StructureSpec } from '..';
 import {
   constructStructureBodyNodeSpec,
   constructStructureNodeSpec,
-  getStructureHeaderAttrs,
+  constructStructureHeaderNodeSpec,
 } from '../utils/structure';
+import { constructStructureHeader } from './structure-header';
 import { v4 as uuid } from 'uuid';
 import {
   ELI,
@@ -34,37 +35,77 @@ export const articleSpec: StructureSpec = {
   constructor: ({ schema, number, content, intl, state }) => {
     const numberConverted = number?.toString() ?? '1';
     const translationWithDocLang = getTranslationFunction(state);
-    const node = schema.node(
-      `article`,
-      { resource: `http://data.lblod.info/articles/${uuid()}` },
-      [
-        schema.node(
-          'article_header',
-          { level: 4, number: numberConverted },
-          schema.node('placeholder', {
-            placeholderText: translationWithDocLang(
-              PLACEHOLDERS.title,
-              intl?.t(PLACEHOLDERS.title) || '',
-            ),
-          }),
-        ),
-        schema.node(
-          `article_body`,
-          {},
-          content ??
-            schema.node(
-              'paragraph',
-              {},
-              schema.node('placeholder', {
-                placeholderText: translationWithDocLang(
-                  PLACEHOLDERS.body,
-                  intl?.t(PLACEHOLDERS.body) || '',
-                ),
-              }),
-            ),
-        ),
-      ],
+    const articleUuid = uuid();
+    const titleRdfaId = uuid();
+    const bodyUuid = uuid();
+    const resource = `http://data.lblod.info/articles/${articleUuid}`;
+    const titleText = translationWithDocLang(
+      PLACEHOLDERS.title,
+      intl?.t(PLACEHOLDERS.title) || '',
     );
+    const articleAttrs: RdfaAttrs = {
+      __rdfaId: articleUuid,
+      rdfaNodeType: 'resource',
+      resource,
+      properties: [
+        {
+          type: 'attribute',
+          predicate: ELI('number').prefixed,
+          object: numberConverted,
+        },
+        {
+          type: 'attribute',
+          predicate: SAY('heading').prefixed,
+          object: `Artikel ${numberConverted}: ${titleText}`,
+        },
+        {
+          type: 'external',
+          predicate: EXT('title').prefixed,
+          object: { type: 'literal', rdfaId: titleRdfaId },
+        },
+        {
+          type: 'external',
+          predicate: SAY('body').prefixed,
+          object: { type: 'literal', rdfaId: bodyUuid },
+        },
+      ],
+      backlinks: [],
+    };
+    const bodyAttrs: RdfaAttrs = {
+      __rdfaId: bodyUuid,
+      rdfaNodeType: 'literal',
+      backlinks: [
+        {
+          subject: resource,
+          predicate: SAY('body').prefixed,
+        },
+      ],
+    };
+    const node = schema.node(`article`, articleAttrs, [
+      constructStructureHeader({
+        schema,
+        backlinkResource: resource,
+        titleRdfaId,
+        titleText,
+        number: numberConverted,
+        headerType: 'article_header',
+      }),
+      schema.node(
+        `article_body`,
+        bodyAttrs,
+        content ??
+          schema.node(
+            'paragraph',
+            {},
+            schema.node('placeholder', {
+              placeholderText: translationWithDocLang(
+                PLACEHOLDERS.body,
+                intl?.t(PLACEHOLDERS.body) || '',
+              ),
+            }),
+          ),
+      ),
+    ]);
     const selectionConfig: {
       relativePos: number;
       type: 'text' | 'node';
@@ -74,6 +115,7 @@ export const articleSpec: StructureSpec = {
     return {
       node,
       selectionConfig,
+      newResource: resource,
     };
   },
   updateNumber: ({ number, pos, transaction }) => {
@@ -91,63 +133,26 @@ export const article = constructStructureNodeSpec({
   content: 'article_header article_body',
 });
 
-export const article_header: NodeSpec = {
-  content: 'text*|placeholder',
-  inline: false,
-  isolating: true,
-  defining: true,
-  attrs: {
-    number: {
-      default: '1',
-    },
-    property: {
-      default: SAY('heading').prefixed,
-    },
-  },
-  allowSplitByTable: false,
+export const article_header = constructStructureHeaderNodeSpec({
+  includeLevel: false,
   outlineText: (node: PNode) => {
     const { number } = node.attrs;
     return `Artikel ${number as string}: ${node.textContent}`;
   },
-  toDOM(node) {
-    return [
-      'div',
-      { property: node.attrs.property as string },
-      'Artikel ',
-      [
-        'span',
-        {
-          property: ELI('number').prefixed,
-          datatype: XSD('string').prefixed,
-          contenteditable: false,
-        },
-        node.attrs.number,
-      ],
-      ['span', { contenteditable: false }, ': '],
-      [
-        'span',
-        {
-          property: EXT('title').prefixed,
-        },
-        0,
-      ],
-    ];
-  },
-  parseDOM: [
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        const headerAttrs = getStructureHeaderAttrs(element);
-        if (headerAttrs) {
-          return headerAttrs;
-        }
-        return false;
+  numberContentDOM: (number) => [
+    'Artikel ',
+    [
+      'span',
+      {
+        property: ELI('number').prefixed,
+        datatype: XSD('string').prefixed,
+        contenteditable: false,
       },
-      contentElement: `span[property~='${EXT('title').prefixed}'],
-                       span[property~='${EXT('title').full}']`,
-    },
+      number,
+    ],
+    ['span', { contenteditable: false }, ': '],
   ],
-};
+});
 
 export const article_body = constructStructureBodyNodeSpec({
   content: '(block|article_paragraph)+',

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -147,4 +147,5 @@ export const article_header = constructStructureHeaderNodeSpec({
 
 export const article_body = constructStructureBodyNodeSpec({
   content: '(block|article_paragraph)+',
+  context: 'article/',
 });

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -11,7 +11,6 @@ import {
   ELI,
   EXT,
   SAY,
-  XSD,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
@@ -145,5 +144,5 @@ export const article_header = constructStructureHeaderNodeSpec({
 
 export const article_body = constructStructureBodyNodeSpec({
   content: '(block|article_paragraph)+',
-  context: 'article/',
+  context: 'article//',
 });

--- a/addon/plugins/article-structure-plugin/structures/chapter.ts
+++ b/addon/plugins/article-structure-plugin/structures/chapter.ts
@@ -42,7 +42,7 @@ export const chapterSpec: StructureSpec = {
     const headingRdfaId = uuid();
     const titleRdfaId = uuid();
     const numberRdfaId = uuid();
-    const bodyUuid = uuid();
+    const bodyRdfaId = uuid();
     const chapterResource = `http://data.lblod.info/chapters/${chapterUuid}`;
     const chapterAttrs: RdfaAttrs = {
       __rdfaId: chapterUuid,
@@ -67,13 +67,13 @@ export const chapterSpec: StructureSpec = {
         {
           type: 'external',
           predicate: SAY('body').prefixed,
-          object: { type: 'literal', rdfaId: bodyUuid },
+          object: { type: 'literal', rdfaId: bodyRdfaId },
         },
       ],
       backlinks: [],
     };
     const bodyAttrs: RdfaAttrs = {
-      __rdfaId: bodyUuid,
+      __rdfaId: bodyRdfaId,
       rdfaNodeType: 'literal',
       backlinks: [
         {
@@ -109,15 +109,13 @@ export const chapterSpec: StructureSpec = {
           ),
       ),
     ]);
-    const selectionConfig: {
-      relativePos: number;
-      type: 'text' | 'node';
-    } = content
-      ? { relativePos: 5, type: 'text' }
-      : { relativePos: 6, type: 'node' };
+
     return {
       node,
-      selectionConfig,
+      selectionConfig: {
+        type: content ? 'text' : 'node',
+        rdfaId: bodyRdfaId,
+      },
       newResource: chapterResource,
     };
   },

--- a/addon/plugins/article-structure-plugin/structures/chapter.ts
+++ b/addon/plugins/article-structure-plugin/structures/chapter.ts
@@ -1,3 +1,4 @@
+import { RdfaAttrs } from '@lblod/ember-rdfa-editor';
 import { StructureSpec } from '..';
 import {
   constructStructureBodyNodeSpec,
@@ -5,9 +6,14 @@ import {
   romanize,
 } from '../utils/structure';
 import { v4 as uuid } from 'uuid';
-import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import {
+  ELI,
+  EXT,
+  SAY,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
+import { constructStructureHeader } from './structure-header';
 
 const PLACEHOLDERS = {
   title: 'article-structure-plugin.placeholder.chapter.heading',
@@ -28,37 +34,76 @@ export const chapterSpec: StructureSpec = {
   constructor: ({ schema, number, content, intl, state }) => {
     const numberConverted = romanize(number ?? 1);
     const translationWithDocLang = getTranslationFunction(state);
-    const node = schema.node(
-      `chapter`,
-      { resource: `http://data.lblod.info/chapters/${uuid()}` },
-      [
-        schema.node(
-          'structure_header',
-          { level: 4, number: numberConverted },
-          schema.node('placeholder', {
-            placeholderText: translationWithDocLang(
-              PLACEHOLDERS.title,
-              intl?.t(PLACEHOLDERS.title) || '',
-            ),
-          }),
-        ),
-        schema.node(
-          `chapter_body`,
-          {},
-          content ??
-            schema.node(
-              'paragraph',
-              {},
-              schema.node('placeholder', {
-                placeholderText: translationWithDocLang(
-                  PLACEHOLDERS.body,
-                  intl?.t(PLACEHOLDERS.body) || '',
-                ),
-              }),
-            ),
-        ),
-      ],
+    const titleText = translationWithDocLang(
+      PLACEHOLDERS.title,
+      intl?.t(PLACEHOLDERS.title) || '',
     );
+    const chapterUuid = uuid();
+    const headingUuid = uuid();
+    const bodyUuid = uuid();
+    const chapterResource = `http://data.lblod.info/chapters/${chapterUuid}`;
+    const chapterAttrs: RdfaAttrs = {
+      __rdfaId: chapterUuid,
+      rdfaNodeType: 'resource',
+      resource: chapterResource,
+      properties: [
+        {
+          type: 'attribute',
+          predicate: ELI('number').prefixed,
+          object: numberConverted,
+        },
+        {
+          type: 'attribute',
+          predicate: SAY('heading').prefixed,
+          object: `${numberConverted}. ${titleText}`,
+        },
+        {
+          type: 'external',
+          predicate: EXT('title').prefixed,
+          object: { type: 'literal', rdfaId: headingUuid },
+        },
+        {
+          type: 'external',
+          predicate: SAY('body').prefixed,
+          object: { type: 'literal', rdfaId: bodyUuid },
+        },
+      ],
+      backlinks: [],
+    };
+    const bodyAttrs: RdfaAttrs = {
+      __rdfaId: bodyUuid,
+      rdfaNodeType: 'literal',
+      backlinks: [
+        {
+          subject: chapterResource,
+          predicate: SAY('body').prefixed,
+        },
+      ],
+    };
+    const node = schema.node(`chapter`, chapterAttrs, [
+      constructStructureHeader({
+        schema,
+        titleRdfaId: headingUuid,
+        titleText,
+        backlinkResource: chapterResource,
+        level: 4,
+      }),
+      schema.node(
+        `chapter_body`,
+        bodyAttrs,
+        content ??
+          schema.node(
+            'paragraph',
+            {},
+            schema.node('placeholder', {
+              placeholderText: translationWithDocLang(
+                PLACEHOLDERS.body,
+                intl?.t(PLACEHOLDERS.body) || '',
+              ),
+            }),
+          ),
+      ),
+    ]);
     const selectionConfig: {
       relativePos: number;
       type: 'text' | 'node';
@@ -68,6 +113,7 @@ export const chapterSpec: StructureSpec = {
     return {
       node,
       selectionConfig,
+      newResource: chapterResource,
     };
   },
   updateNumber: ({ number, pos, transaction }) => {

--- a/addon/plugins/article-structure-plugin/structures/chapter.ts
+++ b/addon/plugins/article-structure-plugin/structures/chapter.ts
@@ -138,4 +138,5 @@ export const chapter = constructStructureNodeSpec({
 
 export const chapter_body = constructStructureBodyNodeSpec({
   content: '(section|block)+|(article|block)+',
+  context: 'chapter/',
 });

--- a/addon/plugins/article-structure-plugin/structures/chapter.ts
+++ b/addon/plugins/article-structure-plugin/structures/chapter.ts
@@ -39,7 +39,8 @@ export const chapterSpec: StructureSpec = {
       intl?.t(PLACEHOLDERS.title) || '',
     );
     const chapterUuid = uuid();
-    const headingUuid = uuid();
+    const headingRdfaId = uuid();
+    const titleRdfaId = uuid();
     const bodyUuid = uuid();
     const chapterResource = `http://data.lblod.info/chapters/${chapterUuid}`;
     const chapterAttrs: RdfaAttrs = {
@@ -53,14 +54,14 @@ export const chapterSpec: StructureSpec = {
           object: numberConverted,
         },
         {
-          type: 'attribute',
+          type: 'external',
           predicate: SAY('heading').prefixed,
-          object: `${numberConverted}. ${titleText}`,
+          object: { type: 'literal', rdfaId: headingRdfaId },
         },
         {
           type: 'external',
           predicate: EXT('title').prefixed,
-          object: { type: 'literal', rdfaId: headingUuid },
+          object: { type: 'literal', rdfaId: titleRdfaId },
         },
         {
           type: 'external',
@@ -83,8 +84,9 @@ export const chapterSpec: StructureSpec = {
     const node = schema.node(`chapter`, chapterAttrs, [
       constructStructureHeader({
         schema,
-        titleRdfaId: headingUuid,
+        titleRdfaId,
         titleText,
+        headingRdfaId,
         backlinkResource: chapterResource,
         level: 4,
       }),

--- a/addon/plugins/article-structure-plugin/structures/chapter.ts
+++ b/addon/plugins/article-structure-plugin/structures/chapter.ts
@@ -119,9 +119,8 @@ export const chapterSpec: StructureSpec = {
       newResource: chapterResource,
     };
   },
-  updateNumber: ({ number, pos, transaction }) => {
-    const numberConverted = romanize(number);
-    return transaction.setNodeAttribute(pos + 1, 'number', numberConverted);
+  updateNumber: {
+    convertNumber: romanize,
   },
   content: ({ pos, state }) => {
     const node = unwrap(state.doc.nodeAt(pos));

--- a/addon/plugins/article-structure-plugin/structures/chapter.ts
+++ b/addon/plugins/article-structure-plugin/structures/chapter.ts
@@ -41,6 +41,7 @@ export const chapterSpec: StructureSpec = {
     const chapterUuid = uuid();
     const headingRdfaId = uuid();
     const titleRdfaId = uuid();
+    const numberRdfaId = uuid();
     const bodyUuid = uuid();
     const chapterResource = `http://data.lblod.info/chapters/${chapterUuid}`;
     const chapterAttrs: RdfaAttrs = {
@@ -49,9 +50,9 @@ export const chapterSpec: StructureSpec = {
       resource: chapterResource,
       properties: [
         {
-          type: 'attribute',
+          type: 'external',
           predicate: ELI('number').prefixed,
-          object: numberConverted,
+          object: { type: 'literal', rdfaId: numberRdfaId },
         },
         {
           type: 'external',
@@ -88,6 +89,8 @@ export const chapterSpec: StructureSpec = {
         titleText,
         headingRdfaId,
         backlinkResource: chapterResource,
+        numberRdfaId,
+        number: numberConverted,
         level: 4,
       }),
       schema.node(

--- a/addon/plugins/article-structure-plugin/structures/index.ts
+++ b/addon/plugins/article-structure-plugin/structures/index.ts
@@ -1,6 +1,11 @@
 import { ArticleStructurePluginOptions } from '..';
 import { article, articleSpec, article_body, article_header } from './article';
-import { articleParagraphSpec, article_paragraph } from './article-paragraph';
+import {
+  articleParagraphSpec,
+  article_paragraph,
+  article_paragraph_number,
+  article_paragraph_body,
+} from './article-paragraph';
 import { chapterSpec, chapter, chapter_body } from './chapter';
 import { titleSpec, title, title_body } from './title';
 import { sectionSpec, section, section_body } from './section';
@@ -32,6 +37,8 @@ export const STRUCTURE_NODES = {
   article_header,
   article_body,
   article_paragraph,
+  article_paragraph_number,
+  article_paragraph_body,
   structure_header_title,
   structure_header_number,
 };

--- a/addon/plugins/article-structure-plugin/structures/index.ts
+++ b/addon/plugins/article-structure-plugin/structures/index.ts
@@ -5,6 +5,7 @@ import { chapterSpec, chapter, chapter_body } from './chapter';
 import { titleSpec, title, title_body } from './title';
 import { sectionSpec, section, section_body } from './section';
 import { structure_header } from './structure-header';
+import { structure_header_title } from './structure-header-title';
 import { subsectionSpec, subsection, subsection_body } from './subsection';
 
 export const STRUCTURE_SPECS: ArticleStructurePluginOptions = [
@@ -30,4 +31,5 @@ export const STRUCTURE_NODES = {
   article_header,
   article_body,
   article_paragraph,
+  structure_header_title,
 };

--- a/addon/plugins/article-structure-plugin/structures/index.ts
+++ b/addon/plugins/article-structure-plugin/structures/index.ts
@@ -6,6 +6,7 @@ import { titleSpec, title, title_body } from './title';
 import { sectionSpec, section, section_body } from './section';
 import { structure_header } from './structure-header';
 import { structure_header_title } from './structure-header-title';
+import { structure_header_number } from './structure-header-number';
 import { subsectionSpec, subsection, subsection_body } from './subsection';
 
 export const STRUCTURE_SPECS: ArticleStructurePluginOptions = [
@@ -32,4 +33,5 @@ export const STRUCTURE_NODES = {
   article_body,
   article_paragraph,
   structure_header_title,
+  structure_header_number,
 };

--- a/addon/plugins/article-structure-plugin/structures/section.ts
+++ b/addon/plugins/article-structure-plugin/structures/section.ts
@@ -36,6 +36,7 @@ export const sectionSpec: StructureSpec = {
     const translationWithDocLang = getTranslationFunction(state);
     const resourceUuid = uuid();
     const titleRdfaId = uuid();
+    const headingRdfaId = uuid();
     const bodyRdfaId = uuid();
     const resource = `http://data.lblod.info/sections/${resourceUuid}`;
     const titleText = translationWithDocLang(
@@ -53,9 +54,9 @@ export const sectionSpec: StructureSpec = {
           object: numberConverted,
         },
         {
-          type: 'attribute',
+          type: 'external',
           predicate: SAY('heading').prefixed,
-          object: `${numberConverted}. ${titleText}`,
+          object: { type: 'literal', rdfaId: headingRdfaId },
         },
         {
           type: 'external',
@@ -87,6 +88,7 @@ export const sectionSpec: StructureSpec = {
         number: numberConverted,
         titleRdfaId,
         titleText,
+        headingRdfaId,
         backlinkResource: resource,
       }),
       schema.node(

--- a/addon/plugins/article-structure-plugin/structures/section.ts
+++ b/addon/plugins/article-structure-plugin/structures/section.ts
@@ -138,4 +138,5 @@ export const section = constructStructureNodeSpec({
 
 export const section_body = constructStructureBodyNodeSpec({
   content: '(subsection|block)+|(article|block)+',
+  context: 'section/',
 });

--- a/addon/plugins/article-structure-plugin/structures/section.ts
+++ b/addon/plugins/article-structure-plugin/structures/section.ts
@@ -109,15 +109,13 @@ export const sectionSpec: StructureSpec = {
           ),
       ),
     ]);
-    const selectionConfig: {
-      relativePos: number;
-      type: 'text' | 'node';
-    } = content
-      ? { relativePos: 5, type: 'text' }
-      : { relativePos: 6, type: 'node' };
+
     return {
       node,
-      selectionConfig,
+      selectionConfig: {
+        type: content ? 'text' : 'node',
+        rdfaId: bodyRdfaId,
+      },
       newResource: resource,
     };
   },

--- a/addon/plugins/article-structure-plugin/structures/section.ts
+++ b/addon/plugins/article-structure-plugin/structures/section.ts
@@ -37,6 +37,7 @@ export const sectionSpec: StructureSpec = {
     const resourceUuid = uuid();
     const titleRdfaId = uuid();
     const headingRdfaId = uuid();
+    const numberRdfaId = uuid();
     const bodyRdfaId = uuid();
     const resource = `http://data.lblod.info/sections/${resourceUuid}`;
     const titleText = translationWithDocLang(
@@ -49,9 +50,9 @@ export const sectionSpec: StructureSpec = {
       resource,
       properties: [
         {
-          type: 'attribute',
+          type: 'external',
           predicate: ELI('number').prefixed,
-          object: numberConverted,
+          object: { type: 'literal', rdfaId: numberRdfaId },
         },
         {
           type: 'external',
@@ -89,6 +90,7 @@ export const sectionSpec: StructureSpec = {
         titleRdfaId,
         titleText,
         headingRdfaId,
+        numberRdfaId,
         backlinkResource: resource,
       }),
       schema.node(

--- a/addon/plugins/article-structure-plugin/structures/section.ts
+++ b/addon/plugins/article-structure-plugin/structures/section.ts
@@ -119,9 +119,8 @@ export const sectionSpec: StructureSpec = {
       newResource: resource,
     };
   },
-  updateNumber: ({ number, pos, transaction }) => {
-    const numberConverted = romanize(number);
-    return transaction.setNodeAttribute(pos + 1, 'number', numberConverted);
+  updateNumber: {
+    convertNumber: romanize,
   },
   content: ({ pos, state }) => {
     const node = unwrap(state.doc.nodeAt(pos));

--- a/addon/plugins/article-structure-plugin/structures/structure-header-number.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header-number.ts
@@ -1,10 +1,10 @@
 import { NodeSpec } from 'prosemirror-model';
 import { getRdfaAttrs, rdfaAttrSpec } from '@lblod/ember-rdfa-editor';
 import { renderRdfaAware } from '@lblod/ember-rdfa-editor/core/schema';
-import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { ELI } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { hasBacklink } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 
-export const structure_header_title: NodeSpec = {
+export const structure_header_number: NodeSpec = {
   attrs: rdfaAttrSpec,
   content: 'text*',
   inline: true,
@@ -14,7 +14,10 @@ export const structure_header_title: NodeSpec = {
     return renderRdfaAware({
       renderable: node,
       tag: 'span',
-      attrs: node.attrs,
+      attrs: {
+        contenteditable: false,
+        ...node.attrs,
+      },
       content: 0,
     });
   },
@@ -23,7 +26,7 @@ export const structure_header_title: NodeSpec = {
       tag: 'span',
       getAttrs(node: HTMLElement) {
         const attrs = getRdfaAttrs(node);
-        if (hasBacklink(attrs, EXT('title'))) {
+        if (hasBacklink(attrs, ELI('number'))) {
           return attrs;
         }
         return false;

--- a/addon/plugins/article-structure-plugin/structures/structure-header-title.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header-title.ts
@@ -32,6 +32,7 @@ export const structure_header_title: NodeSpec = {
         }
         return false;
       },
+      contentElement: '[data-content-container~="true"]',
     },
   ],
 };

--- a/addon/plugins/article-structure-plugin/structures/structure-header-title.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header-title.ts
@@ -1,0 +1,38 @@
+import { NodeSpec } from 'prosemirror-model';
+import { getRdfaAttrs, rdfaAttrSpec } from '@lblod/ember-rdfa-editor';
+import { renderRdfaAware } from '@lblod/ember-rdfa-editor/core/schema';
+import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+
+export const structure_header_title: NodeSpec = {
+  attrs: {
+    ...rdfaAttrSpec,
+    __tag: { default: 'span' },
+  },
+  content: 'text*',
+  inline: true,
+  editable: true,
+  hasRdfa: true,
+  toDOM(node) {
+    return renderRdfaAware({
+      renderable: node,
+      tag: 'span',
+      attrs: node.attrs,
+      content: 0,
+    });
+  },
+  parseDOM: [
+    {
+      tag: 'span',
+      getAttrs(node: HTMLElement) {
+        const attrs = getRdfaAttrs(node);
+        if (
+          attrs &&
+          attrs.backlinks.some((bl) => bl.predicate === EXT('title').prefixed)
+        ) {
+          return attrs;
+        }
+        return false;
+      },
+    },
+  ],
+};

--- a/addon/plugins/article-structure-plugin/structures/structure-header-title.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header-title.ts
@@ -6,7 +6,6 @@ import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 export const structure_header_title: NodeSpec = {
   attrs: {
     ...rdfaAttrSpec,
-    __tag: { default: 'span' },
   },
   content: 'text*',
   inline: true,

--- a/addon/plugins/article-structure-plugin/structures/structure-header.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header.ts
@@ -1,5 +1,8 @@
 import { NodeSpec, PNode, RdfaAttrs, Schema } from '@lblod/ember-rdfa-editor';
-import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import {
+  EXT,
+  SAY,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { constructStructureHeaderNodeSpec } from '../utils/structure';
 
 export const structure_header: NodeSpec = constructStructureHeaderNodeSpec({
@@ -25,21 +28,33 @@ type ConstructArgs = {
   backlinkResource: string;
   titleRdfaId: string;
   titleText: string;
+  headingRdfaId: string;
+  headingProperty?: string;
   level?: number;
   number?: string;
   headerType?: string;
-  headingProperty?: string;
 };
 export function constructStructureHeader({
   schema,
   backlinkResource,
   titleRdfaId,
   titleText,
+  headingRdfaId,
+  headingProperty = SAY('heading').prefixed,
   level,
   number,
   headerType = 'structure_header',
-  headingProperty,
 }: ConstructArgs) {
+  const headingAttrs: RdfaAttrs = {
+    __rdfaId: headingRdfaId,
+    rdfaNodeType: 'literal',
+    backlinks: [
+      {
+        subject: backlinkResource,
+        predicate: headingProperty,
+      },
+    ],
+  };
   const titleAttrs: RdfaAttrs = {
     __rdfaId: titleRdfaId,
     rdfaNodeType: 'literal',
@@ -52,7 +67,7 @@ export function constructStructureHeader({
   };
   return schema.node(
     headerType,
-    { level, number, property: headingProperty },
+    { level, number, ...headingAttrs },
     schema.node('structure_header_title', titleAttrs, schema.text(titleText)),
   );
 }

--- a/addon/plugins/article-structure-plugin/structures/structure-header.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header.ts
@@ -1,83 +1,33 @@
 import { NodeSpec, PNode, RdfaAttrs, Schema } from '@lblod/ember-rdfa-editor';
-import {
-  EXT,
-  SAY,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { constructStructureHeaderNodeSpec } from '../utils/structure';
 
-const TAG_TO_LEVEL = new Map([
-  ['h1', 1],
-  ['h2', 2],
-  ['h3', 3],
-  ['h4', 4],
-  ['h5', 5],
-  ['h6', 6],
-]);
-
-export const structure_header: NodeSpec = {
-  content: 'structure_header_title',
-  inline: false,
-  defining: true,
-  isolating: true,
-  selectable: false,
-  allowSplitByTable: false,
-  attrs: {
-    property: {
-      default: SAY('heading').prefixed,
-    },
-    number: {
-      default: '1',
-    },
-    level: {
-      default: 1,
-    },
-  },
+export const structure_header: NodeSpec = constructStructureHeaderNodeSpec({
+  includeLevel: true,
   outlineText: (node: PNode) => {
     const { number } = node.attrs;
     return `${number as string}. ${node.textContent}`;
   },
-  toDOM(node) {
-    return [
-      `h${node.attrs.level as number}`,
+  numberContentDOM: (number) => [
+    [
+      'span',
       {
-        level: node.attrs.level as number,
-        property: node.attrs.property as string,
+        contenteditable: false,
       },
-      [
-        'span',
-        {
-          contenteditable: false,
-        },
-        node.attrs.number,
-      ],
-      ['span', { contenteditable: false }, '. '],
-      ['span', {}, 0],
-    ];
-  },
-  parseDOM: [
-    {
-      tag: 'h1,h2,h3,h4,h5,h6',
-      priority: 60,
-      getAttrs(element: HTMLElement) {
-        const level = TAG_TO_LEVEL.get(element.tagName.toLowerCase()) ?? 6;
-        const property = element.getAttribute('property');
-        if (property === SAY('heading').prefixed) {
-          return { level };
-        }
-
-        return false;
-      },
-      contentElement: (node) => node.lastChild as HTMLElement,
-    },
+      number,
+    ],
+    ['span', { contenteditable: false }, '. '],
   ],
-};
+});
 
 type ConstructArgs = {
   schema: Schema;
   backlinkResource: string;
   titleRdfaId: string;
   titleText: string;
-  level: number;
+  level?: number;
   number?: string;
+  headerType?: string;
   headingProperty?: string;
 };
 export function constructStructureHeader({
@@ -87,6 +37,7 @@ export function constructStructureHeader({
   titleText,
   level,
   number,
+  headerType = 'structure_header',
   headingProperty,
 }: ConstructArgs) {
   const titleAttrs: RdfaAttrs = {
@@ -100,7 +51,7 @@ export function constructStructureHeader({
     ],
   };
   return schema.node(
-    'structure_header',
+    headerType,
     { level, number, property: headingProperty },
     schema.node('structure_header_title', titleAttrs, schema.text(titleText)),
   );

--- a/addon/plugins/article-structure-plugin/structures/subsection.ts
+++ b/addon/plugins/article-structure-plugin/structures/subsection.ts
@@ -39,6 +39,7 @@ export const subsectionSpec: StructureSpec = {
     const resourceUuid = uuid();
     const titleRdfaId = uuid();
     const headingRdfaId = uuid();
+    const numberRdfaId = uuid();
     const bodyRdfaId = uuid();
     const resource = `http://data.lblod.info/subsections/${resourceUuid}`;
     const titleText = translationWithDocLang(
@@ -51,9 +52,9 @@ export const subsectionSpec: StructureSpec = {
       resource,
       properties: [
         {
-          type: 'attribute',
+          type: 'external',
           predicate: ELI('number').prefixed,
-          object: numberConverted,
+          object: { type: 'literal', rdfaId: numberRdfaId },
         },
         {
           type: 'external',
@@ -81,6 +82,7 @@ export const subsectionSpec: StructureSpec = {
         titleRdfaId,
         titleText,
         headingRdfaId,
+        numberRdfaId,
         backlinkResource: resource,
       }),
       schema.node(

--- a/addon/plugins/article-structure-plugin/structures/subsection.ts
+++ b/addon/plugins/article-structure-plugin/structures/subsection.ts
@@ -38,6 +38,7 @@ export const subsectionSpec: StructureSpec = {
     const translationWithDocLang = getTranslationFunction(state);
     const resourceUuid = uuid();
     const titleRdfaId = uuid();
+    const headingRdfaId = uuid();
     const bodyRdfaId = uuid();
     const resource = `http://data.lblod.info/subsections/${resourceUuid}`;
     const titleText = translationWithDocLang(
@@ -55,9 +56,9 @@ export const subsectionSpec: StructureSpec = {
           object: numberConverted,
         },
         {
-          type: 'attribute',
+          type: 'external',
           predicate: SAY('heading').prefixed,
-          object: `${numberConverted}. ${titleText}`,
+          object: { type: 'literal', rdfaId: headingRdfaId },
         },
         {
           type: 'external',
@@ -79,6 +80,7 @@ export const subsectionSpec: StructureSpec = {
         number: numberConverted,
         titleRdfaId,
         titleText,
+        headingRdfaId,
         backlinkResource: resource,
       }),
       schema.node(

--- a/addon/plugins/article-structure-plugin/structures/subsection.ts
+++ b/addon/plugins/article-structure-plugin/structures/subsection.ts
@@ -130,4 +130,5 @@ export const subsection = constructStructureNodeSpec({
 
 export const subsection_body = constructStructureBodyNodeSpec({
   content: '(article|block)+',
+  context: 'subsection/',
 });

--- a/addon/plugins/article-structure-plugin/structures/subsection.ts
+++ b/addon/plugins/article-structure-plugin/structures/subsection.ts
@@ -111,9 +111,8 @@ export const subsectionSpec: StructureSpec = {
       newResource: resource,
     };
   },
-  updateNumber: ({ number, pos, transaction }) => {
-    const numberConverted = romanize(number);
-    return transaction.setNodeAttribute(pos + 1, 'number', numberConverted);
+  updateNumber: {
+    convertNumber: romanize,
   },
   content: ({ pos, state }) => {
     const node = unwrap(state.doc.nodeAt(pos));

--- a/addon/plugins/article-structure-plugin/structures/subsection.ts
+++ b/addon/plugins/article-structure-plugin/structures/subsection.ts
@@ -101,15 +101,13 @@ export const subsectionSpec: StructureSpec = {
           ),
       ),
     ]);
-    const selectionConfig: {
-      relativePos: number;
-      type: 'text' | 'node';
-    } = content
-      ? { relativePos: 5, type: 'text' }
-      : { relativePos: 6, type: 'node' };
+
     return {
       node,
-      selectionConfig,
+      selectionConfig: {
+        type: content ? 'text' : 'node',
+        rdfaId: bodyRdfaId,
+      },
       newResource: resource,
     };
   },

--- a/addon/plugins/article-structure-plugin/structures/title.ts
+++ b/addon/plugins/article-structure-plugin/structures/title.ts
@@ -139,5 +139,6 @@ export const title = constructStructureNodeSpec({
 
 export const title_body = constructStructureBodyNodeSpec({
   content: '(chapter|block)+|(article|block)+',
+  context: 'title/',
   allowSplitByTable: false,
 });

--- a/addon/plugins/article-structure-plugin/structures/title.ts
+++ b/addon/plugins/article-structure-plugin/structures/title.ts
@@ -119,9 +119,8 @@ export const titleSpec: StructureSpec = {
       newResource: resource,
     };
   },
-  updateNumber: ({ number, pos, transaction }) => {
-    const numberConverted = romanize(number);
-    return transaction.setNodeAttribute(pos + 1, 'number', numberConverted);
+  updateNumber: {
+    convertNumber: romanize,
   },
   content: ({ pos, state }) => {
     const node = unwrap(state.doc.nodeAt(pos));

--- a/addon/plugins/article-structure-plugin/structures/title.ts
+++ b/addon/plugins/article-structure-plugin/structures/title.ts
@@ -36,6 +36,7 @@ export const titleSpec: StructureSpec = {
     const translationWithDocLang = getTranslationFunction(state);
     const __rdfaId = uuid();
     const titleRdfaId = uuid();
+    const headingRdfaId = uuid();
     const bodyRdfaId = uuid();
     const resource = `http://data.lblod.info/titles/${__rdfaId}`;
     const titleText = translationWithDocLang(
@@ -53,9 +54,9 @@ export const titleSpec: StructureSpec = {
           object: numberConverted,
         },
         {
-          type: 'attribute',
+          type: 'external',
           predicate: SAY('heading').prefixed,
-          object: `${numberConverted}. ${titleText}`,
+          object: { type: 'literal', rdfaId: headingRdfaId },
         },
         {
           type: 'external',
@@ -87,6 +88,7 @@ export const titleSpec: StructureSpec = {
         number: numberConverted,
         titleRdfaId,
         titleText,
+        headingRdfaId,
         backlinkResource: resource,
       }),
       schema.node(

--- a/addon/plugins/article-structure-plugin/structures/title.ts
+++ b/addon/plugins/article-structure-plugin/structures/title.ts
@@ -37,6 +37,7 @@ export const titleSpec: StructureSpec = {
     const __rdfaId = uuid();
     const titleRdfaId = uuid();
     const headingRdfaId = uuid();
+    const numberRdfaId = uuid();
     const bodyRdfaId = uuid();
     const resource = `http://data.lblod.info/titles/${__rdfaId}`;
     const titleText = translationWithDocLang(
@@ -49,9 +50,9 @@ export const titleSpec: StructureSpec = {
       resource,
       properties: [
         {
-          type: 'attribute',
+          type: 'external',
           predicate: ELI('number').prefixed,
-          object: numberConverted,
+          object: { type: 'literal', rdfaId: numberRdfaId },
         },
         {
           type: 'external',
@@ -89,6 +90,7 @@ export const titleSpec: StructureSpec = {
         titleRdfaId,
         titleText,
         headingRdfaId,
+        numberRdfaId,
         backlinkResource: resource,
       }),
       schema.node(

--- a/addon/plugins/article-structure-plugin/structures/title.ts
+++ b/addon/plugins/article-structure-plugin/structures/title.ts
@@ -109,15 +109,13 @@ export const titleSpec: StructureSpec = {
           ),
       ),
     ]);
-    const selectionConfig: {
-      relativePos: number;
-      type: 'text' | 'node';
-    } = content
-      ? { relativePos: 5, type: 'text' }
-      : { relativePos: 6, type: 'node' };
+
     return {
       node,
-      selectionConfig,
+      selectionConfig: {
+        type: content ? 'text' : 'node',
+        rdfaId: bodyRdfaId,
+      },
       newResource: resource,
     };
   },

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -12,7 +12,6 @@ import {
 } from '@lblod/ember-rdfa-editor/core/schema';
 import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 import {
-  ELI,
   EXT,
   RDF,
   SAY,
@@ -215,19 +214,6 @@ export function findAncestorOfType(selection: Selection, ...types: NodeType[]) {
     };
   }
   return;
-}
-
-export function getStructureHeaderAttrs(element: HTMLElement) {
-  const numberNode = element.querySelector(
-    `[property~="${ELI('number').prefixed}"],
-     [property~="${ELI('number').full}"]`,
-  );
-  if (numberNode) {
-    return {
-      number: numberNode.textContent,
-    };
-  }
-  return false;
 }
 
 export function romanize(num: number) {

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -73,9 +73,10 @@ export function constructStructureNodeSpec(config: {
 
 export function constructStructureBodyNodeSpec(config: {
   content: string;
+  context: string;
   allowSplitByTable?: boolean;
 }): NodeSpec {
-  const { content } = config;
+  const { content, context } = config;
   return {
     content,
     inline: false,
@@ -100,12 +101,14 @@ export function constructStructureBodyNodeSpec(config: {
     parseDOM: [
       {
         tag: 'div',
+        context,
         getAttrs(element: HTMLElement) {
+          const rdfaAttrs = getRdfaAttrs(element);
           if (
-            hasRDFaAttribute(element, 'property', SAY('body')) &&
+            hasBacklink(rdfaAttrs, SAY('body')) &&
             hasRDFaAttribute(element, 'datatype', RDF('XMLLiteral'))
           ) {
-            return {};
+            return rdfaAttrs;
           }
           return false;
         },

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -1,4 +1,3 @@
-import type { DOMOutputSpec } from 'prosemirror-model';
 import {
   NodeSpec,
   NodeType,
@@ -127,17 +126,15 @@ const TAG_TO_LEVEL = new Map([
 
 type StructureHeaderArgs = {
   outlineText: (node: PNode) => string;
-  numberContentDOM: (number: number | string) => DOMOutputSpec[];
   includeLevel: boolean;
 };
 
 export function constructStructureHeaderNodeSpec({
   outlineText,
-  numberContentDOM,
   includeLevel,
 }: StructureHeaderArgs): NodeSpec {
   return {
-    content: 'structure_header_title',
+    content: 'text* structure_header_number text* structure_header_title',
     inline: false,
     defining: true,
     isolating: true,
@@ -172,7 +169,7 @@ export function constructStructureHeaderNodeSpec({
           ...attrs,
           ...(includeLevel ? { level: level as number } : {}),
         },
-        contentArray: [...numberContentDOM(attrs.number), ['span', {}, 0]],
+        content: 0,
       });
     },
     parseDOM: [
@@ -195,11 +192,7 @@ export function constructStructureHeaderNodeSpec({
 
           return false;
         },
-        contentElement: (node) => {
-          return ((node as HTMLElement)?.querySelector(
-            '[data-content-container="true"]',
-          )?.lastElementChild ?? node) as HTMLElement;
-        },
+        contentElement: '[data-content-container="true"]',
       },
     ],
   };

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -74,8 +74,9 @@ export function constructStructureBodyNodeSpec(config: {
   content: string;
   context: string;
   allowSplitByTable?: boolean;
+  tag?: string;
 }): NodeSpec {
-  const { content, context } = config;
+  const { content, context, tag = 'div' } = config;
   return {
     content,
     inline: false,
@@ -87,7 +88,7 @@ export function constructStructureBodyNodeSpec(config: {
     toDOM(node) {
       return renderRdfaAware({
         renderable: node,
-        tag: 'div',
+        tag,
         attrs: {
           ...node.attrs,
           class: 'say-editable',
@@ -99,7 +100,7 @@ export function constructStructureBodyNodeSpec(config: {
     },
     parseDOM: [
       {
-        tag: 'div',
+        tag,
         context,
         getAttrs(element: HTMLElement) {
           const rdfaAttrs = getRdfaAttrs(element);
@@ -111,7 +112,7 @@ export function constructStructureBodyNodeSpec(config: {
           }
           return false;
         },
-        contentElement: 'div[data-content-container="true"]',
+        contentElement: `${tag}[data-content-container="true"]`,
       },
     ],
   };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -184,10 +184,13 @@ export const besluitArticleStructure: StructureSpec = {
   constructor: ({ schema, number, content, intl, state }) => {
     const translationWithDocLang = getTranslationFunction(state);
     const numberConverted = number?.toString() ?? '1';
+    const articleRdfaId = uuid();
+    const resource = `http://data.lblod.info/articles/${articleRdfaId}`;
     const node = schema.node(
       `besluit_article`,
       {
-        resource: `http://data.lblod.info/articles/${uuid()}`,
+        resource,
+        __rdfaId: articleRdfaId,
       },
       [
         schema.node('besluit_article_header', {
@@ -212,15 +215,14 @@ export const besluitArticleStructure: StructureSpec = {
         ),
       ],
     );
-    const selectionConfig: {
-      relativePos: number;
-      type: 'text' | 'node';
-    } = content
-      ? { relativePos: 3, type: 'text' }
-      : { relativePos: 4, type: 'node' };
+
     return {
       node,
-      selectionConfig,
+      newResource: resource,
+      selectionConfig: {
+        type: content ? 'text' : 'node',
+        rdfaId: articleRdfaId,
+      },
     };
   },
   updateNumber: function ({ number, pos, transaction }): Transaction {

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -1,7 +1,7 @@
 import {
   getRdfaAttrs,
   NodeSpec,
-  rdfaAttrs,
+  rdfaAttrSpec,
   Transaction,
 } from '@lblod/ember-rdfa-editor';
 import {
@@ -23,7 +23,7 @@ export const besluit_title: NodeSpec = {
   defining: true,
   canSplit: false,
   attrs: {
-    ...rdfaAttrs,
+    ...rdfaAttrSpec,
     property: {
       default: 'eli:title',
     },
@@ -53,7 +53,7 @@ export const description: NodeSpec = {
   inline: false,
   canSplit: false,
   attrs: {
-    ...rdfaAttrs,
+    ...rdfaAttrSpec,
     property: {
       default: 'eli:description',
     },
@@ -82,7 +82,7 @@ export const motivering: NodeSpec = {
   inline: false,
   canSplit: false,
   attrs: {
-    ...rdfaAttrs,
+    ...rdfaAttrSpec,
     property: {
       default: 'besluit:motivering',
     },
@@ -112,7 +112,7 @@ export const article_container: NodeSpec = {
   inline: false,
   canSplit: false,
   attrs: {
-    ...rdfaAttrs,
+    ...rdfaAttrSpec,
     property: {
       default: 'prov:value',
     },
@@ -142,7 +142,7 @@ export const besluit_article: NodeSpec = {
     'besluit_article_header{1}(language_node*)besluit_article_content{1}',
   inline: false,
   attrs: {
-    ...rdfaAttrs,
+    ...rdfaAttrSpec,
     property: {
       default: 'eli:has_part',
     },
@@ -238,7 +238,7 @@ export const besluit_article_header: NodeSpec = {
   inline: false,
   selectable: false,
   attrs: {
-    ...rdfaAttrs,
+    ...rdfaAttrSpec,
     number: {
       default: '1',
     },
@@ -283,7 +283,7 @@ export const besluit_article_content: NodeSpec = {
   content: 'block+',
   inline: false,
   attrs: {
-    ...rdfaAttrs,
+    ...rdfaAttrSpec,
     property: {
       default: 'prov:value',
     },
@@ -316,7 +316,7 @@ export const besluit: NodeSpec = {
   isolating: true,
   canSplit: false,
   attrs: {
-    ...rdfaAttrs,
+    ...rdfaAttrSpec,
     property: {
       default: 'prov:generated',
     },
@@ -350,7 +350,7 @@ export const language_node: NodeSpec = {
   inline: false,
   atom: true,
   attrs: {
-    ...rdfaAttrs,
+    ...rdfaAttrSpec,
     style: {
       default: 'style="display:none;"',
     },

--- a/addon/utils/_private/find-insertion-range.ts
+++ b/addon/utils/_private/find-insertion-range.ts
@@ -3,23 +3,36 @@ import { NodeType, PNode, ResolvedPos, Schema } from '@lblod/ember-rdfa-editor';
 import { containsOnlyPlaceholder } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/utils/structure';
 import { findNodes } from '@lblod/ember-rdfa-editor/utils/position-utils';
 
+type Return = {
+  from: number;
+  to: number;
+  containerNode: PNode;
+};
 export function findInsertionRange(args: {
   doc: PNode;
   $from: ResolvedPos;
   nodeType: NodeType;
   schema: Schema;
   limitTo?: string;
-}) {
+}): Return | null {
   const { doc, $from, nodeType, schema, limitTo } = args;
   for (let currentDepth = $from.depth; currentDepth >= 0; currentDepth--) {
     const currentAncestor = $from.node(currentDepth);
     const index = $from.index(currentDepth);
     if (currentAncestor.canReplaceWith(index, index, nodeType)) {
       if (containsOnlyPlaceholder(schema, currentAncestor)) {
-        return { from: $from.start(currentDepth), to: $from.end(currentDepth) };
+        return {
+          from: $from.start(currentDepth),
+          to: $from.end(currentDepth),
+          containerNode: currentAncestor,
+        };
       } else {
         const insertPos = $from.after(currentDepth + 1);
-        return { from: insertPos, to: insertPos };
+        return {
+          from: insertPos,
+          to: insertPos,
+          containerNode: currentAncestor,
+        };
       }
     }
   }
@@ -66,10 +79,11 @@ export function findInsertionRange(args: {
     const { from, to } = nextContainerRange;
     const containerNode = doc.nodeAt(from);
     if (containerNode) {
+      console.warn('now we have a container', containerNode)
       if (containsOnlyPlaceholder(schema, containerNode)) {
-        return { from: from + 1, to: to - 1 };
+        return { from: from + 1, to: to - 1, containerNode };
       } else {
-        return { from: to - 1, to: to - 1 };
+        return { from: to - 1, to: to - 1, containerNode };
       }
     }
   }

--- a/addon/utils/_private/find-insertion-range.ts
+++ b/addon/utils/_private/find-insertion-range.ts
@@ -79,7 +79,6 @@ export function findInsertionRange(args: {
     const { from, to } = nextContainerRange;
     const containerNode = doc.nodeAt(from);
     if (containerNode) {
-      console.warn('now we have a container', containerNode)
       if (containsOnlyPlaceholder(schema, containerNode)) {
         return { from: from + 1, to: to - 1, containerNode };
       } else {

--- a/addon/utils/namespace.ts
+++ b/addon/utils/namespace.ts
@@ -56,6 +56,13 @@ export function hasParsedRDFaAttribute(
   });
 }
 
+export function hasBacklink(rdfaAttrs: RdfaAttrs | false, predicate: Resource) {
+  return (
+    rdfaAttrs &&
+    rdfaAttrs.backlinks.some((bl) => predicate.matches(bl.predicate))
+  );
+}
+
 export function findChildWithRdfaAttribute(
   element: Element,
   attr: string,

--- a/addon/utils/namespace.ts
+++ b/addon/utils/namespace.ts
@@ -1,4 +1,5 @@
 import { PNode } from '@lblod/ember-rdfa-editor';
+import type { RdfaAttrs } from '@lblod/ember-rdfa-editor/core/schema';
 
 export class Resource {
   full: string;
@@ -11,6 +12,10 @@ export class Resource {
 
   toString() {
     return this.full;
+  }
+
+  matches(fullOrPrefixed: string) {
+    return this.full === fullOrPrefixed || this.prefixed === fullOrPrefixed;
   }
 }
 
@@ -30,6 +35,25 @@ export function hasRDFaAttribute(
     return result.includes(value.full) || result.includes(value.prefixed);
   }
   return false;
+}
+
+export function hasParsedRDFaAttribute(
+  rdfaAttrs: RdfaAttrs | false,
+  predicate: Resource,
+  object: Resource | string,
+) {
+  if (!rdfaAttrs || rdfaAttrs.rdfaNodeType !== 'resource') {
+    return false;
+  }
+  return rdfaAttrs.properties.some((prop) => {
+    return (
+      prop.type === 'attribute' &&
+      predicate.matches(prop.predicate) &&
+      (typeof object === 'string'
+        ? prop.object === object
+        : object.matches(prop.object))
+    );
+  });
 }
 
 export function findChildWithRdfaAttribute(

--- a/app/styles/article-structure-plugin.scss
+++ b/app/styles/article-structure-plugin.scss
@@ -1,6 +1,15 @@
 [typeof="say:Paragraph"] {
   display: flex;
 
+  > [data-content-container="true"] {
+    display: flex;
+    // align-items: flex-start;
+
+    > span:first-child {
+      display: inline-block;
+    }
+  }
+
   [property="eli:number"], [contenteditable="false"], [property="say:body"] {
     margin-top: 0;
   }

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -71,6 +71,10 @@ import {
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
 import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
+import {
+  STRUCTURE_NODES,
+  STRUCTURE_SPECS,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/structures';
 
 export default class EditableBlockController extends Controller {
   DebugInfo = DebugInfo;
@@ -82,6 +86,7 @@ export default class EditableBlockController extends Controller {
   schema = new Schema({
     nodes: {
       doc: docWithConfig({
+        content: '((chapter|block)+|(title|block)+|(article|block)+)',
         defaultLanguage: 'nl-BE',
       }),
       paragraph,
@@ -106,6 +111,7 @@ export default class EditableBlockController extends Controller {
       hard_break,
       block_rdfa,
       link: link(this.linkOptions),
+      ...STRUCTURE_NODES,
     },
     marks: {
       inline_rdfa,
@@ -181,5 +187,9 @@ export default class EditableBlockController extends Controller {
   @action
   togglePlugin() {
     console.warn('Live toggling plugins is currently not supported');
+  }
+
+  get structureConfig() {
+    return STRUCTURE_SPECS;
   }
 }

--- a/tests/dummy/app/templates/editable-node.hbs
+++ b/tests/dummy/app/templates/editable-node.hbs
@@ -5,7 +5,6 @@
   <:content>
     <EditorContainer
       @editorOptions={{hash
-        showRdfa="true"
         showRdfaHighlight="true"
         showRdfaHover="true"
         showPaper="true"

--- a/tests/dummy/app/templates/editable-node.hbs
+++ b/tests/dummy/app/templates/editable-node.hbs
@@ -26,8 +26,18 @@
       </:default>
       <:aside>
         <Sidebar>
+          {{#if this.rdfaEditor}}
+            <ArticleStructurePlugin::ArticleStructureCard
+              @controller={{this.rdfaEditor}}
+              @options={{this.structureConfig}}
+            />
+          {{/if}}
           <Plugins::Link::LinkEditor @controller={{this.rdfaEditor}} />
           {{#if this.activeNode}}
+            <ArticleStructurePlugin::StructureCard
+              @controller={{this.rdfaEditor}}
+              @options={{this.structureConfig}}
+            />
             <this.RdfaEditor
               @node={{this.activeNode}}
               @controller={{this.rdfaEditor}}


### PR DESCRIPTION
### Overview
Correctly support the insertion of any structures in the article structures plugin.

All comments should have been addressed, with the exception of pressing enter in the titles, which still creates a whole new structure with a new title. There are some design issues, but since we'll need to overhaul the design for editable nodes, I haven't done any tweaking.

##### connected issues and PRs:
This is made towards #357 with the intent that it collects all of the related changes rather than them being merged straight to master.
[PR on editor repo](https://github.com/lblod/ember-rdfa-editor/pull/1062)

### Setup
The 'editable nodes' route should now have the article structure plugin enabled.

### How to test/reproduce
Inserting structure elements should function as expected.

### Challenges/uncertainties


### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
