### PR TITLE
Add incredibly small plugin for highlighting text as redacted

### DIFF
--- a/.changeset/unlucky-otters-press.md
+++ b/.changeset/unlucky-otters-press.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add incredibly small plugin for highlighting text as redacted

--- a/README.md
+++ b/README.md
@@ -810,6 +810,36 @@ Template comments have a specific style that can be imported in the stylesheet w
 @import 'template-comments-plugin';
 ```
 
+## confidentiality-plugin
+
+A very small plugin which allows for marking parts of text as redacted and including the styles to make this visible.
+
+To enable the plugin you need to add the `MarkSpec` to the `Schema`:
+
+``` js
+import { redacted } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/confidentiality-plugin/marks/redacted';
+// ...
+new Schema({
+  // ...
+  marks: {
+    // ...
+    redacted,
+  },
+});
+```
+
+You can then add the button to the toolbar, passing it the `SayController`:
+
+``` hbs
+<ConfidentialityPlugin::Toolbar @controller={{this.controller}} />
+```
+
+To see the redactions you'll need to add styles that target the `[property='ext:redacted']` selector, which can be done easily in Sass by importing the included stylesheet:
+
+``` scss
+@import 'confidentiality-plugin';
+```
+
 ## Embroider
 To use `@lblod/ember-rdfa-editor-lblod-plugins` with Embroider some extra Webpack configuration is needed, which you can import like this:
 

--- a/addon/components/confidentiality-plugin/redact.hbs
+++ b/addon/components/confidentiality-plugin/redact.hbs
@@ -1,0 +1,6 @@
+<Toolbar::Mark
+  @icon="not-visible"
+  @title={{t 'confidentiality-plugin.redact'}}
+  @mark="redacted"
+  @controller={{@controller}}
+/>

--- a/addon/components/confidentiality-plugin/toolbar.hbs
+++ b/addon/components/confidentiality-plugin/toolbar.hbs
@@ -1,0 +1,1 @@
+<ConfidentialityPlugin::Redact @controller={{@controller}}/>

--- a/addon/plugins/confidentiality-plugin/index.ts
+++ b/addon/plugins/confidentiality-plugin/index.ts
@@ -1,0 +1,1 @@
+export { redacted } from './marks/redacted';

--- a/addon/plugins/confidentiality-plugin/marks/redacted.ts
+++ b/addon/plugins/confidentiality-plugin/marks/redacted.ts
@@ -1,0 +1,24 @@
+import { MarkSpec } from 'prosemirror-model';
+import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { hasRDFaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+
+export const redacted: MarkSpec = {
+  toDOM(_node) {
+    return ['span', { property: EXT('redacted').prefixed }, 0];
+  },
+  parseDOM: [
+    {
+      tag: 'span',
+      getAttrs(value) {
+        if (typeof value === 'string') {
+          return false;
+        }
+        return (
+          hasRDFaAttribute(value, 'property', EXT('redacted')) && {
+            property: value.getAttribute('property'),
+          }
+        );
+      },
+    },
+  ],
+};

--- a/app/components/confidentiality-plugin/redact.js
+++ b/app/components/confidentiality-plugin/redact.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/confidentiality-plugin/redact';

--- a/app/components/confidentiality-plugin/toolbar.js
+++ b/app/components/confidentiality-plugin/toolbar.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/confidentiality-plugin/toolbar';

--- a/app/styles/confidentiality-plugin.scss
+++ b/app/styles/confidentiality-plugin.scss
@@ -1,0 +1,8 @@
+@import 'ember-appuniversum';
+
+.rdfa-annotations {
+  [property='ext:redacted'] {
+    background-color: var(--au-red-400);
+    border: 1px solid var(--au-red-600);
+  }
+}

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -97,6 +97,7 @@ import {
   date,
   dateView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/date';
+import { redacted } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/confidentiality-plugin/marks/redacted';
 
 export default class BesluitSampleController extends Controller {
   @service declare importRdfaSnippet: importRdfaSnippet;
@@ -202,6 +203,7 @@ export default class BesluitSampleController extends Controller {
         strong,
         underline,
         strikethrough,
+        redacted,
       },
     });
   }

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -91,6 +91,8 @@ import DateInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/
 import LocationInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/location/insert';
 import CodelistInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/codelist/insert';
 import VariablePluginAddressInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/insert-variable';
+import { redacted } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/confidentiality-plugin/marks/redacted';
+
 export default class RegulatoryStatementSampleController extends Controller {
   @service declare importRdfaSnippet: ImportRdfaSnippet;
   @service declare intl: IntlService;
@@ -143,6 +145,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       strong,
       underline,
       strikethrough,
+      redacted,
     },
   });
 

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -14,6 +14,7 @@
 @import 'document-title-plugin';
 @import 'snippet-plugin';
 @import 'template-comments-plugin';
+@import 'confidentiality-plugin';
 
 div.table-of-contents {
   padding: $au-unit-small !important;

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -26,6 +26,9 @@
                 <Toolbar::Styling @controller={{this.controller}} />
               </Tb.Group>
               <Tb.Group>
+                <ConfidentialityPlugin::Toolbar @controller={{this.controller}} />
+              </Tb.Group>
+              <Tb.Group>
                 <Toolbar::List @controller={{this.controller}} />
                 <Plugins::Indentation::IndentationMenu
                   @controller={{this.controller}}

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -26,6 +26,9 @@
               <Toolbar::Styling @controller={{this.controller}}/>
             </Tb.Group>
             <Tb.Group>
+              <ConfidentialityPlugin::Toolbar @controller={{this.controller}} />
+            </Tb.Group>
+            <Tb.Group>
               <Toolbar::List @controller={{this.controller}}/>
               <Plugins::Indentation::IndentationMenu
                 @controller={{this.controller}}

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -377,3 +377,6 @@ editor-plugins:
         contact: In case of persisting issues, contact <a href="mailto:{email}">{email}</a>.
     nodeview:
       placeholder: Insert address
+
+confidentiality-plugin:
+  redact: Redact

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -381,3 +381,6 @@ editor-plugins:
         contact: Bij blijvende problemen, contacteer <a href="mailto:{email}">{email}</a>.
     nodeview:
       placeholder: Voeg adres in
+
+confidentiality-plugin:
+  redact: Redigeren


### PR DESCRIPTION
### Overview
Just adds a property and a style to highlight that property.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4627

### Setup
N/A

### How to test/reproduce
You should see a new icon in the test toolbar with an icon of an eye with a cross through it, which will add the redacted property to the highlighted text and you should see the styling.

### Challenges/uncertainties
All the build problems...

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
