### PR TITLE
GN-4650: Fix behavior of "Insert snippet" button

### DIFF
--- a/.changeset/hot-owls-laugh.md
+++ b/.changeset/hot-owls-laugh.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+GN-4650: Fix behavior of "Insert snippet" button

--- a/addon/components/snippet-plugin/snippet-insert-rdfa.hbs
+++ b/addon/components/snippet-plugin/snippet-insert-rdfa.hbs
@@ -1,7 +1,6 @@
-{{#if this.showInsert}}
-  <SnippetPlugin::SnippetInsert
-    @config={{this.config}}
-    @controller={{this.controller}}
-    @assignedSnippetListsIds={{this.assignedSnippetListsIds}}
-  />
-{{/if}}
+<SnippetPlugin::SnippetInsert
+  @config={{this.config}}
+  @controller={{this.controller}}
+  @assignedSnippetListsIds={{this.assignedSnippetListsIds}}
+  @disabled={{not this.showInsert}}
+/>

--- a/addon/components/snippet-plugin/snippet-insert.hbs
+++ b/addon/components/snippet-plugin/snippet-insert.hbs
@@ -3,6 +3,7 @@
     @icon='add'
     @iconAlignment='left'
     @skin='link'
+    @disabled={{this.disabled}}
     {{on 'click' this.openModal}}
   >
     {{t 'snippet-plugin.insert.title'}}

--- a/addon/components/snippet-plugin/snippet-insert.ts
+++ b/addon/components/snippet-plugin/snippet-insert.ts
@@ -10,6 +10,7 @@ interface Args {
   controller: SayController;
   config: SnippetPluginConfig;
   assignedSnippetListsIds: string[];
+  disabled?: boolean;
 }
 
 export default class SnippetInsertComponent extends Component<Args> {
@@ -61,5 +62,9 @@ export default class SnippetInsertComponent extends Component<Args> {
     this.controller.withTransaction((tr) =>
       tr.replaceSelection(this.createSliceFromElement(parsed)),
     );
+  }
+
+  get disabled() {
+    return this.args.disabled ?? false;
   }
 }

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
@@ -15,7 +15,6 @@
           <tr>
             <td class="selectColumn">
               <AuCheckbox
-                @identifier={{snippetList.label}}
                 @onChange={{fn this.onChange snippetList.id}}
                 @checked={{in-array @assignedSnippetListsIds snippetList.id}}
               />


### PR DESCRIPTION
### Overview

* Fix behavior of "Insert snippet" button - The "Insert snippets" button now does not disappear, but becomes disabled instead.
* Remove `@identifier` argument from `AuCheckbox`

##### connected issues and PRs:

* https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/369
* https://binnenland.atlassian.net/browse/GN-4650

### Setup

1. Checkout this branch
2. `npm link` or `yalc the feat/rdfa-links-ui` branch of ember-rdfa-editor

### How to test/reproduce


https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/340a76b4-deb5-4054-91de-8e3abc4b6c29



The "Insert snippets" button now does not disappear, but becomes disabled instead.

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check if dummy app is correctly updated
- [X] Check cancel/go-back flows
- [X] changelog
- [X] npm lint
- [X] no new deprecations
