### PR TITLE
Pin devdependencies which are included as peerdependencies to the lowest supported version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
         "ember-disable-prototype-extensions": "^1.1.3",
         "ember-intl": "^5.7.2",
         "ember-load-initializers": "^2.1.2",
+        "ember-modifier": "3.2.7",
         "ember-page-title": "^8.0.0",
         "ember-power-select": "^7.1.2",
         "ember-qunit": "^6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "ember-load-initializers": "^2.1.2",
         "ember-modifier": "3.2.7",
         "ember-page-title": "^8.0.0",
-        "ember-power-select": "^7.1.2",
+        "ember-power-select": "6.0.0",
         "ember-qunit": "^6.0.0",
         "ember-resolver": "^11.0.1",
         "ember-simple-auth": "4.2.2",
@@ -2772,6 +2772,18 @@
       "version": "0.0.4",
       "license": "MIT"
     },
+    "node_modules/@ember-decorators/utils": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@ember-decorators/utils/-/utils-6.1.1.tgz",
+      "integrity": "sha512-0KqnoeoLKb6AyoSU65TRF5T85wmS4uDn06oARddwNPxxf/lt5jQlh41uX3W7V/fWL9tPu8x1L1Vvpc80MN1+YA==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.1.3"
+      },
+      "engines": {
+        "node": ">= 8.*"
+      }
+    },
     "node_modules/@ember/edition-utils": {
       "version": "1.2.0",
       "license": "MIT"
@@ -2966,6 +2978,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.1.1.tgz",
       "integrity": "sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==",
+      "peer": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6"
       },
@@ -12736,29 +12749,141 @@
       }
     },
     "node_modules/ember-basic-dropdown": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-7.2.2.tgz",
-      "integrity": "sha512-H8mNW9nL2gJG59wkX6V+9S0PWktxvF1hGkRvlqaeegLCnCl9ML+z1QXxt8eMNdaVj7+7BXZ3nKy0mU9wMuxRIQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-6.0.2.tgz",
+      "integrity": "sha512-JgI/cy7eS/Y2WoQl7B2Mko/1aFTAlxr5d+KpQeH7rBKOFml7IQtLvhiDQrpU/FLkrQ9aLNEJtzwtDZV1xQxAKA==",
       "dev": true,
       "dependencies": {
-        "@ember/render-modifiers": "^2.0.5",
-        "@embroider/macros": "^1.12.0",
-        "@embroider/util": "^1.11.0",
-        "@glimmer/component": "^1.1.2",
-        "@glimmer/tracking": "^1.1.2",
-        "ember-auto-import": "^2.6.3",
+        "@ember/render-modifiers": "^2.0.4",
+        "@embroider/macros": "^1.2.0",
+        "@embroider/util": "^1.2.0",
+        "@glimmer/component": "^1.0.4",
+        "@glimmer/tracking": "^1.0.4",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.2.0",
-        "ember-cli-typescript": "^5.2.1",
-        "ember-element-helper": "^0.8.2",
+        "ember-cli-htmlbars": "^6.0.1",
+        "ember-cli-typescript": "^4.2.1",
+        "ember-element-helper": "^0.6.0",
         "ember-get-config": "^2.1.1",
-        "ember-maybe-in-element": "^2.1.0",
-        "ember-modifier": "^3.2.7 || ^4.0.0",
-        "ember-style-modifier": "^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0",
+        "ember-maybe-in-element": "^2.0.3",
+        "ember-modifier": "^3.2.7",
+        "ember-style-modifier": "^0.8.0 || ^1.0.0",
         "ember-truth-helpers": "^2.1.0 || ^3.0.0"
       },
       "engines": {
-        "node": "16.* || >= 18"
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/ember-basic-dropdown/node_modules/ember-cli-typescript": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
+      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-to-html": "^0.6.15",
+        "broccoli-stew": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "fs-extra": "^9.0.1",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.8.1",
+        "semver": "^7.3.2",
+        "stagehand": "^1.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-basic-dropdown/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/ember-basic-dropdown/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-basic-dropdown/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-basic-dropdown/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/ember-basic-dropdown/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-basic-dropdown/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-basic-dropdown/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/ember-cache-primitive-polyfill": {
@@ -14715,6 +14840,358 @@
         "node": "10.* || 12.* || 14.* || >= 16"
       }
     },
