### PR TITLE
Stricten `ember-concurrency` peerdep to `^2.3.7 || ^3.1.0`

### DIFF
--- a/.changeset/clean-eagles-kiss.md
+++ b/.changeset/clean-eagles-kiss.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': major
+---
+
+Stricten `ember-concurrency` peerdep to `^2.3.7 || ^3.1.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "ember-auto-import": "~2.6.3",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.1.1",
-        "ember-concurrency": "^2.x || ^3.1.0",
+        "ember-concurrency": "2.3.7",
         "ember-mu-transform-helpers": "^2.0.0",
         "ember-resources": "^6.1.1",
         "ember-velcro": "^2.1.0",
@@ -128,7 +128,7 @@
         "@ember/string": "3.x",
         "@glint/template": "^1.1.0",
         "@lblod/ember-rdfa-editor": "^6.0.0 || ^7.0.1 || ^8.0.1",
-        "ember-concurrency": "2.x || ^3.1.0",
+        "ember-concurrency": "^2.3.7 || ^3.1.0",
         "ember-modifier": "^3.2.7",
         "ember-power-select": "6.x || 7.x",
         "ember-source": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-auto-import": "~2.6.3",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",
-    "ember-concurrency": "^2.x || ^3.1.0",
+    "ember-concurrency": "2.3.7",
     "ember-mu-transform-helpers": "^2.0.0",
     "ember-resources": "^6.1.1",
     "ember-velcro": "^2.1.0",
@@ -146,7 +146,7 @@
     "@ember/string": "3.x",
     "@glint/template": "^1.1.0",
     "@lblod/ember-rdfa-editor": "^6.0.0 || ^7.0.1 || ^8.0.1",
-    "ember-concurrency": "2.x || ^3.1.0",
+    "ember-concurrency": "^2.3.7 || ^3.1.0",
     "ember-modifier": "^3.2.7",
     "ember-power-select": "6.x || 7.x",
     "ember-source": "^4.8.0"


### PR DESCRIPTION
### Overview
This PR drops support for `ember-concurrency` versions lower than `2.3.7`.
Additionally, it pins the `ember-concurrency` dev-dependency to the lowest supported version (2.3.7).

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
