### PR TITLE
GN-4732: ensure variables are selected/focused after insertion

### DIFF
--- a/.changeset/wet-baboons-serve.md
+++ b/.changeset/wet-baboons-serve.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": minor
+---
+
+Ensure that variables are node-selected/focused after insertion

--- a/addon/commands/index.ts
+++ b/addon/commands/index.ts
@@ -1,0 +1,1 @@
+export { default as replaceSelectionWithAndSelectNode } from './replace-selection-and-select-node';

--- a/addon/commands/replace-selection-and-select-node.ts
+++ b/addon/commands/replace-selection-and-select-node.ts
@@ -1,0 +1,24 @@
+import { Command, NodeSelection, PNode } from '@lblod/ember-rdfa-editor';
+
+const replaceSelectionWithAndSelectNode = (node: PNode): Command => {
+  return (state, dispatch) => {
+    if (!node.type.spec.selectable) {
+      return false;
+    }
+
+    if (dispatch) {
+      const tr = state.tr;
+      tr.replaceSelectionWith(node);
+      if (tr.selection.$anchor.nodeBefore) {
+        const resolvedPos = tr.doc.resolve(
+          tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
+        );
+        tr.setSelection(new NodeSelection(resolvedPos));
+      }
+      dispatch(tr);
+    }
+    return true;
+  };
+};
+
+export default replaceSelectionWithAndSelectNode;

--- a/addon/components/variable-plugin/codelist/insert.ts
+++ b/addon/components/variable-plugin/codelist/insert.ts
@@ -16,6 +16,7 @@ import {
   EXT,
   RDF,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { replaceSelectionWithAndSelectNode } from '@lblod/ember-rdfa-editor-lblod-plugins/commands';
 
 export type CodelistInsertOptions = {
   publisher?: string;
@@ -141,20 +142,9 @@ export default class CodelistInsertComponent extends Component<Args> {
     );
 
     this.label = undefined;
-
-    this.controller.withTransaction(
-      (tr) => {
-        tr.replaceSelectionWith(node);
-        if (tr.selection.$anchor.nodeBefore) {
-          const resolvedPos = tr.doc.resolve(
-            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
-          );
-          tr.setSelection(new NodeSelection(resolvedPos));
-        }
-        return tr;
-      },
-      { view: this.controller.mainEditorView },
-    );
+    this.controller.doCommand(replaceSelectionWithAndSelectNode(node), {
+      view: this.controller.mainEditorView,
+    });
   }
 
   @action

--- a/addon/components/variable-plugin/codelist/insert.ts
+++ b/addon/components/variable-plugin/codelist/insert.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { SayController } from '@lblod/ember-rdfa-editor';
+import { NodeSelection, SayController } from '@lblod/ember-rdfa-editor';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   CodeList,
@@ -144,7 +144,14 @@ export default class CodelistInsertComponent extends Component<Args> {
 
     this.controller.withTransaction(
       (tr) => {
-        return tr.replaceSelectionWith(node);
+        tr.replaceSelectionWith(node);
+        if (tr.selection.$anchor.nodeBefore) {
+          const resolvedPos = tr.doc.resolve(
+            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
+          );
+          tr.setSelection(new NodeSelection(resolvedPos));
+        }
+        return tr;
       },
       { view: this.controller.mainEditorView },
     );

--- a/addon/components/variable-plugin/date/insert-variable.ts
+++ b/addon/components/variable-plugin/date/insert-variable.ts
@@ -2,11 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import {
-  NodeSelection,
-  SayController,
-  Transaction,
-} from '@lblod/ember-rdfa-editor';
+import { SayController } from '@lblod/ember-rdfa-editor';
 import { v4 as uuidv4 } from 'uuid';
 import IntlService from 'ember-intl/services/intl';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
@@ -16,6 +12,7 @@ import {
   RDF,
   XSD,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { replaceSelectionWithAndSelectNode } from '@lblod/ember-rdfa-editor-lblod-plugins/commands';
 
 type Args = {
   controller: SayController;
@@ -79,19 +76,8 @@ export default class DateInsertVariableComponent extends Component<Args> {
     });
 
     this.label = undefined;
-
-    this.controller.withTransaction(
-      (tr: Transaction) => {
-        tr.replaceSelectionWith(node);
-        if (tr.selection.$anchor.nodeBefore) {
-          const resolvedPos = tr.doc.resolve(
-            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
-          );
-          tr.setSelection(new NodeSelection(resolvedPos));
-        }
-        return tr;
-      },
-      { view: this.controller.mainEditorView },
-    );
+    this.controller.doCommand(replaceSelectionWithAndSelectNode(node), {
+      view: this.controller.mainEditorView,
+    });
   }
 }

--- a/addon/components/variable-plugin/date/insert-variable.ts
+++ b/addon/components/variable-plugin/date/insert-variable.ts
@@ -2,7 +2,11 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { SayController, Transaction } from '@lblod/ember-rdfa-editor';
+import {
+  NodeSelection,
+  SayController,
+  Transaction,
+} from '@lblod/ember-rdfa-editor';
 import { v4 as uuidv4 } from 'uuid';
 import IntlService from 'ember-intl/services/intl';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
@@ -78,7 +82,14 @@ export default class DateInsertVariableComponent extends Component<Args> {
 
     this.controller.withTransaction(
       (tr: Transaction) => {
-        return tr.replaceSelectionWith(node);
+        tr.replaceSelectionWith(node);
+        if (tr.selection.$anchor.nodeBefore) {
+          const resolvedPos = tr.doc.resolve(
+            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
+          );
+          tr.setSelection(new NodeSelection(resolvedPos));
+        }
+        return tr;
       },
       { view: this.controller.mainEditorView },
     );

--- a/addon/components/variable-plugin/date/insert.ts
+++ b/addon/components/variable-plugin/date/insert.ts
@@ -1,11 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import {
-  NodeSelection,
-  SayController,
-  Transaction,
-} from '@lblod/ember-rdfa-editor';
+import { SayController } from '@lblod/ember-rdfa-editor';
 import IntlService from 'ember-intl/services/intl';
 import { v4 as uuidv4 } from 'uuid';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
@@ -14,6 +10,7 @@ import {
   EXT,
   RDF,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { replaceSelectionWithAndSelectNode } from '@lblod/ember-rdfa-editor-lblod-plugins/commands';
 
 type Args = {
   controller: SayController;
@@ -69,20 +66,8 @@ export default class DateInsertComponent extends Component<Args> {
       ],
       backlinks: [],
     });
-    console.log(node);
-
-    this.controller.withTransaction(
-      (tr: Transaction) => {
-        tr.replaceSelectionWith(node);
-        if (tr.selection.$anchor.nodeBefore) {
-          const resolvedPos = tr.doc.resolve(
-            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
-          );
-          tr.setSelection(new NodeSelection(resolvedPos));
-        }
-        return tr;
-      },
-      { view: this.controller.mainEditorView },
-    );
+    this.controller.doCommand(replaceSelectionWithAndSelectNode(node), {
+      view: this.controller.mainEditorView,
+    });
   }
 }

