### PR TITLE
Increase `@appuniversum/ember-appuniversum` peerdependency requirement to `^2.15.0`

### DIFF
--- a/.changeset/strange-rockets-deliver.md
+++ b/.changeset/strange-rockets-deliver.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': major
+---
+
+Increase `@appuniversum/ember-appuniversum` peerdependency requirement to `^2.15.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.4.2",
+        "@appuniversum/ember-appuniversum": "2.15.0",
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.26.2",
         "@ember/optional-features": "^2.0.0",
@@ -124,7 +124,7 @@
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.4.2",
+        "@appuniversum/ember-appuniversum": "^2.15.0",
         "@ember/string": "3.x",
         "@glint/template": "^1.1.0",
         "@lblod/ember-rdfa-editor": "^6.0.0 || ^7.0.1 || ^8.0.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.4.2",
+    "@appuniversum/ember-appuniversum": "2.15.0",
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.2",
     "@ember/optional-features": "^2.0.0",
@@ -142,7 +142,7 @@
     "webpack": "^5.74.0"
   },
   "peerDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.4.2",
+    "@appuniversum/ember-appuniversum": "^2.15.0",
     "@ember/string": "3.x",
     "@glint/template": "^1.1.0",
     "@lblod/ember-rdfa-editor": "^6.0.0 || ^7.0.1 || ^8.0.1",


### PR DESCRIPTION
### Overview
This PR includes an increase of the peerdependency requirement of `@appuniversum/ember-appuniversum` package to `^2.15.0`.

The main reason for this stricter requirement is to be able to use features of the more recent versions of the package.

Additionally, this PR also pins the `@appuniversum/ember-appuniversum` to the lowest supported version (2.15.0).

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
