### PR TITLE
Update editor peer-dep to include ^10.0.0

### DIFF
--- a/.changeset/nervous-pillows-dance.md
+++ b/.changeset/nervous-pillows-dance.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Widen support for ember-rdfa-editor to include upcoming v10

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,7 +128,7 @@
         "@appuniversum/ember-appuniversum": "^2.15.0",
         "@ember/string": "3.x",
         "@glint/template": "^1.1.0",
-        "@lblod/ember-rdfa-editor": "^9.0.0",
+        "@lblod/ember-rdfa-editor": "^9.0.0 || ^10.0.0",
         "ember-concurrency": "^2.3.7 || ^3.1.0",
         "ember-intl": "^5.7.2 || ^6.1.0",
         "ember-modifier": "^3.2.7",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "@appuniversum/ember-appuniversum": "^2.15.0",
     "@ember/string": "3.x",
     "@glint/template": "^1.1.0",
-    "@lblod/ember-rdfa-editor": "^9.0.0",
+    "@lblod/ember-rdfa-editor": "^9.0.0 || ^10.0.0",
     "ember-concurrency": "^2.3.7 || ^3.1.0",
     "ember-intl": "^5.7.2 || ^6.1.0",
     "ember-modifier": "^3.2.7",


### PR DESCRIPTION
### Overview
Since the changes to `editor` have been made backwards compatible, the plugins can now support either version without changes. This is needed to add the HTML editor to embeddable as the addition of the toolbar button was made on the RDFa aware branch.

##### connected issues and PRs:
https://github.com/lblod/frontend-embeddable-notule-editor/issues/238

### Setup
N/A

### How to test/reproduce
Modify the package.json to set a dev build of the rdfa-aware branch, for example `10.0.0-dev.f918748be0b3f4a01622379b403901024f03eeec` and test that everything works.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
