### PR TITLE
More article structure parsing and aligning sample with RS frontend

### DIFF
--- a/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
+++ b/addon/plugins/article-structure-plugin/structures/article-paragraph.ts
@@ -185,7 +185,9 @@ export const article_paragraph: NodeSpec = {
       context: 'article/article_body/',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element);
-        if (rdfaAttrs) {
+        if (
+          hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), SAY('Paragraph'))
+        ) {
           return rdfaAttrs;
         }
         return false;

--- a/addon/plugins/article-structure-plugin/structures/structure-header-number.ts
+++ b/addon/plugins/article-structure-plugin/structures/structure-header-number.ts
@@ -5,7 +5,10 @@ import {
   renderRdfaAware,
 } from '@lblod/ember-rdfa-editor/core/schema';
 import { ELI } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
-import { hasBacklink } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import {
+  hasBacklink,
+  hasRDFaAttribute,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 
 export const structure_header_number: NodeSpec = {
   attrs: rdfaAttrSpec,
@@ -35,6 +38,19 @@ export const structure_header_number: NodeSpec = {
         return false;
       },
       contentElement: getRdfaContentElement,
+    },
+    // Backwards compatibility
+    {
+      tag: 'span',
+      getAttrs(node: HTMLElement) {
+        if (hasRDFaAttribute(node, 'property', ELI('number'))) {
+          return {
+            rdfaNodeType: 'literal',
+            property: ELI('number').prefixed,
+          };
+        }
+        return false;
+      },
     },
   ],
 };

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -65,6 +65,22 @@ export function constructStructureNodeSpec(config: {
         preserveWhitespace: false,
         getAttrs(element: HTMLElement) {
           const rdfaAttrs = getRdfaAttrs(element);
+          if (
+            hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), type) &&
+            hasRdfaContentChild(element)
+          ) {
+            return rdfaAttrs;
+          }
+          return false;
+        },
+        contentElement: getRdfaContentElement,
+      },
+      // Backwards compatibility
+      {
+        tag: 'div',
+        preserveWhitespace: false,
+        getAttrs(element: HTMLElement) {
+          const rdfaAttrs = getRdfaAttrs(element);
           if (hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), type)) {
             return rdfaAttrs;
           }

--- a/tests/dummy/app/controllers/editable-nodes-regulatory-statement.ts
+++ b/tests/dummy/app/controllers/editable-nodes-regulatory-statement.ts
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 import { tracked } from 'tracked-built-ins';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
-import { getOwner } from '@ember/application';
 
 import { SayController } from '@lblod/ember-rdfa-editor';
 import { Schema, Plugin } from '@lblod/ember-rdfa-editor';