+    "node_modules/ember-concurrency-decorators": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ember-concurrency-decorators/-/ember-concurrency-decorators-2.0.3.tgz",
+      "integrity": "sha512-r6O34YKI/slyYapVsuOPnmaKC4AsmBSwvgcadbdy+jHNj+mnryXPkm+3hhhRnFdlsKUKdEuXvl43lhjhYRLhhA==",
+      "dev": true,
+      "dependencies": {
+        "@ember-decorators/utils": "^6.1.0",
+        "ember-cli-babel": "^7.19.0",
+        "ember-cli-htmlbars": "^4.3.1",
+        "ember-cli-typescript": "^3.1.4"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
+      "integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-typescript": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/async-disk-cache": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
+      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "2.1.0",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.5.3",
+        "rsvp": "^3.0.18",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/async-disk-cache/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/babel-plugin-htmlbars-inline-precompile": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
+      "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==",
+      "dev": true,
+      "engines": {
+        "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/broccoli-output-wrapper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
+      "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
+      "dev": true,
+      "dependencies": {
+        "heimdalljs-logger": "^0.1.10"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/broccoli-persistent-filter": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
+      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
+      "dev": true,
+      "dependencies": {
+        "async-disk-cache": "^1.2.1",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^1.0.0",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^2.6.1",
+        "rsvp": "^4.7.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^1.3.3",
+        "walk-sync": "^1.0.0"
+      },
+      "engines": {
+        "node": "6.* || >= 8.*"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/broccoli-persistent-filter/node_modules/broccoli-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "dev": true,
+      "dependencies": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/broccoli-persistent-filter/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/broccoli-persistent-filter/node_modules/walk-sync": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^1.1.1"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/broccoli-plugin": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
+      "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-node-api": "^1.6.0",
+        "broccoli-output-wrapper": "^2.0.0",
+        "fs-merger": "^3.0.1",
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/ember-cli-htmlbars": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz",
+      "integrity": "sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==",
+      "dev": true,
+      "dependencies": {
+        "@ember/edition-utils": "^1.2.0",
+        "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
+        "broccoli-debug": "^0.6.5",
+        "broccoli-persistent-filter": "^2.3.1",
+        "broccoli-plugin": "^3.1.0",
+        "common-tags": "^1.8.0",
+        "ember-cli-babel-plugin-helpers": "^1.1.0",
+        "fs-tree-diff": "^2.0.1",
+        "hash-for-dep": "^1.5.1",
+        "heimdalljs-logger": "^0.1.10",
+        "json-stable-stringify": "^1.0.1",
+        "semver": "^6.3.0",
+        "strip-bom": "^4.0.0",
+        "walk-sync": "^2.0.2"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/ember-cli-typescript": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz",
+      "integrity": "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.6.0",
+        "@babel/plugin-transform-typescript": "~7.8.0",
+        "ansi-to-html": "^0.6.6",
+        "broccoli-stew": "^3.0.0",
+        "debug": "^4.0.0",
+        "ember-cli-babel-plugin-helpers": "^1.0.0",
+        "execa": "^3.0.0",
+        "fs-extra": "^8.0.0",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.8.1",
+        "semver": "^6.3.0",
+        "stagehand": "^1.0.0",
+        "walk-sync": "^2.0.0"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/ember-cli-typescript/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/execa": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "p-finally": "^2.0.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": "^8.12.0 || >=9.7.0"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/istextorbinary": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
+      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
+      "dev": true,
+      "dependencies": {
+        "binaryextensions": "1 || 2",
+        "editions": "^1.1.1",
+        "textextensions": "1 || 2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/p-finally": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/sync-disk-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
+      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.2.8",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-concurrency-decorators/node_modules/sync-disk-cache/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
     "node_modules/ember-concurrency/node_modules/ember-cli-htmlbars": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
@@ -15591,32 +16068,20 @@
       }
     },
     "node_modules/ember-element-helper": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/ember-element-helper/-/ember-element-helper-0.8.5.tgz",
-      "integrity": "sha512-yZYzuasn6ZC8Nwv0MpaLYGtm68ZxIBSNSe/CYxNWkDdgcuAb2lAG1gx37XkwBIiwPQET0W2agwq7++/HwdMF8g==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/ember-element-helper/-/ember-element-helper-0.6.1.tgz",
+      "integrity": "sha512-YiOdAMlzYul4ulkIoNp8z7iHDfbT1fbut/9xGFRfxDwU/FmF8HtAUB2f1veu/w50HTeZNopa1OV2PCloZ76XlQ==",
       "dev": true,
       "dependencies": {
-        "@embroider/addon-shim": "1.8.3",
-        "@embroider/util": "^1.0.0"
-      },
-      "engines": {
-        "node": "14.* || 16.* || >= 18"
-      },
-      "peerDependencies": {
-        "ember-source": "^3.8 || ^4.0.0 || >= 5.0.0"
-      }
-    },
-    "node_modules/ember-element-helper/node_modules/@embroider/addon-shim": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.3.tgz",
-      "integrity": "sha512-7pyHwzT6ESXc3nZsB8rfnirLkUhQWdvj6CkYH+0MUPN74mX4rslf7pnBqZE/KZkW3uBIaBYvU8fxi0hcKC/Paw==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/shared-internals": "^1.8.3",
-        "semver": "^7.3.5"
+        "@embroider/util": "^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.0.1"
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "ember-source": "^3.8 || 4"
       }
     },
     "node_modules/ember-factory-for-polyfill": {
@@ -17311,26 +17776,139 @@
       }
     },
     "node_modules/ember-power-select": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-7.1.2.tgz",
