### PR TITLE
GN-4722: simplify label of template-comments

### DIFF
--- a/.changeset/sour-zebras-carry.md
+++ b/.changeset/sour-zebras-carry.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Simplify label of template-comments from 'Toelichtings- en voorbeeldbepaling' to 'Toelichting'

--- a/addon/components/template-comments-plugin/template-comment.ts
+++ b/addon/components/template-comments-plugin/template-comment.ts
@@ -16,7 +16,7 @@ export default class TemplateCommentsPluginTemplateCommentComponent extends Comp
 
   get translation() {
     return {
-      title: this.intl.t('template-comments-plugin.long-title', {
+      title: this.intl.t('template-comments-plugin.title', {
         locale: this.documentLanguage,
       }),
     };

--- a/addon/plugins/template-comments-plugin/node.ts
+++ b/addon/plugins/template-comments-plugin/node.ts
@@ -23,10 +23,7 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
     attrs: {},
     serialize(_, state) {
       const t = getTranslationFunction(state);
-      const heading = t(
-        'template-comments-plugin.long-title',
-        'Toelichtings- of voorbeeldbepaling',
-      );
+      const heading = t('template-comments-plugin.title', 'Toelichting');
 
       return [
         'div',

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -290,14 +290,13 @@ snippet-plugin:
         list: List
 
 template-comments-plugin:
-  long-title: Template comment or example
+  title: Template comment
   insert:
-    title: Add template comment or example
+    title: Add template comment
   edit:
-    remove: Remove template comment or example
-    move-up: Move comment up
-    move-down: Move comment down
-  heading: comment or example
+    remove: Remove template comment
+    move-up: Move template comment up
+    move-down: Move template comment down
 
 pagination:
   next: Next page

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -294,14 +294,13 @@ snippet-plugin:
         list: Lijst
 
 template-comments-plugin:
-  long-title: Toelichtings- of voorbeeldbepaling
+  title: Toelichting
   insert:
-    title: Toelichtings- of voorbeeldbepaling invoegen
+    title: Toelichting invoegen
   edit:
-    remove: Verwijder Toelichtings- of voorbeeldbepaling
-    move-down: Toelichtings- of voorbeeldbepaling naar onder
-    move-up: Toelichtings- of voorbeeldbepaling naar boven
-  heading: toelichtingsbepaling
+    remove: Verwijder toelichting
+    move-down: Toelichting naar onder verplaatsen
+    move-up: Toelichting naar boven verplaatsen
 
 pagination:
   next: Volgende pagina


### PR DESCRIPTION
### Overview
This PR simplifies the label/header/name of template-comments in the following manner:
- In dutch: from 'toelichtings- en voorbeeldbepaling' to 'toelichting'
- In english: from 'template comment or example' to 'template comment'

##### connected issues and PRs:
[GN-4722](https://binnenland.atlassian.net/browse/GN-4722?atlOrigin=eyJpIjoiNjkyMTY1N2YyZWExNDlmZmJjMzk1MDQyYjVjNGE3YzkiLCJwIjoiaiJ9)

### How to test/reproduce
- Open the 'regulatory statements' dummy app
- Insert a template-comment
- Notice that the insertion buttons/navigational buttons/heading have changed
- The html output should also have the desired changes



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