@@ -12,6 +11,8 @@ import {
   em,
   strikethrough,
   strong,
+  subscript,
+  superscript,
   underline,
 } from '@lblod/ember-rdfa-editor/plugins/text-style';
 import {
@@ -27,7 +28,7 @@ import {
 import {
   tableKeymap,
   tableNodes,
-  tablePlugin,
+  tablePlugins,
 } from '@lblod/ember-rdfa-editor/plugins/table';
 import { link, linkView } from '@lblod/ember-rdfa-editor/nodes/link';
 import { NodeViewConstructor } from '@lblod/ember-rdfa-editor';
@@ -45,21 +46,13 @@ import {
   inline_rdfa,
   inlineRdfaView,
 } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
-import {
-  createInvisiblesPlugin,
-  hardBreak,
-  heading as headingInvisible,
-  paragraph as paragraphInvisible,
-} from '@lblod/ember-rdfa-editor/plugins/invisibles';
-import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
-import { firefoxCursorFix } from '@lblod/ember-rdfa-editor/plugins/firefox-cursor-fix';
-import { chromeHacksPlugin } from '@lblod/ember-rdfa-editor/plugins/chrome-hacks-plugin';
-import { lastKeyPressedPlugin } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
 import { linkPasteHandler } from '@lblod/ember-rdfa-editor/plugins/link';
 import {
   editableNodePlugin,
   getActiveEditableNode,
 } from '@lblod/ember-rdfa-editor/plugins/_private/editable-node';
+import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
+import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
 import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
@@ -69,6 +62,7 @@ import {
   tableOfContentsView,
   table_of_contents,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin/nodes';
+import { TableOfContentsConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/table-of-contents-plugin';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import {
   STRUCTURE_NODES,
@@ -78,8 +72,6 @@ import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/d
 import {
   codelist,
   codelistView,
-  location,
-  locationView,
   number,
   numberView,
   textVariableView,
@@ -96,6 +88,10 @@ import {
   date,
   dateView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/date';
+import {
+  citationPlugin,
+  CitationPluginConfig,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
 import TextVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/text/insert';
 import NumberInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/number/insert';
 import DateInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/date/insert-variable';
@@ -103,6 +99,8 @@ import LocationInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/comp
 import CodelistInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/codelist/insert';
 import VariablePluginAddressInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/insert-variable';
 import { redacted } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/confidentiality-plugin/marks/redacted';
+
+const SNIPPET_LISTS_IDS_DOCUMENT_ATTRIBUTE = 'data-snippet-list-ids';
 
 export default class RegulatoryStatementSampleController extends Controller {
   DebugInfo = DebugInfo;
@@ -112,6 +110,7 @@ export default class RegulatoryStatementSampleController extends Controller {
   @service declare importRdfaSnippet: ImportRdfaSnippet;
   @service declare intl: IntlService;
   @tracked controller?: SayController;
+  @tracked citationPlugin = citationPlugin(this.config.citation);
 
   prefixes = {
     ext: 'http://mu.semte.ch/vocabularies/ext/',
@@ -125,32 +124,39 @@ export default class RegulatoryStatementSampleController extends Controller {
       doc: docWithConfig({
         content:
           'table_of_contents? document_title? ((block|chapter)+|(block|title)+|(block|article)+)',
+        extraAttributes: {
+          [SNIPPET_LISTS_IDS_DOCUMENT_ATTRIBUTE]: { default: null },
+        },
       }),
       paragraph,
       document_title,
       repaired_block,
+
       list_item,
       ordered_list,
       bullet_list,
       templateComment,
       placeholder,
       ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+      address,
       date: date(this.dateOptions),
       text_variable,
       number,
-      location,
       codelist,
-      address,
       ...STRUCTURE_NODES,
       heading,
       blockquote,
+
       horizontal_rule,
       code_block,
+
       text,
+
       image,
+
+      inline_rdfa,
       hard_break,
       block_rdfa,
-      inline_rdfa,
       table_of_contents: table_of_contents(this.config.tableOfContents),
       invisible_rdfa,
       link: link(this.config.link),
@@ -161,6 +167,10 @@ export default class RegulatoryStatementSampleController extends Controller {
       underline,
       strikethrough,
       redacted,
+      subscript,
+      superscript,
+      highlight,
+      color,
     },
   });
 
@@ -184,11 +194,13 @@ export default class RegulatoryStatementSampleController extends Controller {
     return {
       formats: [
         {
+          label: 'Short Date',
           key: 'short',
           dateFormat: 'dd/MM/yy',
           dateTimeFormat: 'dd/MM/yy HH:mm',
         },
         {
+          label: 'Long Date',
           key: 'long',
           dateFormat: 'EEEE dd MMMM yyyy',
           dateTimeFormat: 'PPPPp',
@@ -238,26 +250,23 @@ export default class RegulatoryStatementSampleController extends Controller {
             'structure_header|article_header',
           ],
           scrollContainer: () =>
-            document.getElementsByClassName(
-              'say-container__main',
-            )[0] as HTMLElement,
+            document.getElementsByClassName('say-container__main')[0],
         },
-      ],
-      templateVariable: {
-        endpoint: 'https://dev.roadsigns.lblod.info/sparql',
-        zonalLocationCodelistUri:
-          'http://lblod.data.gift/concept-schemes/62331E6900730AE7B99DF7EF',
-        nonZonalLocationCodelistUri:
-          'http://lblod.data.gift/concept-schemes/62331FDD00730AE7B99DF7F2',
-      },
+      ] as TableOfContentsConfig,
       structures: STRUCTURE_SPECS,
+      citation: {
+        type: 'nodes',
+        activeInNodeTypes(schema: Schema) {
+          return new Set([schema.nodes.doc]);
+        },
+        endpoint: '/codex/sparql',
+      } as CitationPluginConfig,
       link: {
         interactive: true,
       },
       snippet: {
         endpoint: 'https://dev.reglementairebijlagen.lblod.info/sparql',
       },
-      assignedSnippetListsIds: [],
     };
   }
 
@@ -277,27 +286,20 @@ export default class RegulatoryStatementSampleController extends Controller {
         controller,
       ),
       link: linkView(this.config.link)(controller),
+      address: addressView(controller),
       date: dateView(this.dateOptions)(controller),
       number: numberView(controller),
       text_variable: textVariableView(controller),
-      location: locationView(controller),
       codelist: codelistView(controller),
       templateComment: templateCommentView(controller),
-      address: addressView(controller),
       inline_rdfa: inlineRdfaView(controller),
     };
   };
   @tracked plugins: Plugin[] = [
-    firefoxCursorFix(),
-    chromeHacksPlugin(),
-    lastKeyPressedPlugin,
-    tablePlugin,
+    ...tablePlugins,
     tableKeymap,
+    this.citationPlugin,
     linkPasteHandler(this.schema.nodes.link),
-    createInvisiblesPlugin([hardBreak, paragraphInvisible, headingInvisible], {
-      shouldShowInvisibles: false,
-    }),
-    emberApplication({ application: getOwner(this) }),
     editableNodePlugin(),
   ];
 


### PR DESCRIPTION
### Overview
Some more parsing problems for article structure nodes (I could have sworn I fixed these already :s ).
I also changed the configuration of the editor in the editable-nodes-regulatory-statement test page to be almost the same as that on the RS frontend project.

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor/pull/1139

### Setup
N/A

### How to test/reproduce
Construct a RS document on QA, export, then import into the RS editable node sample page and confirm the nodes are all recreated correctly.

### Challenges/uncertainties
It seems there are some problems with parsing, as noted in chat.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
