### PR TITLE
Update to latest version of editor and fix issues with typescript

### DIFF
--- a/addon/components/import-snippet-plugin/card.ts
+++ b/addon/components/import-snippet-plugin/card.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { ProseParser } from '@lblod/ember-rdfa-editor';
-import { SayController } from '@lblod/ember-rdfa-editor';
+import { SayController } from '@lblod/ember-rdfa-editor/index';
 import ImportRdfaSnippet from '@lblod/ember-rdfa-editor-lblod-plugins/services/import-rdfa-snippet';
 import { RdfaSnippet } from '@lblod/ember-rdfa-editor-lblod-plugins/services/import-rdfa-snippet';
 import { findParentNodeOfType } from '@curvenote/prosemirror-utils';

--- a/addon/components/snippet-plugin/snippet-insert-rdfa.ts
+++ b/addon/components/snippet-plugin/snippet-insert-rdfa.ts
@@ -3,13 +3,13 @@ import Component from '@glimmer/component';
 
 import { SayController } from '@lblod/ember-rdfa-editor';
 import { SnippetPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
-import { ResolvedPNode } from '@lblod/ember-rdfa-editor/addon/utils/_private/types';
-import { OutgoingTriple } from '@lblod/ember-rdfa-editor/addon/core/rdfa-processor';
 import { findParentNodeClosestToPos } from '@curvenote/prosemirror-utils';
 import {
   getAssignedSnippetListsIdsFromProperties,
   getSnippetListIdsProperties,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
+import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
+import { ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
 
 interface Args {
   controller: SayController;

--- a/addon/components/snippet-plugin/snippet-list-select-rdfa.ts
+++ b/addon/components/snippet-plugin/snippet-list-select-rdfa.ts
@@ -1,12 +1,7 @@
 import Component from '@glimmer/component';
 import { task } from 'ember-concurrency';
 
-import { ResolvedPNode } from '@lblod/ember-rdfa-editor/addon/utils/_private/types';
-
 import { isResourceNode } from '@lblod/ember-rdfa-editor/utils/node-utils';
-import { OutgoingTriple } from '@lblod/ember-rdfa-editor/addon/core/rdfa-processor';
-
-import SayController from '@lblod/ember-rdfa-editor/addon/core/say-controller';
 
 import { SnippetPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import {
@@ -14,6 +9,9 @@ import {
   getSnippetListIdsProperties,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { updateSnippetIds } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/commands';
+import { ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
+import { SayController } from '@lblod/ember-rdfa-editor';
+import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 
 interface Args {
   controller: SayController;

--- a/addon/components/variable-plugin/address/utils.ts
+++ b/addon/components/variable-plugin/address/utils.ts
@@ -1,4 +1,5 @@
 import { SayController, NodeSelection } from '@lblod/ember-rdfa-editor';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   DCT,
   EXT,
@@ -21,24 +22,20 @@ export function replaceSelectionWithAddress(
         __rdfaId: uuidv4(),
         properties: [
           {
-            type: 'attribute',
             predicate: RDF('type').full,
-            object: EXT('Mapping').full,
+            object: sayDataFactory.namedNode(EXT('Mapping').full),
           },
           {
-            type: 'attribute',
             predicate: EXT('instance').full,
-            object: variableInstance,
+            object: sayDataFactory.namedNode(variableInstance),
           },
           {
-            type: 'attribute',
             predicate: DCT('type').full,
-            object: 'address',
+            object: sayDataFactory.namedNode('address'),
           },
           {
-            type: 'attribute',
             predicate: EXT('label').full,
-            object: label,
+            object: sayDataFactory.namedNode(label || ''),
           },
         ],
       }),

--- a/addon/components/variable-plugin/codelist/insert.ts
+++ b/addon/components/variable-plugin/codelist/insert.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { SayController } from '@lblod/ember-rdfa-editor';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   CodeList,
   fetchCodeListsByPublisher,
@@ -105,38 +106,32 @@ export default class CodelistInsertComponent extends Component<Args> {
         __rdfaId: variableId,
         properties: [
           {
-            type: 'attribute',
             predicate: RDF('type').full,
-            object: EXT('Mapping').full,
+            object: sayDataFactory.namedNode(EXT('Mapping').full),
           },
           {
-            type: 'attribute',
             predicate: EXT('instance').full,
-            object: variableInstance,
+            object: sayDataFactory.namedNode(variableInstance),
           },
           {
-            type: 'attribute',
             predicate: EXT('label').full,
-            object: label,
+            object: sayDataFactory.namedNode(label),
           },
           {
-            type: 'attribute',
             predicate: EXT('codelist').full,
-            object: codelistResource,
+            object: sayDataFactory.namedNode(codelistResource || ''),
           },
           {
-            type: 'attribute',
             predicate: DCT('source').full,
-            object: source,
+            object: sayDataFactory.namedNode(source),
           },
           {
-            type: 'attribute',
             predicate: DCT('type').full,
-            object: 'codelist',
+            object: sayDataFactory.namedNode('codelist'),
           },
           {
-            type: 'content',
             predicate: EXT('content').full,
+            object: sayDataFactory.contentLiteral(),
           },
         ],
       },

--- a/addon/components/variable-plugin/date/insert-variable.ts
+++ b/addon/components/variable-plugin/date/insert-variable.ts
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 import { SayController, Transaction } from '@lblod/ember-rdfa-editor';
 import { v4 as uuidv4 } from 'uuid';
 import IntlService from 'ember-intl/services/intl';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   DCT,
   EXT,
@@ -53,21 +54,21 @@ export default class DateInsertVariableComponent extends Component<Args> {
       __rdfaId: variableId,
       properties: [
         {
-          type: 'attribute',
           predicate: RDF('type').full,
-          object: EXT('Mapping').full,
+          object: sayDataFactory.namedNode(EXT('Mapping').full),
         },
         {
-          type: 'attribute',
           predicate: EXT('instance').full,
-          object: variableInstance,
+          object: sayDataFactory.namedNode(variableInstance),
         },
         {
-          type: 'attribute',
           predicate: EXT('label').full,
-          object: label,
+          object: sayDataFactory.namedNode(label),
         },
-        { type: 'attribute', predicate: DCT('type').full, object: 'date' },
+        {
+          predicate: DCT('type').full,
+          object: sayDataFactory.namedNode('date'),
+        },
       ],
       backlinks: [],
     });

--- a/addon/components/variable-plugin/date/insert.ts
+++ b/addon/components/variable-plugin/date/insert.ts
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import { SayController, Transaction } from '@lblod/ember-rdfa-editor';
 import IntlService from 'ember-intl/services/intl';
 import { v4 as uuidv4 } from 'uuid';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   DCT,
   EXT,
@@ -46,21 +47,21 @@ export default class DateInsertComponent extends Component<Args> {
       __rdfaId: variableId,
       properties: [
         {
-          type: 'attribute',
           predicate: RDF('type').full,
-          object: EXT('Mapping').full,
+          object: sayDataFactory.namedNode(EXT('Mapping').full),
         },
         {
-          type: 'attribute',
           predicate: EXT('instance').full,
-          object: variableInstance,
+          object: sayDataFactory.namedNode(variableInstance),
         },
         {
-          type: 'attribute',
           predicate: EXT('label').full,
-          object: label,
+          object: sayDataFactory.namedNode(label),
         },
-        { type: 'attribute', predicate: DCT('type').full, object: 'date' },
+        {
+          predicate: DCT('type').full,
+          object: sayDataFactory.namedNode('date'),
+        },
       ],
       backlinks: [],
     });

--- a/addon/components/variable-plugin/number/insert.ts
+++ b/addon/components/variable-plugin/number/insert.ts
@@ -7,6 +7,7 @@ import { isNumber } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/strings';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 import { modifier } from 'ember-modifier';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   DCT,
   EXT,
@@ -105,21 +106,21 @@ export default class NumberInsertComponent extends Component<Args> {
       __rdfaId: variableId,
       properties: [
         {
-          type: 'attribute',
           predicate: RDF('type').full,
-          object: EXT('Mapping').full,
+          object: sayDataFactory.namedNode(EXT('Mapping').full),
         },
         {
-          type: 'attribute',
           predicate: EXT('instance').full,
-          object: variableInstance,
+          object: sayDataFactory.namedNode(variableInstance),
         },
         {
-          type: 'attribute',
           predicate: EXT('label').full,
-          object: label,
+          object: sayDataFactory.namedNode(label),
         },
-        { type: 'attribute', predicate: DCT('type').full, object: 'number' },
+        {
+          predicate: DCT('type').full,
+          object: sayDataFactory.namedNode('number'),
+        },
       ],
       ...(isNumber(this.minimumValue) && {
         minimumValue: Number(this.minimumValue),

--- a/addon/components/variable-plugin/text/insert.ts
+++ b/addon/components/variable-plugin/text/insert.ts
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import type { SayController } from '@lblod/ember-rdfa-editor';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { v4 as uuidv4 } from 'uuid';
 import IntlService from 'ember-intl/services/intl';
 import {
@@ -54,24 +55,24 @@ export default class TextVariableInsertComponent extends Component<Args> {
         __rdfaId: variableId,
         properties: [
           {
-            type: 'attribute',
             predicate: RDF('type').full,
-            object: EXT('Mapping').full,
+            object: sayDataFactory.namedNode(EXT('Mapping').full),
           },
           {
-            type: 'attribute',
             predicate: EXT('instance').full,
-            object: variableInstance,
+            object: sayDataFactory.namedNode(variableInstance),
           },
           {
-            type: 'attribute',
             predicate: EXT('label').full,
-            object: label,
+            object: sayDataFactory.namedNode(label),
           },
-          { type: 'attribute', predicate: DCT('type').full, object: 'text' },
           {
-            type: 'content',
+            predicate: DCT('type').full,
+            object: sayDataFactory.namedNode('text'),
+          },
+          {
             predicate: EXT('content').full,
+            object: sayDataFactory.contentLiteral(),
           },
         ],
       },

--- a/addon/components/variable-plugin/text/insert.ts
+++ b/addon/components/variable-plugin/text/insert.ts
@@ -38,7 +38,7 @@ export default class TextVariableInsertComponent extends Component<Args> {
 
   @action
   insert() {
-    const mappingResource = `http://data.lblod.info/mappings/${uuidv4()}`;
+    const mappingSubject = `http://data.lblod.info/mappings/${uuidv4()}`;
     const variableInstance = `http://data.lblod.info/variables/${uuidv4()}`;
     const variableId = uuidv4();
 
@@ -49,8 +49,7 @@ export default class TextVariableInsertComponent extends Component<Args> {
     const label = this.label ?? placeholder;
     const node = this.schema.nodes.text_variable.create(
       {
-        resource: mappingResource,
-        subject: mappingResource,
+        subject: mappingSubject,
         rdfaNodeType: 'resource',
         __rdfaId: variableId,
         properties: [

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -38,7 +38,7 @@ const insertStructure = (
     const containerAttrs = insertionRange.containerNode.attrs;
     if (dispatch && isRdfaAttrs(containerAttrs)) {
       const incoming = containerAttrs.backlinks;
-      const resource = incoming?.find((backlink) =>
+      const subject = incoming?.find((backlink) =>
         SAY('body').matches(backlink.predicate),
       )?.subject;
       const {
@@ -68,10 +68,10 @@ const insertStructure = (
       transaction.scrollIntoView();
       recalculateStructureNumbers(transaction, schema, structureSpec);
 
-      if (resource) {
+      if (subject) {
         const newState = state.apply(transaction);
         addProperty({
-          resource: resource.value,
+          resource: subject.value,
           property: {
             predicate: (structureSpec.relationshipPredicate ?? SAY('hasPart'))
               .prefixed,

--- a/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
+++ b/addon/plugins/article-structure-plugin/commands/wrap-structure-content.ts
@@ -118,12 +118,12 @@ function findInsertionContainer(
   const { $from } = selection;
   let container: ContainerNode | null = null;
   const resourceHierarchy: string[] = [];
-  // Loop from current depth to top looking for a container and resource URIs
+  // Loop from current depth to top looking for a container and subject URIs
   for (let currentDepth = $from.depth; currentDepth >= 0; currentDepth--) {
     const currentAncestor = $from.node(currentDepth);
-    const resource = currentAncestor.attrs?.resource as string | undefined;
-    if (resource) {
-      resourceHierarchy.unshift(resource);
+    const subject = currentAncestor.attrs?.subject as string | undefined;
+    if (subject) {
+      resourceHierarchy.unshift(subject);
     }
     if (!container) {
       const pos = currentDepth > 0 ? $from.before(currentDepth) : -1;
@@ -224,7 +224,7 @@ function findUpdatedRelationships({
     'attrs' in contentToWrap
       ? contentToWrap.attrs
       : contentToWrap.firstChild?.attrs
-  )?.resource as string;
+  )?.subject as string;
 
   const toCreate: [string, string][] = [];
   const toRemove: [string, string][] = [];

--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -44,11 +44,11 @@ export const articleParagraphSpec: StructureSpec = {
     const paragraphRdfaId = uuid();
     const numberRdfaId = uuid();
     const bodyRdfaId = uuid();
-    const resource = `http://data.lblod.info/paragraphs/${paragraphRdfaId}`;
+    const subject = `http://data.lblod.info/paragraphs/${paragraphRdfaId}`;
     const paragraphAttrs: RdfaAttrs = {
       __rdfaId: paragraphRdfaId,
       rdfaNodeType: 'resource',
-      resource,
+      subject,
       properties: [
         {
           predicate: ELI('number').prefixed,
@@ -67,7 +67,7 @@ export const articleParagraphSpec: StructureSpec = {
       backlinks: [
         {
           predicate: ELI('number').prefixed,
-          subject: sayDataFactory.literalNode(resource),
+          subject: sayDataFactory.literalNode(subject),
         },
       ],
     };
@@ -77,7 +77,7 @@ export const articleParagraphSpec: StructureSpec = {
       backlinks: [
         {
           predicate: SAY('body').prefixed,
-          subject: sayDataFactory.literalNode(resource),
+          subject: sayDataFactory.literalNode(subject),
         },
       ],
     };
@@ -109,7 +109,7 @@ export const articleParagraphSpec: StructureSpec = {
     return {
       node,
       selectionConfig: { rdfaId: bodyRdfaId, type: 'node' },
-      newResource: resource,
+      newResource: subject,
     };
   },
   updateNumber: {

--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -248,7 +248,7 @@ export const article_paragraph: NodeSpec = {
           numberSpan
         ) {
           return {
-            resource: element.getAttribute('resource'),
+            subject: element.getAttribute('resource'),
             number: numberSpan.textContent,
           };
         }

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -74,7 +74,7 @@ export const articleSpec: StructureSpec = {
       rdfaNodeType: 'literal',
       backlinks: [
         {
-          subject: sayDataFactory.resourceNode(subject),
+          subject: sayDataFactory.literalNode(subject),
           predicate: SAY('body').prefixed,
         },
       ],

--- a/addon/plugins/article-structure-plugin/structures/article.ts
+++ b/addon/plugins/article-structure-plugin/structures/article.ts
@@ -40,7 +40,7 @@ export const articleSpec: StructureSpec = {
     const headingRdfaId = uuid();
     const numberRdfaId = uuid();
     const bodyRdfaId = uuid();
-    const resource = `http://data.lblod.info/articles/${articleUuid}`;
+    const subject = `http://data.lblod.info/articles/${articleUuid}`;
     const titleText = translationWithDocLang(
       PLACEHOLDERS.title,
       intl?.t(PLACEHOLDERS.title) || '',
@@ -48,7 +48,7 @@ export const articleSpec: StructureSpec = {
     const articleAttrs: RdfaAttrs = {
       __rdfaId: articleUuid,
       rdfaNodeType: 'resource',
-      resource,
+      subject,
       properties: [
         {
           predicate: ELI('number').prefixed,
@@ -74,7 +74,7 @@ export const articleSpec: StructureSpec = {
       rdfaNodeType: 'literal',
       backlinks: [
         {
-          subject: sayDataFactory.resourceNode(resource),
+          subject: sayDataFactory.resourceNode(subject),
           predicate: SAY('body').prefixed,
         },
       ],
@@ -82,7 +82,7 @@ export const articleSpec: StructureSpec = {
     const node = schema.node(`article`, articleAttrs, [
       constructStructureHeader({
         schema,
-        backlinkResource: resource,
+        backlinkResource: subject,
         titleRdfaId,
         titleText,
         headingRdfaId,
@@ -113,7 +113,7 @@ export const articleSpec: StructureSpec = {
         type: content ? 'text' : 'node',
         rdfaId: bodyRdfaId,
       },
-      newResource: resource,
+      newResource: subject,
     };
   },
   updateNumber: {

--- a/addon/plugins/article-structure-plugin/structures/chapter.ts
+++ b/addon/plugins/article-structure-plugin/structures/chapter.ts
@@ -44,11 +44,11 @@ export const chapterSpec: StructureSpec = {
     const titleRdfaId = uuid();
     const numberRdfaId = uuid();
     const bodyRdfaId = uuid();
-    const chapterResource = `http://data.lblod.info/chapters/${chapterUuid}`;
+    const chapterSubject = `http://data.lblod.info/chapters/${chapterUuid}`;
     const chapterAttrs: RdfaAttrs = {
       __rdfaId: chapterUuid,
       rdfaNodeType: 'resource',
-      resource: chapterResource,
+      subject: chapterSubject,
       properties: [
         {
           predicate: ELI('number').prefixed,
@@ -74,7 +74,7 @@ export const chapterSpec: StructureSpec = {
       rdfaNodeType: 'literal',
       backlinks: [
         {
-          subject: sayDataFactory.literalNode(chapterResource),
+          subject: sayDataFactory.literalNode(chapterSubject),
           predicate: SAY('body').prefixed,
         },
       ],
@@ -85,7 +85,7 @@ export const chapterSpec: StructureSpec = {
         titleRdfaId,
         titleText,
         headingRdfaId,
-        backlinkResource: chapterResource,
+        backlinkResource: chapterSubject,
         numberRdfaId,
         number: numberConverted,
         level: 4,
@@ -113,7 +113,7 @@ export const chapterSpec: StructureSpec = {
         type: content ? 'text' : 'node',
         rdfaId: bodyRdfaId,
       },
-      newResource: chapterResource,
+      newResource: chapterSubject,
     };
   },
   updateNumber: {

--- a/addon/plugins/article-structure-plugin/structures/section.ts
+++ b/addon/plugins/article-structure-plugin/structures/section.ts
@@ -40,7 +40,7 @@ export const sectionSpec: StructureSpec = {
     const headingRdfaId = uuid();
     const numberRdfaId = uuid();
     const bodyRdfaId = uuid();
-    const resource = `http://data.lblod.info/sections/${resourceUuid}`;
+    const subject = `http://data.lblod.info/sections/${resourceUuid}`;
     const titleText = translationWithDocLang(
       PLACEHOLDERS.title,
       intl?.t(PLACEHOLDERS.title) || '',
@@ -48,7 +48,7 @@ export const sectionSpec: StructureSpec = {
     const sectionAttrs: RdfaAttrs = {
       __rdfaId: resourceUuid,
       rdfaNodeType: 'resource',
-      resource,
+      subject,
       properties: [
         {
           predicate: ELI('number').prefixed,
@@ -74,7 +74,7 @@ export const sectionSpec: StructureSpec = {
       rdfaNodeType: 'literal',
       backlinks: [
         {
-          subject: sayDataFactory.literalNode(resource),
+          subject: sayDataFactory.literalNode(subject),
           predicate: SAY('body').prefixed,
         },
       ],
@@ -88,7 +88,7 @@ export const sectionSpec: StructureSpec = {
         titleText,
         headingRdfaId,
         numberRdfaId,
-        backlinkResource: resource,
+        backlinkResource: subject,
       }),
       schema.node(
         `section_body`,
@@ -113,7 +113,7 @@ export const sectionSpec: StructureSpec = {
         type: content ? 'text' : 'node',
         rdfaId: bodyRdfaId,
       },
-      newResource: resource,
+      newResource: subject,
     };
   },
   updateNumber: {

--- a/addon/plugins/article-structure-plugin/structures/subsection.ts
+++ b/addon/plugins/article-structure-plugin/structures/subsection.ts
@@ -42,7 +42,7 @@ export const subsectionSpec: StructureSpec = {
     const headingRdfaId = uuid();
     const numberRdfaId = uuid();
     const bodyRdfaId = uuid();
-    const resource = `http://data.lblod.info/subsections/${resourceUuid}`;
+    const subject = `http://data.lblod.info/subsections/${resourceUuid}`;
     const titleText = translationWithDocLang(
       PLACEHOLDERS.title,
       intl?.t(PLACEHOLDERS.title) || '',
@@ -50,7 +50,7 @@ export const subsectionSpec: StructureSpec = {
     const sectionAttrs: RdfaAttrs = {
       __rdfaId: resourceUuid,
       rdfaNodeType: 'resource',
-      resource,
+      subject,
       properties: [
         {
           predicate: ELI('number').prefixed,
@@ -80,7 +80,7 @@ export const subsectionSpec: StructureSpec = {
         titleText,
         headingRdfaId,
         numberRdfaId,
-        backlinkResource: resource,
+        backlinkResource: subject,
       }),
       schema.node(
         `subsection_body`,
@@ -105,7 +105,7 @@ export const subsectionSpec: StructureSpec = {
         type: content ? 'text' : 'node',
         rdfaId: bodyRdfaId,
       },
-      newResource: resource,
+      newResource: subject,
     };
   },
   updateNumber: {

--- a/addon/plugins/article-structure-plugin/structures/title.ts
+++ b/addon/plugins/article-structure-plugin/structures/title.ts
@@ -40,7 +40,6 @@ export const titleSpec: StructureSpec = {
     const headingRdfaId = uuid();
     const numberRdfaId = uuid();
     const bodyRdfaId = uuid();
-    const resource = `http://data.lblod.info/titles/${__rdfaId}`;
     const subject = `http://data.lblod.info/titles/${__rdfaId}`;
     const titleText = translationWithDocLang(
       PLACEHOLDERS.heading,
@@ -49,7 +48,6 @@ export const titleSpec: StructureSpec = {
     const titleAttrs: RdfaAttrs = {
       __rdfaId,
       rdfaNodeType: 'resource',
-      resource,
       subject,
       properties: [
         {

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -45,6 +45,7 @@ export function constructStructureNodeSpec(config: {
       typeof: {
         default: type.prefixed,
       },
+      subject: {},
     },
     allowSplitByTable: config.allowSplitByTable,
     toDOM(node) {

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -39,7 +39,9 @@ export function constructStructureNodeSpec(config: {
     isolating: true,
     attrs: {
       ...rdfaAttrSpec,
-      rdfaNodeType: "resource",
+      rdfaNodeType: {
+        default: 'resource',
+      },
       typeof: {
         default: type.prefixed,
       },

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -39,6 +39,7 @@ export function constructStructureNodeSpec(config: {
     isolating: true,
     attrs: {
       ...rdfaAttrSpec,
+      rdfaNodeType: "resource",
       typeof: {
         default: type.prefixed,
       },

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -42,7 +42,6 @@ export function constructStructureNodeSpec(config: {
       typeof: {
         default: type.prefixed,
       },
-      resource: {},
     },
     allowSplitByTable: config.allowSplitByTable,
     toDOM(node) {

--- a/addon/plugins/snippet-plugin/commands/update-snippet-ids.ts
+++ b/addon/plugins/snippet-plugin/commands/update-snippet-ids.ts
@@ -1,9 +1,9 @@
 import { Command } from '@lblod/ember-rdfa-editor';
 import { addProperty, removeProperty } from '@lblod/ember-rdfa-editor/commands';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
-import { OutgoingTriple } from '@lblod/ember-rdfa-editor/addon/core/rdfa-processor';
 import { SNIPPET_LIST_RDFA_PREDICATE } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { getSnippetUriFromId } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
+import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 
 const updateSnippetIds = ({
   resource,

--- a/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
+++ b/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
@@ -1,5 +1,5 @@
 import { PNode } from '@lblod/ember-rdfa-editor';
-import { OutgoingTriple } from '@lblod/ember-rdfa-editor/addon/core/rdfa-processor';
+import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import { getSnippetIdFromUri } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { getOutgoingTripleList } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -76,7 +76,11 @@ export const besluit_title: NodeSpec = {
       tag: 'h1,h2,h3,h4,h5',
       getAttrs(element: HTMLElement) {
         if (hasRDFaAttribute(element, 'property', ELI('title'))) {
-          return getRdfaAttrs(element);
+          const rdfaAttrs = getRdfaAttrs(element);
+          return {
+            ...rdfaAttrs,
+            subject: element.getAttribute('resource'),
+          }
         }
         return false;
       },
@@ -261,7 +265,7 @@ export const besluit_article: NodeSpec = {
     typeof: {
       default: BESLUIT('Artikel').prefixed,
     },
-    resource: {},
+    subject: {},
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -325,11 +329,11 @@ export const besluitArticleStructure: StructureSpec = {
     const translationWithDocLang = getTranslationFunction(state);
     const numberConverted = number?.toString() ?? '1';
     const articleRdfaId = uuid();
-    const resource = `http://data.lblod.info/articles/${articleRdfaId}`;
+    const subject = `http://data.lblod.info/articles/${articleRdfaId}`;
     const node = schema.node(
       `besluit_article`,
       {
-        resource,
+        subject,
         __rdfaId: articleRdfaId,
       },
       [
@@ -358,7 +362,7 @@ export const besluitArticleStructure: StructureSpec = {
 
     return {
       node,
-      newResource: resource,
+      newResource: subject,
       selectionConfig: {
         type: content ? 'text' : 'node',
         rdfaId: articleRdfaId,
@@ -491,7 +495,7 @@ export const besluit: NodeSpec = {
     typeof: {
       default: 'besluit:Besluit ext:BesluitNieuweStijl',
     },
-    resource: {},
+    subject: {},
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -564,7 +568,7 @@ export const language_node: NodeSpec = {
     typeof: {
       default: 'skos:Concept',
     },
-    resource: {
+    subject: {
       default: 'http://publications.europa.eu/resource/authority/language/NLD',
     },
   },
@@ -578,8 +582,7 @@ export const language_node: NodeSpec = {
         const rdfaAttrs = getRdfaAttrs(element);
         if (
           hasBacklink(rdfaAttrs, ELI('language')) &&
-          hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('text'), SKOS('Concept')) &&
-          hasRdfaContentChild(element)
+          hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), SKOS('Concept'))
         ) {
           return getRdfaAttrs(element);
         }

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -281,7 +281,11 @@ export const besluit_article: NodeSpec = {
         const rdfaAttrs = getRdfaAttrs(element);
         if (
           hasBacklink(rdfaAttrs, ELI('has_part')) &&
-          hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), BESLUIT('Artikel')) &&
+          hasOutgoingNamedNodeTriple(
+            rdfaAttrs,
+            RDF('type'),
+            BESLUIT('Artikel'),
+          ) &&
           hasRdfaContentChild(element)
         ) {
           return rdfaAttrs;
@@ -411,7 +415,7 @@ export const besluit_article_header: NodeSpec = {
         );
         if (numberNode) {
           return {
-            ...getRdfaAttrs(numberNode),
+            ...getRdfaAttrs(numberNode as HTMLElement),
             number: numberNode.textContent,
           };
         }
@@ -507,7 +511,11 @@ export const besluit: NodeSpec = {
         const rdfaAttrs = getRdfaAttrs(element);
         if (
           hasBacklink(rdfaAttrs, PROV('generated')) &&
-          hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), BESLUIT('Besluit')) &&
+          hasOutgoingNamedNodeTriple(
+            rdfaAttrs,
+            RDF('type'),
+            BESLUIT('Besluit'),
+          ) &&
           hasRdfaContentChild(element)
         ) {
           return {

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -80,7 +80,7 @@ export const besluit_title: NodeSpec = {
           return {
             ...rdfaAttrs,
             subject: element.getAttribute('resource'),
-          }
+          };
         }
         return false;
       },

--- a/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
+++ b/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
@@ -11,6 +11,7 @@ import {
 import TableOfContentsComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/table-of-contents-plugin/ember-nodes/table-of-contents';
 import type { ComponentLike } from '@glint/template';
 import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
+import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 
 export const emberNodeConfig: (
   config: TableOfContentsConfig,
@@ -31,10 +32,10 @@ export const emberNodeConfig: (
 
       const { config } = node.attrs;
       const entries = extractOutline({
-        node: state.doc,
+        node: unwrap(state).doc,
         pos: -1,
         config: config as TableOfContentsConfig,
-        state,
+        state: unwrap(state),
       });
 
       const title = t('table-of-contents-plugin.title', 'Inhoudstafel');

--- a/addon/plugins/variable-plugin/utils/dom-constructors.ts
+++ b/addon/plugins/variable-plugin/utils/dom-constructors.ts
@@ -20,7 +20,7 @@ export const mappingSpan = (
 ) => {
   return span(
     {
-      resource: mapping,
+      subject: mapping,
       typeof: EXT('Mapping').prefixed,
       ...attributes,
     },
@@ -32,7 +32,7 @@ export const mappingSpan = (
  * Constructs a variable instance span based on a variable-instance resource.
  */
 export const instanceSpan = (variableInstance: string) => {
-  return span({ property: EXT('instance'), resource: variableInstance });
+  return span({ property: EXT('instance'), subject: variableInstance });
 };
 
 /**
@@ -48,7 +48,7 @@ export const typeSpan = (variableType: string) => {
 export const sourceSpan = (variableSource: string) => {
   return span({
     property: DCT('source').prefixed,
-    resource: variableSource,
+    subject: variableSource,
   });
 };
 

--- a/addon/plugins/variable-plugin/variables/address.ts
+++ b/addon/plugins/variable-plugin/variables/address.ts
@@ -18,6 +18,7 @@ import {
   PNode,
   ParseRule,
 } from '@lblod/ember-rdfa-editor';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   hasRdfaVariableType,
   isVariable,
@@ -282,28 +283,26 @@ const parseDOM: ParseRule[] = [
 
         const properties = [
           {
-            type: 'attribute',
             predicate: RDF('type').full,
-            object: EXT('Mapping').full,
+            object: sayDataFactory.namedNode(EXT('Mapping').full),
           },
           {
-            type: 'attribute',
             predicate: EXT('instance').full,
-            object:
+            object: sayDataFactory.namedNode(
               variableInstance ??
-              `http://data.lblod.info/variables/${uuidv4()}`,
+                `http://data.lblod.info/variables/${uuidv4()}`,
+            ),
           },
           {
-            type: 'attribute',
             predicate: DCT('type').full,
-            object: 'address',
+            object: sayDataFactory.namedNode('address'),
+
           },
         ];
         if (label) {
           properties.push({
-            type: 'attribute',
             predicate: EXT('label').full,
-            object: label,
+            object: sayDataFactory.namedNode(label),
           });
         }
 

--- a/addon/plugins/variable-plugin/variables/address.ts
+++ b/addon/plugins/variable-plugin/variables/address.ts
@@ -296,7 +296,6 @@ const parseDOM: ParseRule[] = [
           {
             predicate: DCT('type').full,
             object: sayDataFactory.namedNode('address'),
-
           },
         ];
         if (label) {

--- a/addon/plugins/variable-plugin/variables/address.ts
+++ b/addon/plugins/variable-plugin/variables/address.ts
@@ -240,17 +240,14 @@ const parseDOM: ParseRule[] = [
         dataContainer &&
         hasRdfaVariableType(attrs, 'address')
       ) {
-        if (!attrs.subject) {
+        if (attrs.rdfaNodeType !== 'resource') {
           return false;
         }
         // Filter out properties with content predicate,
         // as we handle this ourselves with the `value` attribute
-        attrs.properties =
-          attrs.rdfaNodeType !== 'resource'
-            ? []
-            : attrs.properties.filter((prop) => {
-                return !EXT('content').matches(prop.predicate);
-              });
+        attrs.properties = attrs.properties.filter((prop) => {
+          return !EXT('content').matches(prop.predicate);
+        });
         const addressNode = [...dataContainer.children].find((el) =>
           hasRDFaAttribute(el, 'property', EXT('content')),
         );

--- a/addon/plugins/variable-plugin/variables/codelist.ts
+++ b/addon/plugins/variable-plugin/variables/codelist.ts
@@ -19,6 +19,7 @@ import {
   getRdfaAttrs,
   rdfaAttrSpec,
 } from '@lblod/ember-rdfa-editor';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   hasRdfaVariableType,
   isVariable,
@@ -88,46 +89,41 @@ const parseDOM = [
 
         const properties = [
           {
-            type: 'attribute',
             predicate: RDF('type').full,
-            object: EXT('Mapping').full,
+            object: sayDataFactory.namedNode(EXT('Mapping').full),
           },
           {
-            type: 'attribute',
             predicate: EXT('instance').full,
-            object:
+            object: sayDataFactory.namedNode(
               variableInstance ??
-              `http://data.lblod.info/variables/${uuidv4()}`,
+                `http://data.lblod.info/variables/${uuidv4()}`,
+            ),
           },
           {
-            type: 'attribute',
             predicate: DCT('type').full,
-            object: 'codelist',
+            object: sayDataFactory.namedNode('codelist'),
           },
           {
-            type: 'content',
             predicate: EXT('content').full,
+            object: sayDataFactory.contentLiteral(),
           },
         ];
         if (label) {
           properties.push({
-            type: 'attribute',
             predicate: EXT('label').full,
-            object: label,
+            object: sayDataFactory.namedNode(label),
           });
         }
         if (codelistResource) {
           properties.push({
-            type: 'attribute',
             predicate: EXT('codelist').full,
-            object: codelistResource,
+            object: sayDataFactory.namedNode(codelistResource),
           });
         }
         if (source) {
           properties.push({
-            type: 'attribute',
             predicate: DCT('source').full,
-            object: source,
+            object: sayDataFactory.namedNode(source),
           });
         }
         return {

--- a/addon/plugins/variable-plugin/variables/codelist.ts
+++ b/addon/plugins/variable-plugin/variables/codelist.ts
@@ -48,7 +48,7 @@ const parseDOM = [
         node.querySelector('[data-content-container="true"]') &&
         hasRdfaVariableType(attrs, 'codelist')
       ) {
-        if (!attrs.subject) {
+        if (attrs.rdfaNodeType !== 'resource') {
           return false;
         }
         const selectionStyle = node.dataset.selectionStyle ?? null;

--- a/addon/plugins/variable-plugin/variables/date.ts
+++ b/addon/plugins/variable-plugin/variables/date.ts
@@ -142,8 +142,8 @@ const parseDOM = [
     tag: 'span',
     getAttrs: (node: HTMLElement) => {
       if (isVariable(node) && parseVariableType(node) === 'date') {
-        const mappingResource = node.getAttribute('resource');
-        if (!mappingResource) {
+        const mappingSubject = node.getAttribute('subject');
+        if (!mappingSubject) {
           return false;
         }
         const onlyDate = !![...node.children].find((el) =>
@@ -189,7 +189,7 @@ const parseDOM = [
           custom: dateNode?.dataset.custom === 'true',
           customAllowed: dateNode?.dataset.customAllowed !== 'false',
           rdfaNodeType: 'resource',
-          subject: mappingResource,
+          subject: mappingSubject,
           __rdfaId: uuidv4(),
           properties,
         };

--- a/addon/plugins/variable-plugin/variables/date.ts
+++ b/addon/plugins/variable-plugin/variables/date.ts
@@ -67,8 +67,7 @@ const parseDOM = [
         node.querySelector('[data-content-container="true"]') &&
         hasRdfaVariableType(attrs, 'date')
       ) {
-        const mappingResource = attrs.subject;
-        if (!mappingResource) {
+        if (attrs.rdfaNodeType !== 'resource') {
           return false;
         }
 
@@ -268,8 +267,11 @@ const emberNodeConfig = (options: DateOptions): EmberNodeConfig => ({
     const humanReadableDate = value
       ? formatDate(new Date(value), format)
       : onlyDate
-      ? t('date-plugin.insert.date', TRANSLATION_FALLBACKS.insertDate)
-      : t('date-plugin.insert.datetime', TRANSLATION_FALLBACKS.insertDateTime);
+        ? t('date-plugin.insert.date', TRANSLATION_FALLBACKS.insertDate)
+        : t(
+            'date-plugin.insert.datetime',
+            TRANSLATION_FALLBACKS.insertDateTime,
+          );
 
     return humanReadableDate;
   },

--- a/addon/plugins/variable-plugin/variables/date.ts
+++ b/addon/plugins/variable-plugin/variables/date.ts
@@ -3,6 +3,7 @@ import {
   createEmberNodeView,
   EmberNodeConfig,
 } from '@lblod/ember-rdfa-editor/utils/ember-node';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   DCT,
   EXT,
@@ -102,22 +103,24 @@ const parseDOM = [
         const content = node.getAttribute('content');
         const properties = [
           {
-            type: 'attribute',
             predicate: RDF('type').full,
-            object: EXT('Mapping').full,
+            object: sayDataFactory.namedNode(EXT('Mapping').full),
           },
           {
-            type: 'attribute',
             predicate: EXT('instance').full,
-            object: `http://data.lblod.info/variables/${uuidv4()}`,
+            object: sayDataFactory.namedNode(
+              `http://data.lblod.info/variables/${uuidv4()}`,
+            ),
           },
-          { type: 'attribute', predicate: DCT('type').full, object: 'date' },
+          {
+            predicate: DCT('type').full,
+            object: sayDataFactory.namedNode('date'),
+          },
         ];
         if (content) {
           properties.push({
-            type: 'attribute',
             predicate: EXT('content').full,
-            object: content,
+            object: sayDataFactory.namedNode(content),
           });
         }
         return {
@@ -157,29 +160,30 @@ const parseDOM = [
         const label = parseLabel(node);
         const properties = [
           {
-            type: 'attribute',
             predicate: RDF('type').full,
-            object: EXT('Mapping').full,
+            object: sayDataFactory.namedNode(EXT('Mapping').full),
           },
           {
-            type: 'attribute',
             predicate: EXT('instance').full,
-            object: `http://data.lblod.info/variables/${uuidv4()}`,
+            object: sayDataFactory.namedNode(
+              `http://data.lblod.info/variables/${uuidv4()}`,
+            ),
           },
-          { type: 'attribute', predicate: DCT('type').full, object: 'date' },
+          {
+            predicate: DCT('type').full,
+            object: sayDataFactory.namedNode('date'),
+          },
         ];
         if (label) {
           properties.push({
-            type: 'attribute',
             predicate: EXT('label').full,
-            object: label,
+            object: sayDataFactory.namedNode(label),
           });
         }
         if (value) {
           properties.push({
-            type: 'attribute',
             predicate: EXT('content').full,
-            object: value,
+            object: sayDataFactory.namedNode(value),
           });
         }
         return {
@@ -267,11 +271,8 @@ const emberNodeConfig = (options: DateOptions): EmberNodeConfig => ({
     const humanReadableDate = value
       ? formatDate(new Date(value), format)
       : onlyDate
-        ? t('date-plugin.insert.date', TRANSLATION_FALLBACKS.insertDate)
-        : t(
-            'date-plugin.insert.datetime',
-            TRANSLATION_FALLBACKS.insertDateTime,
-          );
+      ? t('date-plugin.insert.date', TRANSLATION_FALLBACKS.insertDate)
+      : t('date-plugin.insert.datetime', TRANSLATION_FALLBACKS.insertDateTime);
 
     return humanReadableDate;
   },

--- a/addon/plugins/variable-plugin/variables/number.ts
+++ b/addon/plugins/variable-plugin/variables/number.ts
@@ -70,8 +70,8 @@ const parseDOM: ParseRule[] = [
     tag: 'span',
     getAttrs: (node: HTMLElement) => {
       if (isVariable(node) && parseVariableType(node) === 'number') {
-        const mappingResource = node.getAttribute('resource');
-        if (!mappingResource) {
+        const mappingSubject = node.getAttribute('subject');
+        if (!mappingSubject) {
           return false;
         }
         const variableInstance = parseVariableInstance(node);
@@ -121,7 +121,7 @@ const parseDOM: ParseRule[] = [
           writtenNumber,
           minimumValue,
           maximumValue,
-          subject: mappingResource,
+          subject: mappingSubject,
           rdfaNodeType: 'resource',
           __rdfaId: uuidv4(),
           properties,

--- a/addon/plugins/variable-plugin/variables/number.ts
+++ b/addon/plugins/variable-plugin/variables/number.ts
@@ -35,6 +35,7 @@ import NumberNodeviewComponent from '@lblod/ember-rdfa-editor-lblod-plugins/comp
 import type { ComponentLike } from '@glint/template';
 import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 import { renderRdfaAware } from '@lblod/ember-rdfa-editor/core/schema';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 
 const parseDOM: ParseRule[] = [
   {
@@ -86,35 +87,31 @@ const parseDOM: ParseRule[] = [
 
         const properties = [
           {
-            type: 'attribute',
             predicate: RDF('type').full,
-            object: EXT('Mapping').full,
+            object: sayDataFactory.namedNode(EXT('Mapping').full),
           },
           {
-            type: 'attribute',
             predicate: EXT('instance').full,
-            object:
+            object: sayDataFactory.namedNode(
               variableInstance ??
-              `http://data.lblod.info/variables/${uuidv4()}`,
+                `http://data.lblod.info/variables/${uuidv4()}`,
+            ),
           },
           {
-            type: 'attribute',
             predicate: DCT('type').full,
-            object: 'number',
+            object: sayDataFactory.namedNode('number'),
           },
         ];
         if (label) {
           properties.push({
-            type: 'attribute',
             predicate: EXT('label').full,
-            object: label,
+            object: sayDataFactory.namedNode(label),
           });
         }
         if (value) {
           properties.push({
-            type: 'attribute',
             predicate: EXT('content').full,
-            object: value,
+            object: sayDataFactory.namedNode(value),
           });
         }
         return {

--- a/addon/plugins/variable-plugin/variables/number.ts
+++ b/addon/plugins/variable-plugin/variables/number.ts
@@ -49,7 +49,7 @@ const parseDOM: ParseRule[] = [
         node.querySelector('[data-content-container="true"]') &&
         hasRdfaVariableType(attrs, 'number')
       ) {
-        if (!attrs.subject) {
+        if (attrs.rdfaNodeType !== 'resource') {
           return false;
         }
         const writtenNumber =

--- a/addon/plugins/variable-plugin/variables/text.ts
+++ b/addon/plugins/variable-plugin/variables/text.ts
@@ -42,10 +42,9 @@ const parseDOM = [
         node.querySelector('[data-content-container="true"]') &&
         hasRdfaVariableType(attrs, 'text')
       ) {
-        if (!attrs.subject) {
+        if (attrs.rdfaNodeType !== 'resource') {
           return false;
         }
-        console.log('parse text-var');
         return attrs;
       }
 

--- a/addon/plugins/variable-plugin/variables/text.ts
+++ b/addon/plugins/variable-plugin/variables/text.ts
@@ -60,16 +60,15 @@ const parseDOM = [
         node.querySelector(CONTENT_SELECTOR) &&
         parseVariableType(node) === 'text'
       ) {
-        const mappingResource = node.getAttribute('resource');
-        if (!mappingResource) {
+        const mappingSubject = node.getAttribute('subject');
+        if (!mappingSubject) {
           return false;
         }
         const variableInstance = parseVariableInstance(node);
         const label = parseLabel(node);
         return {
           __rdfaId: uuidv4(),
-          subject: mappingResource,
-          resource: mappingResource,
+          subject: mappingSubject,
           rdfaNodeType: 'resource',
           properties: [
             {

--- a/addon/plugins/variable-plugin/variables/text.ts
+++ b/addon/plugins/variable-plugin/variables/text.ts
@@ -26,6 +26,7 @@ import VariableNodeViewComponent from '@lblod/ember-rdfa-editor-lblod-plugins/co
 import type { ComponentLike } from '@glint/template';
 import { hasOutgoingNamedNodeTriple } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 import { renderRdfaAware } from '@lblod/ember-rdfa-editor/core/schema';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 
 const CONTENT_SELECTOR = `span[property~='${EXT('content').prefixed}'],
                           span[property~='${EXT('content').full}']`;
@@ -72,26 +73,27 @@ const parseDOM = [
           rdfaNodeType: 'resource',
           properties: [
             {
-              type: 'attribute',
               predicate: RDF('type').full,
-              object: EXT('Mapping').full,
+              object: sayDataFactory.namedNode(EXT('Mapping').full),
             },
             {
-              type: 'attribute',
               predicate: EXT('instance').full,
-              object:
+              object: sayDataFactory.namedNode(
                 variableInstance ??
-                `http://data.lblod.info/variables/${uuidv4()}`,
+                  `http://data.lblod.info/variables/${uuidv4()}`,
+              ),
             },
             {
-              type: 'attribute',
               predicate: EXT('label').full,
-              object: label,
+              object: sayDataFactory.namedNode(label || ''),
             },
-            { type: 'attribute', predicate: DCT('type').full, object: 'text' },
             {
-              type: 'content',
+              predicate: DCT('type').full,
+              object: sayDataFactory.namedNode('text'),
+            },
+            {
               predicate: EXT('content').full,
+              object: sayDataFactory.contentLiteral(),
             },
           ],
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,7 @@
         "@appuniversum/ember-appuniversum": "^2.15.0",
         "@ember/string": "3.x",
         "@glint/template": "^1.1.0",
-        "@lblod/ember-rdfa-editor": "9.0.0-next.0",
+        "@lblod/ember-rdfa-editor": "10.0.0-next.1",
         "ember-concurrency": "^2.3.7 || ^3.1.0",
         "ember-intl": "^5.7.2 || ^6.1.0",
         "ember-modifier": "^3.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "@glint/template": "1.1.0",
-        "@lblod/ember-rdfa-editor": "9.0.0-next.0",
+        "@lblod/ember-rdfa-editor": "10.0.0-next.1",
         "@rdfjs/types": "^1.1.0",
         "@release-it/keep-a-changelog": "^3.1.0",
         "@tsconfig/ember": "^3.0.0",
@@ -224,11 +224,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -300,29 +300,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-      "integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.17.tgz",
-      "integrity": "sha512-2EENLmhpwplDux5PSsZnSbnSkB3tZ6QTksgO25xwEL7pIDcNOMhF5v/s6RzwjMZzZzw9Ofc30gHv5ChCC8pifQ==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
+      "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
-        "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.22.17",
-        "@babel/helpers": "^7.22.15",
-        "@babel/parser": "^7.22.16",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.17",
-        "@babel/types": "^7.22.17",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helpers": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.3",
@@ -336,6 +336,11 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+    },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -345,11 +350,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dependencies": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -393,13 +398,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
       "dependencies": {
-        "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.15",
-        "browserslist": "^4.21.9",
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -558,15 +563,15 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.17.tgz",
-      "integrity": "sha512-XouDDhQESrLHTpnBtCKExJdyY4gJCdrvH2Pyv8r8kovX2U8G0dRUOT45T9XlbLtuu9CLXP15eusnkprhoPV5iQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-simple-access": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.15"
+        "@babel/helper-validator-identifier": "^7.22.20"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -660,9 +665,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -676,9 +681,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -697,24 +702,24 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.15.tgz",
-      "integrity": "sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
+      "integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
@@ -787,9 +792,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+      "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1305,6 +1310,23 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.4.tgz",
+      "integrity": "sha512-nsWu/1M+ggti1SOALj3hfx5FXzAY06fwPJsUZD4/A5e1bWi46VUIWtD+kOX6/IdhXGsXBWllLFDSnqSCdUNydQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
@@ -1866,32 +1888,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+      "integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+      "integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -1899,11 +1921,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+      "integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
@@ -3771,7 +3793,8 @@
     },
     "node_modules/@guardian/prosemirror-invisibles": {
       "version": "3.0.3",
-      "resolved": "git+ssh://git@github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
+      "resolved": "git+ssh://git@github.com/lblod/prosemirror-invisibles.git#133dcb12871f9174ba8fe7dfc517e52496b14bc4",
+      "integrity": "sha512-uIxS7OhBDxp0ZjEKuVZS3Nkq8yZGPQl3KLMempYTIrNtSO/QuVE2qemPqBmxiFOUJqNeErnBaZBM9qTCO2D81Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3882,12 +3905,12 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "9.0.0-next.0",
-      "resolved": "git+https://git@github.com/lblod/ember-rdfa-editor.git#8f337dcfa83f49d82e5020cd5d6c5a0846b5340c",
-      "integrity": "sha512-xNeueYlFhBD0pVVvAiciN2dze5MJ+UXG9kMNFTx+wINKPsvs2Q3qWGzbM9nxQIgqvXA9WviYmvpX7Hrfiw0itA==",
+      "version": "10.0.0-next.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.0.0-next.1.tgz",
+      "integrity": "sha512-4oFq67MksVJRqG9HJkQFXi5jxSrPx2XpaZk5SZ8K0XQukSCl8fdnamsjAvZXokqw+atR09DViOkVHPwNRO0+gQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "@babel/core": "^7.23.7",
         "@codemirror/lang-html": "^6.1.1",
         "@codemirror/lang-xml": "^6.0.0",
         "@codemirror/state": "^6.1.1",
@@ -3898,7 +3921,7 @@
         "@embroider/macros": "^1.13.1",
         "@glimmer/tracking": "^1.1.2",
         "@graphy/memory.dataset.fast": "4.3.3",
-        "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles",
+        "@guardian/prosemirror-invisibles": "github:lblod/prosemirror-invisibles#133dcb12871f9174ba8fe7dfc517e52496b14bc4",
         "@lblod/marawa": "^0.8.0-beta.2",
         "codemirror": "^6.0.1",
         "common-tags": "^1.8.0",
@@ -3906,9 +3929,8 @@
         "debug": "^4.3.4",
         "dompurify": "^3.0.0",
         "ember-auto-import": "^2.6.3",
-        "ember-cli-babel": "^7.26.11",
+        "ember-cli-babel": "^8.2.0",
         "ember-cli-htmlbars": "^6.2.0",
-        "ember-cli-typescript": "^5.1.0",
         "ember-focus-trap": "~1.0.1",
         "ember-truth-helpers": "^3.0.0",
         "ember-velcro": "^2.1.0",
@@ -3927,16 +3949,17 @@
         "prosemirror-schema-basic": "^1.2.1",
         "prosemirror-schema-list": "^1.2.2",
         "prosemirror-state": "^1.4.2",
-        "prosemirror-tables": "git://github.com/lblod/prosemirror-tables",
+        "prosemirror-tables": "git://github.com/lblod/prosemirror-tables.git",
         "prosemirror-transform": "^1.8.0",
         "prosemirror-view": "^1.32.4",
-        "rdf-data-factory": "^1.1.0",
+        "rdf-data-factory": "^1.1.2",
         "relative-to-absolute-iri": "^1.0.6",
         "stream-browserify": "^3.0.0",
         "tracked-built-ins": "^3.1.0",
         "tracked-toolbox": "^2.0.0",
         "uuid": "^9.0.0",
-        "xml-formatter": "^3.2.1"
+        "xml-formatter": "^3.2.1",
+        "yup": "^1.3.3"
       },
       "engines": {
         "node": "16.* || 18.* || >= 20"
@@ -3949,6 +3972,174 @@
         "ember-intl": "^5.7.2 || ^6.1.0",
         "ember-modifier": "^3.2.7",
         "ember-source": "^4.12.0"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/@babel/runtime": {
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/babel-plugin-module-resolver": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.0.tgz",
+      "integrity": "sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==",
+      "dev": true,
+      "dependencies": {
+        "find-babel-config": "^2.0.0",
+        "glob": "^8.0.3",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/broccoli-babel-transpiler": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-8.0.0.tgz",
+      "integrity": "sha512-3HEp3flvasUKJGWERcrPgM1SWvHJ0O/fmbEtY9L4kDyMSnqjY6hTYvNvgWCIgbwXAYAUlZP0vjAQsmyLNGLwFw==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-persistent-filter": "^3.0.0",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^6.0.2"
+      },
+      "engines": {
+        "node": "16.* || >= 18"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.17.9"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/ember-cli-babel": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-8.2.0.tgz",
+      "integrity": "sha512-8H4+jQElCDo6tA7CamksE66NqBXWs7VNpS3a738L9pZCjg2kXIX4zoyHzkORUqCtr0Au7YsCnrlAMi1v2ALo7A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-decorators": "^7.20.13",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.20.5",
+        "@babel/plugin-transform-class-static-block": "^7.22.11",
+        "@babel/plugin-transform-modules-amd": "^7.20.11",
+        "@babel/plugin-transform-runtime": "^7.13.9",
+        "@babel/plugin-transform-typescript": "^7.20.13",
+        "@babel/preset-env": "^7.20.2",
+        "@babel/runtime": "7.12.18",
+        "amd-name-resolver": "^1.3.1",
+        "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-module-resolver": "^5.0.0",
+        "broccoli-babel-transpiler": "^8.0.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-source": "^3.0.1",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "clone": "^2.1.2",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^5.1.2",
+        "ensure-posix-path": "^1.0.2",
+        "resolve-package-path": "^4.0.3",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": "16.* || 18.* || >= 20"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/find-babel-config": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.0.0.tgz",
+      "integrity": "sha512-dOKT7jvF3hGzlW60Gc3ONox/0rRZ/tz7WCil0bqA1In/3I8f1BctpXahRnEKDySZqci7u+dqq93sZST9fOJpFw==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.1.1",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
       }
     },
     "node_modules/@lblod/marawa": {
@@ -10008,9 +10199,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
+      "integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -10026,10 +10217,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
-        "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001580",
+        "electron-to-chromium": "^1.4.648",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -10349,9 +10540,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001524",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
-      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
+      "version": "1.0.30001582",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001582.tgz",
+      "integrity": "sha512-vsJG3V5vgfduaQGVxL53uSX/HUzxyr2eA8xCo36OLal7sRcSZbibJtLeh0qja4sFOr/QQGt4opB4tOy+eOgAxg==",
       "funding": [
         {
           "type": "opencollective",
@@ -11651,6 +11842,7 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -12734,9 +12926,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.513",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.513.tgz",
-      "integrity": "sha512-cOB0xcInjm+E5qIssHeXJ29BaUyWpMyFKT5RB3bsLENDheCja0wMkHJyiPl0NBE/VzDI7JDuNEQWhe6RitEUcw=="
+      "version": "1.4.654",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.654.tgz",
+      "integrity": "sha512-hjfFa+Vj4WGLRVTlCQa+IivBkpcp+boGxMQfusOC/me5Y5NfU4wX7wyw+K9p8Cw4tl0BVIZGH2n7y/jMc3w4pg=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -25888,9 +26080,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
     },
     "node_modules/node-watch": {
       "version": "0.7.3",
@@ -30046,6 +30238,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "dev": true
+    },
     "node_modules/prosemirror-commands": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.5.1.tgz",
@@ -30547,8 +30745,9 @@
       }
     },
     "node_modules/rdf-data-factory": {
-      "version": "1.1.1",
-      "license": "MIT",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
+      "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -34233,6 +34432,12 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "dev": true
+    },
     "node_modules/tiny-glob": {
       "version": "0.2.9",
       "dev": true,
@@ -34365,6 +34570,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "dev": true
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -35019,9 +35230,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "funding": [
         {
           "type": "opencollective",
@@ -36257,6 +36468,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.3.3.tgz",
+      "integrity": "sha512-v8QwZSsHH2K3/G9WSkp6mZKO+hugKT1EmnMqLNUcfu51HU9MDyhlETT/JgtzprnrnQHPWsjc6MUDMBp/l9fNnw==",
+      "dev": true,
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "node": ">= 18"
   },
   "volta": {
-    "node": "18.14.0"
+    "node": "20.11.0"
   },
   "ember": {
     "edition": "octane"

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@appuniversum/ember-appuniversum": "^2.15.0",
     "@ember/string": "3.x",
     "@glint/template": "^1.1.0",
-    "@lblod/ember-rdfa-editor": "9.0.0-next.0",
+    "@lblod/ember-rdfa-editor": "10.0.0-next.1",
     "ember-concurrency": "^2.3.7 || ^3.1.0",
     "ember-intl": "^5.7.2 || ^6.1.0",
     "ember-modifier": "^3.2.7",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@glint/template": "1.1.0",
-    "@lblod/ember-rdfa-editor": "9.0.0-next.0",
+    "@lblod/ember-rdfa-editor": "10.0.0-next.1",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^3.1.0",
     "@tsconfig/ember": "^3.0.0",

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -114,7 +114,7 @@ export default class EditableBlockController extends Controller {
   schema = new Schema({
     nodes: {
       doc: docWithConfig({
-        content: '((chapter|block)+|(title|block)+|(article|block)+)',
+        content: '((block|chapter)+|(block|title)+|(block|article)+)',
         defaultLanguage: 'nl-BE',
       }),
       paragraph,

--- a/tests/dummy/app/controllers/editable-nodes-regulatory-statement.ts
+++ b/tests/dummy/app/controllers/editable-nodes-regulatory-statement.ts
@@ -124,7 +124,7 @@ export default class RegulatoryStatementSampleController extends Controller {
     nodes: {
       doc: docWithConfig({
         content:
-          'table_of_contents? document_title? ((chapter|block)+|(title|block)+|(article|block)+)',
+          'table_of_contents? document_title? ((block|chapter)+|(block|title)+|(block|article)+)',
       }),
       paragraph,
       document_title,

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -109,7 +109,7 @@ export default class RegulatoryStatementSampleController extends Controller {
     nodes: {
       doc: docWithConfig({
         content:
-          'table_of_contents? document_title? ((chapter|block)+|(title|block)+|(article|block)+)',
+          'table_of_contents? document_title? ((block|chapter)+|(block|title)+|(block|article)+)',
       }),
       paragraph,
       document_title,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,9 +22,6 @@
     "baseUrl": ".",
     "skipLibCheck": true,
     "experimentalDecorators": true,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
     "paths": {
       "dummy/tests/*": [
         "tests/*"


### PR DESCRIPTION
### Overview
This PR contains the following changes:
- Update the plugins where needed to be conform with latest version of https://github.com/lblod/ember-rdfa-editor/pull/1021
- Volta: pin node version to 20 (same as the one on the editor)
- Fix some import issues


##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor/pull/1021


### Setup
- Checkout latest version of https://github.com/lblod/ember-rdfa-editor/pull/1021
- `yalc publish`
- `yalc add @lblod/ember-rdfa-editor`

### How to test/reproduce
- Run `npm run prepack` and verify that no type issues occur
- Run the application and check for any runtime issues. Note: this PR should not contain any feature changes.

### Challenges/uncertainties
Due to the change from `ember-cli-typescript` to simply using `tsc`, `npm link` is not yet fully working. (there are still several unexplained type issues). This issue does not occur with `yalc` or `npm pack`.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
