### PR TITLE
GN-4617: disable space-invisible in dummy app

### DIFF
--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -74,7 +74,6 @@ import {
   hardBreak,
   heading as headingInvisible,
   paragraph as paragraphInvisible,
-  space,
 } from '@lblod/ember-rdfa-editor/plugins/invisibles';
 
 import { atLeastOneArticleContainer } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/decision-plugin/utils/validation-rules';
@@ -299,12 +298,9 @@ export default class BesluitSampleController extends Controller {
     linkPasteHandler(this.schema.nodes.link),
     this.citationPlugin,
     this.validationPlugin,
-    createInvisiblesPlugin(
-      [space, hardBreak, paragraphInvisible, headingInvisible],
-      {
-        shouldShowInvisibles: false,
-      },
-    ),
+    createInvisiblesPlugin([hardBreak, paragraphInvisible, headingInvisible], {
+      shouldShowInvisibles: false,
+    }),
   ];
 
   @action

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -56,7 +56,6 @@ import {
   hardBreak,
   heading as headingInvisible,
   paragraph as paragraphInvisible,
-  space,
 } from '@lblod/ember-rdfa-editor/plugins/invisibles';
 import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
 import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
@@ -269,12 +268,9 @@ export default class RegulatoryStatementSampleController extends Controller {
     tablePlugin,
     tableKeymap,
     linkPasteHandler(this.schema.nodes.link),
-    createInvisiblesPlugin(
-      [space, hardBreak, paragraphInvisible, headingInvisible],
-      {
-        shouldShowInvisibles: false,
-      },
-    ),
+    createInvisiblesPlugin([hardBreak, paragraphInvisible, headingInvisible], {
+      shouldShowInvisibles: false,
+    }),
     emberApplication({ application: getOwner(this) }),
   ];
 


### PR DESCRIPTION
### Overview
This PR disables the `space` invisible in the dummy application as it causes large slowdowns when pasting large documents/typing in large documents.

The other formatting marks (pilcrow and carriage return) do not cause a large slowdown as they are way more sparse.

##### connected issues and PRs:
[GN-4617](https://binnenland.atlassian.net/browse/GN-4617?atlOrigin=eyJpIjoiODUxN2E2NWYzZWQ0NGMxMDk0NzNlNmUxNDEwY2I4ZTUiLCJwIjoiaiJ9)
https://github.com/lblod/ember-rdfa-editor/pull/1057

### How to test/reproduce
See https://github.com/lblod/ember-rdfa-editor/pull/1057

Note: this PR does not contain any changesets as it only contains internal changes.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
