### PR TITLE
Drop support for ember 4.8

### DIFF
--- a/.changeset/little-news-protect.md
+++ b/.changeset/little-news-protect.md
@@ -1,0 +1,6 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': major
+---
+
+Drop `ember-source` 4.8.x support.
+The supported `ember-source` version range is now `^4.12.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "ember-qunit": "^6.0.0",
         "ember-resolver": "^11.0.1",
         "ember-simple-auth": "4.2.2",
-        "ember-source": "~4.12.0",
+        "ember-source": "4.12.0",
         "ember-source-channel-url": "^3.0.0",
         "ember-template-lint": "^5.11.2",
         "ember-try": "^2.0.0",
@@ -131,7 +131,7 @@
         "ember-concurrency": "2.x || ^3.1.0",
         "ember-modifier": "^3.2.7",
         "ember-power-select": "6.x || 7.x",
-        "ember-source": "^4.8.0"
+        "ember-source": "^4.12.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -17553,15 +17553,14 @@
       }
     },
     "node_modules/ember-source": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-4.12.3.tgz",
-      "integrity": "sha512-UuFpMWf931pEWBPuujkaMYhsoPvFyZc+tMYjlUn7um20uL+hWs+k2n/TxMVuxydSzJLnxrXz81nTwbYIlgRWdw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-4.12.0.tgz",
+      "integrity": "sha512-h0lV902A4Mny2eiqXPy15uXXoCc7BnUegE4axLAy4IoxEkJ1o5h0aLJFiB4Tzb1htx8vgHjJz//Y5Jig7NSDTw==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/plugin-transform-block-scoping": "^7.20.5",
         "@ember/edition-utils": "^1.2.0",
         "@glimmer/vm-babel-plugins": "0.84.2",
-        "@simple-dom/interface": "^1.4.0",
         "babel-plugin-debug-macros": "^0.3.4",
         "babel-plugin-filter-imports": "^4.0.0",
         "broccoli-concat": "^4.2.5",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "ember-qunit": "^6.0.0",
     "ember-resolver": "^11.0.1",
     "ember-simple-auth": "4.2.2",
-    "ember-source": "~4.12.0",
+    "ember-source": "4.12.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.11.2",
     "ember-try": "^2.0.0",
@@ -149,7 +149,7 @@
     "ember-concurrency": "2.x || ^3.1.0",
     "ember-modifier": "^3.2.7",
     "ember-power-select": "6.x || 7.x",
-    "ember-source": "^4.8.0"
+    "ember-source": "^4.12.0"
   },
   "overrides": {
     "ember-intl": {


### PR DESCRIPTION
### Overview
This PR drops support for ember 4.8.
The supported `ember-source` version range is now `^4.12.0`
Ember 5.x is not yet officially supported.

Additionally, this PR also pins the `ember-source` devdep to the lowest supported version (4.12.0).

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
