### PR TITLE
Use full uris in decision-type plugin

### DIFF
--- a/addon/components/besluit-type-plugin/toolbar-dropdown.ts
+++ b/addon/components/besluit-type-plugin/toolbar-dropdown.ts
@@ -5,7 +5,6 @@ import { addProperty, removeProperty } from '@lblod/ember-rdfa-editor/commands';
 import { SayController } from '@lblod/ember-rdfa-editor';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { ResolvedPNode } from '@lblod/ember-rdfa-editor/plugins/datastore';
-import { getRdfaAttribute } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 import fetchBesluitTypes, {
   BesluitType,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-type-plugin/utils/fetchBesluitTypes';
@@ -77,7 +76,7 @@ export default class EditorPluginsToolbarDropdownComponent extends Component<Arg
   get currentBesluitURI() {
     if (this.currentBesluitRange) {
       const node = unwrap(this.doc.nodeAt(this.currentBesluitRange.from));
-      return getRdfaAttribute(node, 'resource').pop();
+      return node.attrs['subject'] as string | undefined;
     }
     return;
   }
@@ -204,7 +203,7 @@ export default class EditorPluginsToolbarDropdownComponent extends Component<Arg
     const resource =
       (this.currentBesluitRange &&
         'node' in this.currentBesluitRange &&
-        (this.currentBesluitRange.node.attrs.resource as string)) ||
+        (this.currentBesluitRange.node.attrs.subject as string)) ||
       undefined;
     if (this.besluitType && resource) {
       this.cardExpanded = false;
@@ -213,7 +212,7 @@ export default class EditorPluginsToolbarDropdownComponent extends Component<Arg
           removeProperty({
             resource,
             property: {
-              predicate: RDF('type').prefixed,
+              predicate: RDF('type').full,
               object: sayDataFactory.namedNode(this.previousBesluitType),
             },
           }),
@@ -224,7 +223,7 @@ export default class EditorPluginsToolbarDropdownComponent extends Component<Arg
         addProperty({
           resource,
           property: {
-            predicate: RDF('type').prefixed,
+            predicate: RDF('type').full,
             object: sayDataFactory.namedNode(this.besluitType.uri),
           },
         }),


### PR DESCRIPTION
### Overview
This PR ensures that the full `RDF('type')` uri is used when inserting/removing decision types from a decision.

##### connected issues and PRs:
Closes #396 

### How to test/reproduce
- `pnpm start`
- Insert a decision
- Select a decision type
- Reload the page
- Select a new decision type
- The old decision type should be correctly removed

### Challenges/uncertainties
- When setting a new decision type, it would probably be better to remove all previous decision type properties (just to be sure). I can still update this PR with this.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