--- a/addon/components/variable-plugin/date/insert.ts
+++ b/addon/components/variable-plugin/date/insert.ts
@@ -1,7 +1,11 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { SayController, Transaction } from '@lblod/ember-rdfa-editor';
+import {
+  NodeSelection,
+  SayController,
+  Transaction,
+} from '@lblod/ember-rdfa-editor';
 import IntlService from 'ember-intl/services/intl';
 import { v4 as uuidv4 } from 'uuid';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
@@ -69,7 +73,14 @@ export default class DateInsertComponent extends Component<Args> {
 
     this.controller.withTransaction(
       (tr: Transaction) => {
-        return tr.replaceSelectionWith(node);
+        tr.replaceSelectionWith(node);
+        if (tr.selection.$anchor.nodeBefore) {
+          const resolvedPos = tr.doc.resolve(
+            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
+          );
+          tr.setSelection(new NodeSelection(resolvedPos));
+        }
+        return tr;
       },
       { view: this.controller.mainEditorView },
     );

--- a/addon/components/variable-plugin/location/insert.ts
+++ b/addon/components/variable-plugin/location/insert.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { SayController } from '@lblod/ember-rdfa-editor';
+import { NodeSelection, SayController } from '@lblod/ember-rdfa-editor';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 import { v4 as uuidv4 } from 'uuid';
@@ -66,7 +66,14 @@ export default class LocationInsertComponent extends Component<Args> {
 
     this.controller.withTransaction(
       (tr) => {
-        return tr.replaceSelectionWith(node);
+        tr.replaceSelectionWith(node);
+        if (tr.selection.$anchor.nodeBefore) {
+          const resolvedPos = tr.doc.resolve(
+            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
+          );
+          tr.setSelection(new NodeSelection(resolvedPos));
+        }
+        return tr;
       },
       { view: this.controller.mainEditorView },
     );

--- a/addon/components/variable-plugin/location/insert.ts
+++ b/addon/components/variable-plugin/location/insert.ts
@@ -1,10 +1,11 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { NodeSelection, SayController } from '@lblod/ember-rdfa-editor';
+import { SayController } from '@lblod/ember-rdfa-editor';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 import { v4 as uuidv4 } from 'uuid';
+import { replaceSelectionWithAndSelectNode } from '@lblod/ember-rdfa-editor-lblod-plugins/commands';
 
 export type LocationInsertOptions = {
   endpoint: string;
@@ -63,19 +64,8 @@ export default class LocationInsertComponent extends Component<Args> {
     );
 
     this.label = undefined;
-
-    this.controller.withTransaction(
-      (tr) => {
-        tr.replaceSelectionWith(node);
-        if (tr.selection.$anchor.nodeBefore) {
-          const resolvedPos = tr.doc.resolve(
-            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
-          );
-          tr.setSelection(new NodeSelection(resolvedPos));
-        }
-        return tr;
-      },
-      { view: this.controller.mainEditorView },
-    );
+    this.controller.doCommand(replaceSelectionWithAndSelectNode(node), {
+      view: this.controller.mainEditorView,
+    });
   }
 }

--- a/addon/components/variable-plugin/number/insert.ts
+++ b/addon/components/variable-plugin/number/insert.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { SayController } from '@lblod/ember-rdfa-editor';
+import { NodeSelection, SayController } from '@lblod/ember-rdfa-editor';
 import { v4 as uuidv4 } from 'uuid';
 import { isNumber } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/strings';
 import { service } from '@ember/service';
@@ -136,7 +136,14 @@ export default class NumberInsertComponent extends Component<Args> {
 
     this.controller.withTransaction(
       (tr) => {
-        return tr.replaceSelectionWith(node);
+        tr.replaceSelectionWith(node);
+        if (tr.selection.$anchor.nodeBefore) {
+          const resolvedPos = tr.doc.resolve(
+            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
+          );
+          tr.setSelection(new NodeSelection(resolvedPos));
+        }
+        return tr;
       },
       { view: this.controller.mainEditorView },
     );

--- a/addon/components/variable-plugin/number/insert.ts
+++ b/addon/components/variable-plugin/number/insert.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { NodeSelection, SayController } from '@lblod/ember-rdfa-editor';
+import { SayController } from '@lblod/ember-rdfa-editor';
 import { v4 as uuidv4 } from 'uuid';
 import { isNumber } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/strings';
 import { service } from '@ember/service';
@@ -13,6 +13,7 @@ import {
   EXT,
   RDF,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { replaceSelectionWithAndSelectNode } from '@lblod/ember-rdfa-editor-lblod-plugins/commands';
 
 type Args = {
   controller: SayController;
@@ -134,18 +135,8 @@ export default class NumberInsertComponent extends Component<Args> {
     this.minimumValue = '';
     this.maximumValue = '';
 
-    this.controller.withTransaction(
-      (tr) => {
-        tr.replaceSelectionWith(node);
-        if (tr.selection.$anchor.nodeBefore) {
-          const resolvedPos = tr.doc.resolve(
-            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
-          );
-          tr.setSelection(new NodeSelection(resolvedPos));
-        }
-        return tr;
-      },
-      { view: this.controller.mainEditorView },
-    );
+    this.controller.doCommand(replaceSelectionWithAndSelectNode(node), {
+      view: this.controller.mainEditorView,
+    });
   }
 }

--- a/addon/components/variable-plugin/text/insert.ts
+++ b/addon/components/variable-plugin/text/insert.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import type { SayController } from '@lblod/ember-rdfa-editor';
+import { NodeSelection, type SayController } from '@lblod/ember-rdfa-editor';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { v4 as uuidv4 } from 'uuid';
 import IntlService from 'ember-intl/services/intl';
@@ -83,7 +83,14 @@ export default class TextVariableInsertComponent extends Component<Args> {
 
     this.controller.withTransaction(
       (tr) => {
-        return tr.replaceSelectionWith(node);
+        tr.replaceSelectionWith(node);
+        if (tr.selection.$anchor.nodeBefore) {
+          const resolvedPos = tr.doc.resolve(
+            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
+          );
+          tr.setSelection(new NodeSelection(resolvedPos));
+        }
+        return tr;
       },
       { view: this.controller.mainEditorView },
     );

--- a/addon/components/variable-plugin/text/insert.ts
+++ b/addon/components/variable-plugin/text/insert.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { NodeSelection, type SayController } from '@lblod/ember-rdfa-editor';
+import { type SayController } from '@lblod/ember-rdfa-editor';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { v4 as uuidv4 } from 'uuid';
 import IntlService from 'ember-intl/services/intl';
@@ -11,6 +11,7 @@ import {
   EXT,
   RDF,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { replaceSelectionWithAndSelectNode } from '@lblod/ember-rdfa-editor-lblod-plugins/commands';
 
 type Args = {
   controller: SayController;
@@ -81,18 +82,8 @@ export default class TextVariableInsertComponent extends Component<Args> {
 
     this.label = undefined;
 
-    this.controller.withTransaction(
-      (tr) => {
-        tr.replaceSelectionWith(node);
-        if (tr.selection.$anchor.nodeBefore) {
-          const resolvedPos = tr.doc.resolve(
-            tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
-          );
-          tr.setSelection(new NodeSelection(resolvedPos));
-        }
-        return tr;
-      },
-      { view: this.controller.mainEditorView },
-    );
+    this.controller.doCommand(replaceSelectionWithAndSelectNode(node), {
+      view: this.controller.mainEditorView,
+    });
   }
 }

--- a/addon/plugins/variable-plugin/variables/address.ts
+++ b/addon/plugins/variable-plugin/variables/address.ts
@@ -351,6 +351,7 @@ const emberNodeConfig: EmberNodeConfig = {
   uriAttributes: ['variableInstance'],
   draggable: false,
   needsFFKludge: true,
+  selectable: true,
   attrs: {
     ...rdfaAttrSpec,
     value: {

--- a/addon/plugins/variable-plugin/variables/codelist.ts
+++ b/addon/plugins/variable-plugin/variables/codelist.ts
@@ -166,6 +166,7 @@ const emberNodeConfig: EmberNodeConfig = {
   uriAttributes: ['variableInstance'],
   draggable: false,
   needsFFKludge: true,
+  selectable: true,
   attrs: {
     ...rdfaAttrSpec,
     selectionStyle: {

--- a/addon/plugins/variable-plugin/variables/location.ts
+++ b/addon/plugins/variable-plugin/variables/location.ts
@@ -79,6 +79,7 @@ const emberNodeConfig: EmberNodeConfig = {
   content: 'inline*',
   atom: true,
   recreateUri: true,
+  selectable: true,
   uriAttributes: ['variableInstance'],
   draggable: false,
   needsFFKludge: true,

--- a/addon/plugins/variable-plugin/variables/number.ts
+++ b/addon/plugins/variable-plugin/variables/number.ts
@@ -175,6 +175,7 @@ const emberNodeConfig: EmberNodeConfig = {
   editable: true,
   draggable: false,
   needsFFKludge: true,
+  selectable: true,
   attrs: {
     ...rdfaAttrSpec,
     writtenNumber: { default: false },

--- a/addon/plugins/variable-plugin/variables/text.ts
+++ b/addon/plugins/variable-plugin/variables/text.ts
@@ -129,6 +129,7 @@ const emberNodeConfig: EmberNodeConfig = {
   draggable: false,
   needsFFKludge: true,
   editable: true,
+  selectable: true,
   attrs: {
     ...rdfaAttrSpec,
   },


### PR DESCRIPTION
### Overview
This PR introduces some changes into what happens after inserting a variable node.

**Before this PR:**
- A text-cursor is set just after the inserted variable (the variable is not focused)
- This causes different issues on both chromium and firefox
   * On chromium: no text-cursor is shown
   * On firefox: a text-cursor is shown, but does not act as a real selection (typing does not work)

**Modifications introduced in this PR:**
- After variable insertion, the variables is selected/focused, allowing users to directly interact with them
- Similar to how addresses/links behave
- Works on both firefox and chromium

##### connected issues and PRs:
Solves [GN-4732](https://binnenland.atlassian.net/browse/GN-4732?atlOrigin=eyJpIjoiYjdjNzFkYTJjMjg5NDJkZmJlODg4OGY0YzZmMjY2NjUiLCJwIjoiaiJ9)

### How to test/reproduce
- `pnpm start`
- Insert a variable (text, number, codelist, location or date)
- Notice that the variable is selected/focused after insertion, you can directly interact with them

### Challenges/uncertainties
I can also add this fix to the stable version of the plugins package, to ensure we can release this fix when releasing to prod.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
