### PR TITLE
Backwards compatability of article structure nodes

### DIFF
--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -1,6 +1,7 @@
 import { Fragment, NodeSpec, RdfaAttrs } from '@lblod/ember-rdfa-editor';
 import {
   getRdfaAttrs,
+  getRdfaContentElement,
   rdfaAttrSpec,
   renderRdfaAware,
 } from '@lblod/ember-rdfa-editor/core/schema';
@@ -183,7 +184,7 @@ export const article_paragraph: NodeSpec = {
         }
         return false;
       },
-      contentElement: '[data-content-container~="true"]',
+      contentElement: getRdfaContentElement,
     },
     // Parsing rule for backwards compatibility (when content was not inside seperate say:body div)
     {

--- a/addon/plugins/article-structure-plugin/structures/structure-header-number.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header-number.ts
@@ -1,6 +1,9 @@
 import { NodeSpec } from 'prosemirror-model';
 import { getRdfaAttrs, rdfaAttrSpec } from '@lblod/ember-rdfa-editor';
-import { renderRdfaAware } from '@lblod/ember-rdfa-editor/core/schema';
+import {
+  getRdfaContentElement,
+  renderRdfaAware,
+} from '@lblod/ember-rdfa-editor/core/schema';
 import { ELI } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { hasBacklink } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 
@@ -31,7 +34,7 @@ export const structure_header_number: NodeSpec = {
         }
         return false;
       },
-      contentElement: '[data-content-container~="true"]',
+      contentElement: getRdfaContentElement,
     },
   ],
 };

--- a/addon/plugins/article-structure-plugin/structures/structure-header-title.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header-title.ts
@@ -1,12 +1,15 @@
 import { NodeSpec } from 'prosemirror-model';
 import { getRdfaAttrs, rdfaAttrSpec } from '@lblod/ember-rdfa-editor';
-import { renderRdfaAware } from '@lblod/ember-rdfa-editor/core/schema';
+import {
+  getRdfaContentElement,
+  renderRdfaAware,
+} from '@lblod/ember-rdfa-editor/core/schema';
 import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { hasBacklink } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 
 export const structure_header_title: NodeSpec = {
   attrs: rdfaAttrSpec,
-  content: 'text*',
+  content: 'placeholder|text*',
   inline: true,
   editable: true,
   hasRdfa: true,
@@ -28,7 +31,7 @@ export const structure_header_title: NodeSpec = {
         }
         return false;
       },
-      contentElement: '[data-content-container~="true"]',
+      contentElement: getRdfaContentElement,
     },
   ],
 };

--- a/addon/plugins/article-structure-plugin/structures/structure-header.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header.ts
@@ -88,6 +88,10 @@ export function constructStructureHeader({
     ...beforeNumberNodes,
     schema.node('structure_header_number', numberAttrs, schema.text(number)),
     ...afterNumberNodes,
-    schema.node('structure_header_title', titleAttrs, schema.text(titleText)),
+    schema.node(
+      'structure_header_title',
+      titleAttrs,
+      schema.node('placeholder', { placeholderText: titleText }),
+    ),
   ]);
 }

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -8,6 +8,7 @@ import {
 } from '@lblod/ember-rdfa-editor';
 import {
   getRdfaAttrs,
+  getRdfaContentElement,
   renderRdfaAware,
 } from '@lblod/ember-rdfa-editor/core/schema';
 import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
@@ -58,6 +59,7 @@ export function constructStructureNodeSpec(config: {
     parseDOM: [
       {
         tag: 'div',
+        preserveWhitespace: false,
         getAttrs(element: HTMLElement) {
           const rdfaAttrs = getRdfaAttrs(element);
           if (hasParsedRDFaAttribute(rdfaAttrs, RDF('type'), type)) {
@@ -112,7 +114,7 @@ export function constructStructureBodyNodeSpec(config: {
           }
           return false;
         },
-        contentElement: `${tag}[data-content-container="true"]`,
+        contentElement: getRdfaContentElement,
       },
     ],
   };
@@ -195,7 +197,7 @@ export function constructStructureHeaderNodeSpec({
 
           return false;
         },
-        contentElement: '[data-content-container="true"]',
+        contentElement: getRdfaContentElement,
       },
     ],
   };

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -153,7 +153,7 @@ export default class EditableBlockController extends Controller {
       ],
     }),
     emberApplication({ application: getOwner(this) }),
-    editableNodePlugin,
+    editableNodePlugin(),
   ];
 
   @tracked nodeViews = (controller: SayController) => {


### PR DESCRIPTION
### Overview
Use the (now exported) `getRdfaContentElement` helper to target the content-container element in article structure nodes in a way that supports importing the content directly if this element does not exist. This allows to correctly import pre-rdfa-aware html documents.

##### connected issues and PRs:
Depends on https://github.com/lblod/ember-rdfa-editor/pull/1077

### Setup
Need to link the [feat/content-predicate](https://github.com/lblod/ember-rdfa-editor/tree/feat/content-predicate) branch of the editor.

### How to test/reproduce
Get an export from an old version of the article structure plugin, for example from staging. Set the variable `presetContent` in `tests/dummy/app/controllers/besluit-sample.ts#334` to be equal to this html. Alternatively you can add it to the sample-data.ts of your locally linked editor repo.

### Challenges/uncertainties
There are some issues with the exact content of some properties, for example those with datatype 'rdf:XMLLiteral` as the html has changed.
