### PR TITLE
Drop support for editor `10.x` releases

### DIFF
--- a/.changeset/wet-oranges-flash.md
+++ b/.changeset/wet-oranges-flash.md
@@ -1,0 +1,7 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Drop support for `@lblod/ember-rdfa-editor` `10.x` range.
+This support was initially introduce to support `10.x` alpha releases of the editor.
+We managed to release the new editor version as a `9.x` minor release (and the `10.x` releases are thus obsolete).

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,7 +128,7 @@
         "@appuniversum/ember-appuniversum": "^2.15.0",
         "@ember/string": "3.x",
         "@glint/template": "^1.1.0",
-        "@lblod/ember-rdfa-editor": "^9.0.0 || ^10.0.0",
+        "@lblod/ember-rdfa-editor": "^9.0.0",
         "ember-concurrency": "^2.3.7 || ^3.1.0",
         "ember-intl": "^5.7.2 || ^6.1.0",
         "ember-modifier": "^3.2.7",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "@appuniversum/ember-appuniversum": "^2.15.0",
     "@ember/string": "3.x",
     "@glint/template": "^1.1.0",
-    "@lblod/ember-rdfa-editor": "^9.0.0 || ^10.0.0",
+    "@lblod/ember-rdfa-editor": "^9.0.0",
     "ember-concurrency": "^2.3.7 || ^3.1.0",
     "ember-intl": "^5.7.2 || ^6.1.0",
     "ember-modifier": "^3.2.7",


### PR DESCRIPTION
### Overview
This PR drops support for `@lblod/ember-rdfa-editor` `10.x` range.
Note: this PR is not breaking, the `10.x` range of the `@lblod/ember-rdfa-editor` package never contained stable releases.
We managed to release the new editor version as a `9.x` minor release (and the alpha `10.x` releases are thus obsolete).

### How to test/reproduce
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