-      "integrity": "sha512-Iw4gzeieRbpqWd7ndUY35uArxbhBaFZQD5v8QyttaIeBOFl/cQL7Rbyyg01AFVJRfKvbDKVWkbPqgHaoie9rWQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-6.0.0.tgz",
+      "integrity": "sha512-mrsb1e5Q3tBXk6iJLKIhyiqni9Nm7PQJOKyUVZpRNeIuXBzDRwIT/h/HzcvPw+jP/pN89uF4Pp/GYl9MZlgjVQ==",
       "dev": true,
       "dependencies": {
-        "@ember/string": "^3.1.1",
-        "@embroider/util": "^1.11.0",
+        "@embroider/util": "^1.0.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "ember-assign-helper": "^0.4.0",
-        "ember-basic-dropdown": "^7.2.2",
+        "ember-basic-dropdown": "^6.0.0",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.2.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-concurrency": "^2.0.0 || ^3.0.0",
+        "ember-cli-htmlbars": "^6.1.0",
+        "ember-cli-typescript": "^4.2.0",
+        "ember-concurrency": ">=1.0.0 <3",
+        "ember-concurrency-decorators": "^2.0.0",
         "ember-text-measurer": "^0.6.0",
-        "ember-truth-helpers": "^3.1.0"
+        "ember-truth-helpers": "^3.0.0"
       },
       "engines": {
-        "node": "16.* || >= 18"
+        "node": "14.* || >= 16"
+      }
+    },
+    "node_modules/ember-power-select/node_modules/ember-cli-typescript": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
+      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-to-html": "^0.6.15",
+        "broccoli-stew": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "fs-extra": "^9.0.1",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.8.1",
+        "semver": "^7.3.2",
+        "stagehand": "^1.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-power-select/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/ember-power-select/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-power-select/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-power-select/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/ember-power-select/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-power-select/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-power-select/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/ember-qunit": {
@@ -17618,20 +18196,16 @@
       }
     },
     "node_modules/ember-style-modifier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ember-style-modifier/-/ember-style-modifier-3.0.1.tgz",
-      "integrity": "sha512-WHRVIiqY/dpwDtVWlnHW0P4Z+Jha8QEwfaQdIF2ckJL77ZKdjbV2j1XZymS0Nzj61EGx5BM+YEsGL16r3hLv2A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-style-modifier/-/ember-style-modifier-1.0.0.tgz",
+      "integrity": "sha512-ANkYpOeI3/tkRxVz750ymb8cQBqfBTKOUOz4RPRsNys8rlaBiaKEa95XLz1JWfCXCzjmqe8i2cIdnAMix+nb3A==",
       "dev": true,
       "dependencies": {
-        "ember-auto-import": "^2.5.0",
         "ember-cli-babel": "^7.26.11",
-        "ember-modifier": "^3.2.7 || ^4.0.0"
+        "ember-modifier": "^3.2.7"
       },
       "engines": {
-        "node": "14.* || 16.* || >= 18"
-      },
-      "peerDependencies": {
-        "@ember/string": "^3.0.1"
+        "node": "14.* || >= 16"
       }
     },
     "node_modules/ember-template-imports": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@embroider/test-setup": "^3.0.1",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@glint/template": "^1.1.0",
+        "@glint/template": "1.1.0",
         "@lblod/ember-rdfa-editor": "^8.0.1",
         "@rdfjs/types": "^1.1.0",
         "@release-it/keep-a-changelog": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@embroider/test-setup": "^3.0.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@glint/template": "^1.1.0",
+    "@glint/template": "1.1.0",
     "@lblod/ember-rdfa-editor": "^8.0.1",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "3.2.7",
     "ember-page-title": "^8.0.0",
-    "ember-power-select": "^7.1.2",
+    "ember-power-select": "6.0.0",
     "ember-qunit": "^6.0.0",
     "ember-resolver": "^11.0.1",
     "ember-simple-auth": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-intl": "^5.7.2",
     "ember-load-initializers": "^2.1.2",
+    "ember-modifier": "3.2.7",
     "ember-page-title": "^8.0.0",
     "ember-power-select": "^7.1.2",
     "ember-qunit": "^6.0.0",


### PR DESCRIPTION
### Overview
This PR pins the remaining devdependencies which are included as peerdependencies to the lowest supported version.
- `ember-modifier` to 3.2.7
- `@glint/template` to 1.1.0
- `ember-power-select` to 6.0.0

This PR is part of a change of strategy to test this addon with the lowest supported peerdependency versions. This way, we can't accidentally include features of these packages which are not supported by their whole peerdependency range.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
