### PR TITLE
GN-4811: Only show the titles of the snippets

### DIFF
--- a/.changeset/famous-items-report.md
+++ b/.changeset/famous-items-report.md
@@ -1,0 +1,7 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": minor
+---
+
+GN-4811: Only show the titles of the snippets
+
+In the snippet insert modal: only show the titles of the snippets

--- a/addon/components/snippet-plugin/snippets/snippet-preview.hbs
+++ b/addon/components/snippet-plugin/snippets/snippet-preview.hbs
@@ -6,19 +6,9 @@
   <div
     class='snippet-preview--article au-u-padding au-u-padding-right-large rdfa-annotations rdfa-annotations-highlight rdfa-annotations-hover'
   >
-    <h3 class='snippet-preview--title au-u-margin-bottom'>
+    <h3 class='snippet-preview--title'>
       {{@snippet.title}}
     </h3>
-    <div class="snippet-preview--editor-container">
-      <div class="say-container__main">
-        <div class="say-editor">
-          <div class="say-editor__inner say-content">
-            {{this.snippet.content}}
-          </div>
-        </div>
-      </div>
-      <div class="snippet-preview--editor-overlay"></div>
-    </div>
   </div>
   <div class='snippet-preview--button au-u-padding-small'>
     <AuButton @skin='naked' {{on 'click' this.onInsert}}>

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -57,6 +57,8 @@
 
   &--button {
     border-left: 1px solid var(--au-gray-200);
+    display: flex;
+    align-items: center;
   }
 
   &--editor-overlay {

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import applyDevTools from 'prosemirror-dev-tools';
 import { action } from '@ember/object';
 import { tracked } from 'tracked-built-ins';
+import { task } from 'ember-concurrency';
 import { SayController } from '@lblod/ember-rdfa-editor';
 import { Schema, Plugin } from '@lblod/ember-rdfa-editor';
 import {
@@ -97,6 +98,8 @@ export default class RegulatoryStatementSampleController extends Controller {
   @service declare importRdfaSnippet: ImportRdfaSnippet;
   @service declare intl: IntlService;
   @tracked controller?: SayController;
+  @tracked assignedSnippetListsIds: string[] =
+    localStorage.getItem('ASSIGNED_SNIPPET_LISTS_IDS')?.split(',') ?? [];
 
   prefixes = {
     ext: 'http://mu.semte.ch/vocabularies/ext/',
@@ -248,12 +251,19 @@ export default class RegulatoryStatementSampleController extends Controller {
       snippet: {
         endpoint: 'https://dev.reglementairebijlagen.lblod.info/sparql',
       },
-      assignedSnippetListsIds: [],
       worship: {
         endpoint: 'https://data.lblod.info/sparql',
       },
     };
   }
+
+  setDocumentContainerSnippetLists = task(async (snippetIds: string[]) => {
+    await new Promise<void>((resolve) => {
+      localStorage.setItem('ASSIGNED_SNIPPET_LISTS_IDS', snippetIds.join(','));
+      this.assignedSnippetListsIds = snippetIds;
+      resolve();
+    });
+  });
 
   @tracked rdfaEditor?: SayController;
   @tracked nodeViews: (

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -73,6 +73,7 @@
               <SnippetPlugin::SnippetInsert
                 @controller={{this.controller}}
                 @config={{this.config.snippet}}
+                @assignedSnippetListsIds={{this.assignedSnippetListsIds}}
               />
               <TemplateCommentsPlugin::Insert
                 @controller={{this.controller}}
@@ -101,7 +102,8 @@
             <AuHr/>
             <SnippetPlugin::SnippetListSelect
               @config={{this.config.snippet}}
-              @assignedSnippetListsIds={{this.config.assignedSnippetListsIds}}
+              @assignedSnippetListsIds={{this.assignedSnippetListsIds}}
+              @onSaveSnippetListIds={{this.setDocumentContainerSnippetLists}}
             />
           </Sidebar>
           {{/if}}


### PR DESCRIPTION
### Overview

GN-4811: Only show the titles of the snippets

In the snippet insert modal: only show the titles of the snippets


##### connected issues and PRs:

* https://binnenland.atlassian.net/browse/GN-4811


### Setup

1. Checkout
2. `npm run start`  

### How to test/reproduce

1. Go to http://localhost:4200/regulatory-statement-sample
2. Click "Manage snippet lists" on the right
3. Add some snippet lists. Save.
4. Click "Insert snippet" in the Insert menu on the left
5. Observe that only snippet names are shown

|Before|After|
|-|-|
|![CleanShot 2024-04-25 at 10 40 02@2x](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/4990d19f-1049-4edd-b729-09f93ac47357)|![CleanShot 2024-04-25 at 10 38 02@2x](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/ec0d6b0e-9f0f-44f3-b1d7-fce8add87094)|

### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check if dummy app is correctly updated
- [X] Check cancel/go-back flows
- [X] changelog
- [X] npm lint
- [X] no new deprecations
