### PR TITLE
GN-4654: improved template-comment styling

### DIFF
--- a/.changeset/afraid-tips-visit.md
+++ b/.changeset/afraid-tips-visit.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Remove `@import "ember-appuniversum"` statements from plugin sass modules in order to prevent style overrding.

--- a/.changeset/chilly-ravens-think.md
+++ b/.changeset/chilly-ravens-think.md
@@ -1,0 +1,6 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+- Addition of the `say-template-comment` class to the static version of template comments.
+- Addition of some extra styles to the `say-template-comment` class.

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -24,8 +24,8 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
     serialize(_, state) {
       const t = getTranslationFunction(state);
       const heading = t(
-        'template-comments-plugin.heading',
-        'toelichtingsbepaling',
+        'template-comments-plugin.long-title',
+        'Toelichtings- of voorbeeldbepaling',
       );
 
       return [

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -32,8 +32,9 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
         'div',
         {
           typeof: EXT('TemplateComment').prefixed,
+          class: 'say-template-comment',
         },
-        ['h3', {}, heading],
+        ['p', {}, ['strong', {}, heading]],
         ['div', { property: EXT('content').prefixed }, 0],
       ];
     },

--- a/app/styles/citaten-plugin.scss
+++ b/app/styles/citaten-plugin.scss
@@ -1,5 +1,3 @@
-@import "ember-appuniversum";
-
 .citaten--decision-list {
   max-height: 35vh;
   overflow: auto;

--- a/app/styles/confidentiality-plugin.scss
+++ b/app/styles/confidentiality-plugin.scss
@@ -1,5 +1,3 @@
-@import 'ember-appuniversum';
-
 .rdfa-annotations {
   [property='ext:redacted'] {
     background-color: var(--au-red-200);

--- a/app/styles/template-comments-plugin.scss
+++ b/app/styles/template-comments-plugin.scss
@@ -1,5 +1,8 @@
 .say-template-comment {
   color: var(--au-blue-900);
+  padding: var(--au-unit-small);
+  border-radius: var(--au-radius);
+  border: 0.1rem solid var(--au-gray-300);
 
   .au-c-alert__content {
     margin-top: 0;

--- a/app/styles/template-comments-plugin.scss
+++ b/app/styles/template-comments-plugin.scss
@@ -1,5 +1,3 @@
-@import "ember-appuniversum";
-
 .say-template-comment {
   color: var(--au-blue-900);
 


### PR DESCRIPTION
### Overview
This PR contains the following changes/improvements:
- Usage of the same title for template comments in the dynamic and static versions
- Removal of `@import "ember-appuniversum"` statements on top of the different sass modules, in order to prevent style overriding.
- Addition of the `say-template-comment` class to the static version of template comments.
- Addition of some extra styles to the `say-template-comment` class.

##### connected issues and PRs:
- Solves [GN-4654](https://binnenland.atlassian.net/browse/GN-4654?atlOrigin=eyJpIjoiZGQ5MDdlY2NlMzZkNDZlZjkyYzcyOGI4NDc1NzU2MDEiLCJwIjoiaiJ9) partially
- https://github.com/lblod/frontend-reglementaire-bijlage/pull/220


### Setup
- `npm link`
- `npm link @lblod/ember-rdfa-editor-lblod-plugins` on master of `frontend-reglementaire-bijlagen`

### How to test/reproduce
- Start the `frontend-reglementaire-bijlagen` application
- Open a template and insert a template comment
- Observe the change in styling of the template comment in the template publishing preview
- Observe the title change of the template comment in the template publishing preview

### Challenges/uncertainties
- This PR also includes the removal of `ember-appuniversum` import statements on top of some sass modules, as that import statement was overriding css rules defined in previously loaded modules. I'm not sure what the best approach is here, but I think importing the `ember-appuniversum` module once in the `app.scss` file is the way to go.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
