### PR TITLE
Differentiate between uri and url of citations

### DIFF
--- a/.changeset/heavy-houses-shave.md
+++ b/.changeset/heavy-houses-shave.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add both a url and uri to citation links

--- a/addon/components/citation-plugin/citation-card.ts
+++ b/addon/components/citation-plugin/citation-card.ts
@@ -206,6 +206,7 @@ export default class CitationCardComponent extends Component<Args> {
   @action
   insertLegalDocumentCitation(legalDocument: LegalDocument): void {
     const uri = legalDocument.uri;
+    const url = legalDocument.meta?.publicationLink ?? uri;
     const title = legalDocument.title ?? '';
     const { from, to } = unwrap(this.activeDecoration);
     this.controller.withTransaction(
@@ -214,7 +215,11 @@ export default class CitationCardComponent extends Component<Args> {
           .replaceRangeWith(
             from,
             to,
-            citedText(this.controller.schema, title, uri),
+            citedText(this.controller.schema, {
+              title,
+              uri,
+              url,
+            }),
           )
           .scrollIntoView(),
       { view: this.controller.mainEditorView },
@@ -236,7 +241,11 @@ export default class CitationCardComponent extends Component<Args> {
           .replaceRangeWith(
             from,
             to,
-            citedText(this.controller.schema, title, uri),
+            citedText(this.controller.schema, {
+              title,
+              uri,
+              url: uri,
+            }),
           )
           .scrollIntoView(),
       { view: this.controller.mainEditorView },

--- a/addon/components/citation-plugin/citation-insert.ts
+++ b/addon/components/citation-plugin/citation-insert.ts
@@ -107,6 +107,7 @@ export default class EditorPluginsCitationInsertComponent extends Component<Args
   insertLegalDocumentCitation(legalDocument: LegalDocument) {
     const type = legalDocument.legislationType?.label || '';
     const uri = legalDocument.uri;
+    const url = legalDocument.meta?.publicationLink ?? uri;
     const title = legalDocument.title ?? '';
     this.controller.withTransaction(
       (tr: Transaction) =>
@@ -115,7 +116,11 @@ export default class EditorPluginsCitationInsertComponent extends Component<Args
             new Slice(
               Fragment.fromArray([
                 this.controller.schema.text(`${type} `),
-                citedText(this.controller.schema, title, uri),
+                citedText(this.controller.schema, {
+                  title,
+                  uri,
+                  url,
+                }),
               ]),
               0,
               0,
@@ -139,7 +144,11 @@ export default class EditorPluginsCitationInsertComponent extends Component<Args
       (tr: Transaction) =>
         tr.replaceWith(from, to, [
           this.controller.schema.text(`${type} `),
-          citedText(this.controller.schema, title, uri),
+          citedText(this.controller.schema, {
+            title,
+            uri,
+            url: uri,
+          }),
         ]),
       { view: this.controller.mainEditorView },
     );

--- a/addon/plugins/citation-plugin/utils/cited-text.ts
+++ b/addon/plugins/citation-plugin/utils/cited-text.ts
@@ -2,15 +2,19 @@ import { PNode } from '@lblod/ember-rdfa-editor';
 import { CitationSchema } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 
-export function citedText(
-  schema: CitationSchema,
-  title: string,
-  uri: string,
-): PNode {
+type Citation = {
+  title: string;
+  uri: string;
+  url: string;
+};
+
+export function citedText(schema: CitationSchema, citation: Citation): PNode {
+  const { title, uri, url } = citation;
   return unwrap(schema.nodes.link).create(
     {
-      href: uri,
       property: 'eli:cites',
+      resource: uri,
+      href: url,
       typeof: 'eli:LegalExpression',
     },
     [schema.text(title)],

--- a/addon/plugins/citation-plugin/utils/legal-documents.ts
+++ b/addon/plugins/citation-plugin/utils/legal-documents.ts
@@ -6,13 +6,16 @@ import { fetchVlaamseCodexLegalDocuments } from '@lblod/ember-rdfa-editor-lblod-
 import { Option } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { fetchPublicDecisions } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin/utils/public-decisions';
 
+type LegalDocumentMeta = {
+  publicationLink?: string | null;
+};
 interface LegalDocumentArgs {
   uri: string;
   legislationTypeUri: Option<string>;
   title: string | null;
   publicationDate: string | null;
   documentDate: string | null;
-  meta?: Record<string, unknown> | null;
+  meta?: LegalDocumentMeta | null;
 }
 
 export class LegalDocument {
@@ -21,7 +24,7 @@ export class LegalDocument {
   title: string | null;
   publicationDate: string | null;
   documentDate: string | null;
-  meta: Record<string, unknown> | null;
+  meta: LegalDocumentMeta | null;
 
   constructor({
     uri,


### PR DESCRIPTION
### Overview
This PR ensures that both a uri (`resource`) and url (`href`) can be added to a citation-link. This is relevant in case these are not the same (for example for published municipality-decisions).

##### connected issues and PRs:
[GN-4682](https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?selectedIssue=GN-4682)

### How to test/reproduce
- Open the `besluit sample` page of the dummy app
- Insert the sample `DecisionTemplate`
- Open the `insert citation` modal
- Select `Municipality decision` from the dropdown
- Insert a link to a decision
- Notice (e.g. in the output or prosemirror devtools) that the resource and href of the inserted citation are different:
   * The `resource` should have the following form: `http://data.lblod.info/id/besluiten/ccae56d0-10b1-4a19-9ddd-7cc3a78ff013`
   * The `href` should have the following form (and is resolvable!): `https://publicatie.gelinkt-notuleren.lblod.info/Edegem/Gemeente/zittingen/fc268e00-ae3c-11ee-b234-65fc68d7dda7/uittreksels/fd6ca290-ae3c-11ee-b234-65fc68d7dda7`

### Challenges/uncertainties
- The url (`href`) of a decision citation does not employ the cool-uri format yet, as cool-uris for decisions have not yet been added to the publication platform. It is probably better to implement this using cool-uris right away, in order to prevent unresolvable urls in the future.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
