### PR TITLE
Removal of redundant attributes and parse-rules from decision node-specs

### DIFF
--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -491,10 +491,6 @@ export const besluit: NodeSpec = {
   canSplit: false,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    typeof: {
-      default: 'besluit:Besluit ext:BesluitNieuweStijl',
-    },
-    subject: {},
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -514,37 +510,15 @@ export const besluit: NodeSpec = {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
         if (
           hasBacklink(rdfaAttrs, PROV('generated')) &&
-          hasOutgoingNamedNodeTriple(
-            rdfaAttrs,
-            RDF('type'),
-            BESLUIT('Besluit'),
-          ) &&
-          hasRdfaContentChild(element)
+          hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), BESLUIT('Besluit'))
         ) {
           return {
-            typeof: element.getAttribute('typeof'),
             ...rdfaAttrs,
           };
         }
         return false;
       },
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        if (
-          hasRDFaAttribute(element, 'property', PROV('generated')) &&
-          hasRDFaAttribute(element, 'typeof', BESLUIT('Besluit'))
-        ) {
-          return {
-            typeof: element.getAttribute('typeof'),
-            ...getRdfaAttrs(element, { rdfaAware }),
-          };
-        }
-        return false;
-      },
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -178,10 +178,6 @@ export const besluit_article: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    typeof: {
-      default: BESLUIT('Artikel').prefixed,
-    },
-    subject: {},
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -201,31 +197,13 @@ export const besluit_article: NodeSpec = {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
         if (
           hasBacklink(rdfaAttrs, ELI('has_part')) &&
-          hasOutgoingNamedNodeTriple(
-            rdfaAttrs,
-            RDF('type'),
-            BESLUIT('Artikel'),
-          ) &&
-          hasRdfaContentChild(element)
+          hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), BESLUIT('Artikel'))
         ) {
           return rdfaAttrs;
         }
         return false;
       },
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        if (
-          hasRDFaAttribute(element, 'property', ELI('has_part')) &&
-          hasRDFaAttribute(element, 'typeof', BESLUIT('Artikel'))
-        ) {
-          return getRdfaAttrs(element, { rdfaAware });
-        }
-        return false;
-      },
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -1,7 +1,6 @@
 import { getRdfaAttrs, NodeSpec, rdfaAttrSpec } from '@lblod/ember-rdfa-editor';
 import {
   getRdfaContentElement,
-  hasRdfaContentChild,
   renderRdfaAware,
   sharedRdfaNodeSpec,
 } from '@lblod/ember-rdfa-editor/core/schema';

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -33,12 +33,6 @@ export const besluit_title: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    property: {
-      default: 'eli:title',
-    },
-    datatype: {
-      default: 'xsd:string',
-    },
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -58,29 +52,12 @@ export const besluit_title: NodeSpec = {
       tag: 'h1,h2,h3,h4,h5',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-        if (
-          hasBacklink(rdfaAttrs, ELI('title')) &&
-          hasRdfaContentChild(element)
-        ) {
+        if (hasBacklink(rdfaAttrs, ELI('title'))) {
           return rdfaAttrs;
         }
         return false;
       },
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'h1,h2,h3,h4,h5',
-      getAttrs(element: HTMLElement) {
-        if (hasRDFaAttribute(element, 'property', ELI('title'))) {
-          const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-          return {
-            ...rdfaAttrs,
-            subject: element.getAttribute('resource'),
-          };
-        }
-        return false;
-      },
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -333,9 +333,6 @@ export const besluit_article_content: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    datatype: {
-      default: 'xsd:string',
-    },
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -353,27 +350,13 @@ export const besluit_article_content: NodeSpec = {
       tag: 'div',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-        if (
-          hasBacklink(rdfaAttrs, PROV('value')) &&
-          hasRdfaContentChild(element)
-        ) {
+        if (hasBacklink(rdfaAttrs, PROV('value'))) {
           return getRdfaAttrs(element, { rdfaAware });
         }
         return false;
       },
       contentElement: getRdfaContentElement,
       context: 'besluit_article/',
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        if (hasRDFaAttribute(element, 'property', PROV('value'))) {
-          return getRdfaAttrs(element, { rdfaAware });
-        }
-        return false;
-      },
-      context: 'besluit_article//',
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -106,12 +106,6 @@ export const motivering: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    property: {
-      default: 'besluit:motivering',
-    },
-    lang: {
-      default: 'nl',
-    },
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -129,25 +123,12 @@ export const motivering: NodeSpec = {
       tag: 'div',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-        if (
-          hasBacklink(rdfaAttrs, BESLUIT('motivering')) &&
-          hasRdfaContentChild(element)
-        ) {
+        if (hasBacklink(rdfaAttrs, BESLUIT('motivering'))) {
           return rdfaAttrs;
         }
         return false;
       },
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        if (hasRDFaAttribute(element, 'property', BESLUIT('motivering'))) {
-          return getRdfaAttrs(element, { rdfaAware });
-        }
-        return false;
-      },
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -142,12 +142,6 @@ export const article_container: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    property: {
-      default: 'prov:value',
-    },
-    datatype: {
-      default: 'xsd:string',
-    },
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -165,27 +159,13 @@ export const article_container: NodeSpec = {
       tag: 'div',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-        if (
-          hasBacklink(rdfaAttrs, PROV('value')) &&
-          hasRdfaContentChild(element)
-        ) {
+        if (hasBacklink(rdfaAttrs, PROV('value'))) {
           return rdfaAttrs;
         }
         return false;
       },
       context: 'besluit/',
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        if (hasRDFaAttribute(element, 'property', PROV('value'))) {
-          return getRdfaAttrs(element, { rdfaAware });
-        }
-        return false;
-      },
-      context: 'besluit/',
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -71,12 +71,6 @@ export const description: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    property: {
-      default: 'eli:description',
-    },
-    datatype: {
-      default: 'xsd:string',
-    },
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -94,25 +88,12 @@ export const description: NodeSpec = {
       tag: 'div,p',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-        if (
-          hasBacklink(rdfaAttrs, ELI('description')) &&
-          hasRdfaContentChild(element)
-        ) {
+        if (hasBacklink(rdfaAttrs, ELI('description'))) {
           return rdfaAttrs;
         }
         return false;
       },
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div,p',
-      getAttrs(element: HTMLElement) {
-        if (hasRDFaAttribute(element, 'property', ELI('description'))) {
-          return getRdfaAttrs(element, { rdfaAware });
-        }
-        return false;
-      },
     },
   ],
 };


### PR DESCRIPTION
### Overview
This PR removes redundant attributes and parse-rules from the following node-specs:
- `besluit`
- `besluit_title`
- `description`
- `motivering`
- `article_container`
- `besluit_article`
- `besluit_article_content`

The parse-rules of these nodespecs should be able to parse both the old and the new representations.

##### connected issues and PRs:
None

### How to test/reproduce
- Start the dummy app
- Import the sample `DecisionTemplate` or copy over a document from GN
- Ensure that all RDFa contained in the decision is correctly parsed and stored.

### Challenges/uncertainties
At the moment, there are still issues in the parsing logic of decision-articles, I will tackle these issues in a seperate PR.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [ ] changelog
- [x] npm lint
