### PR TITLE
GN-4816: Add sorting for snippet lists

### DIFF
--- a/.changeset/twenty-spies-kiss.md
+++ b/.changeset/twenty-spies-kiss.md
@@ -1,0 +1,8 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": minor
+---
+
+GN-4816: Add sorting for snippet lists
+
+* Use `AuDataTable` 
+* Add sorting for snippet lists

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.hbs
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.hbs
@@ -9,53 +9,19 @@
 >
   <modal.Body>
     <AuMainContainer class='snippet-modal--main-container' as |mc|>
-      <mc.sidebar>
-        <div class='au-c-sidebar'>
-          <div class='au-c-sidebar__content au-u-padding'>
-            <AuHeading @level='3' @skin='4' class='au-u-padding-bottom-small'>
-              {{t 'snippet-plugin.snippet-list.modal.search.title'}}
-            </AuHeading>
-            <AuLabel
-              class='au-margin-bottom-small'
-              for='searchTerm'
-              @inline={{false}}
-              @required={{false}}
-              @error={{false}}
-              @warning={{false}}
-            >
-              {{t 'snippet-plugin.snippet-list.modal.search.label'}}
-            </AuLabel>
-            <AuNativeInput
-              @type='text'
-              @width='block'
-              id='searchTerm'
-              value={{this.searchText}}
-              placeholder={{t 'snippet-plugin.snippet-list.modal.search.placeholder'}}
-              {{on 'input' this.setInputSearchText}}
-            />
-          </div>
-        </div>
-      </mc.sidebar>
       <mc.content @scroll={{true}}>
-        <div class='au-u-padding-top snippet-modal--list-container'>
-          {{#if this.snippetListResource.isRunning}}
-            <div class='au-u-margin'>
-              <Common::Search::Loading />
-            </div>
+        <div class='snippet-modal--list-container'>
+          {{#if this.error}}
+            <Common::Search::AlertLoadError @error={{this.error}} class="au-u-margin-top-none" />
           {{else}}
-            {{#if this.error}}
-              <Common::Search::AlertLoadError @error={{this.error}} class="au-u-margin-top-none" />
-            {{else}}
-              {{#if this.snippetListResource.value.length}}
-                <SnippetPlugin::SnippetList::SnippetListView
-                  @snippetLists={{this.snippetListResource.value}}
-                  @assignedSnippetListsIds={{this.assignedSnippetListsIds}}
-                  @onChange={{this.onChange}}
-                />
-              {{else}}
-                <Common::Search::AlertNoItems />
-              {{/if}}
-            {{/if}}
+            <SnippetPlugin::SnippetList::SnippetListView
+              @snippetLists={{this.snippetListResource.value}}
+              @assignedSnippetListsIds={{this.assignedSnippetListsIds}}
+              @listNameFilter={{this.nameFilterText}}
+              @sort={{this.sort}}
+              @onChange={{this.onChange}}
+              @isLoading={{this.snippetListResource.isRunning}}
+            />
           {{/if}}
         </div>
         <AuToolbar @border='top' @size='large' @nowrap={{true}} @reverse={{true}}>

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
@@ -1,12 +1,14 @@
 import Component from '@glimmer/component';
-import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { restartableTask, Task, timeout } from 'ember-concurrency';
 import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
 
 import { tracked } from '@glimmer/tracking';
 
-import { fetchSnippetLists } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/fetch-data';
+import {
+  fetchSnippetLists,
+  OrderBy,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/fetch-data';
 
 import {
   SnippetPluginConfig,
@@ -22,7 +24,10 @@ interface Args {
 
 export default class SnippetListModalComponent extends Component<Args> {
   // Filtering
-  @tracked inputSearchText: string | null = null;
+  @tracked nameFilterText: string | null = null;
+
+  // Sorting
+  @tracked sort: OrderBy = null;
 
   // Display
   @tracked error: unknown;
@@ -33,20 +38,6 @@ export default class SnippetListModalComponent extends Component<Args> {
 
   get config() {
     return this.args.config;
-  }
-
-  get searchText() {
-    return this.inputSearchText;
-  }
-
-  @action
-  setInputSearchText(event: InputEvent) {
-    assert(
-      'inputSearchText must be bound to an input element',
-      event.target instanceof HTMLInputElement,
-    );
-
-    this.inputSearchText = event.target.value;
   }
 
   @action
@@ -72,8 +63,9 @@ export default class SnippetListModalComponent extends Component<Args> {
         endpoint: this.args.config.endpoint,
         abortSignal: abortController.signal,
         filter: {
-          name: this.inputSearchText ?? undefined,
+          name: this.nameFilterText ?? undefined,
         },
+        orderBy: this.sort,
       });
 
       return queryResult.results;
@@ -88,7 +80,7 @@ export default class SnippetListModalComponent extends Component<Args> {
   snippetListResource = trackedTask<SnippetList[]>(
     this,
     this.snippetListSearch,
-    () => [this.inputSearchText],
+    () => [this.nameFilterText, this.sort],
   );
 
   @action

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
@@ -1,30 +1,57 @@
 {{! @glint-nocheck: not typesafe yet }}
-<AuHeading @level='3' @skin='4'>
-  {{t 'snippet-plugin.snippet-list.modal.subtitle'}}
-</AuHeading>
-{{#if @snippetLists.length}}
-  <div class="say-snippet-lists-table">
-    <AuTable class="say-snippet-lists-table">
-      <:header>
-        <tr>
-          <th class="selectColumn">{{t 'snippet-plugin.snippet-list.modal.table.select'}}</th>
-          <th>{{t 'snippet-plugin.snippet-list.modal.table.list'}}</th>
-        </tr>
-      </:header>
-      <:body>
-        {{#each @snippetLists as |snippetList|}}
-          <tr>
-            <td class="selectColumn">
-              <AuCheckbox
-                id={{snippetList.label}}
-                @onChange={{fn this.onChange snippetList.id}}
-                @checked={{in-array @assignedSnippetListsIds snippetList.id}}
-              />
-            </td>
-            <td>{{snippetList.label}}</td>
-          </tr>
-        {{/each}}
-      </:body>
-    </AuTable>
-  </div>
-{{/if}}
+<div class="say-snippet-lists-table">
+  {{#let (t "snippet-plugin.snippet-list.modal.table.list")
+         (t "snippet-plugin.snippet-list.modal.table.created")
+         (t "snippet-plugin.snippet-list.modal.table.select")
+         (t 'snippet-plugin.snippet-list.modal.subtitle')
+         (t 'snippet-plugin.snippet-list.modal.search.label')
+  as |list created select subtitle search|}}
+    <AuDataTable
+      @content={{this.snippetLists}}
+      @isLoading={{@isLoading}}
+      @noDataMessage={{t 'common.search.no-results'}}
+      @sort={{@sort}}
+      @onClickRow={{this.onClickRow}}
+      as |t|
+    >
+      <t.menu as |menu|>
+        <menu.general>
+          <AuToolbar class="au-o-box" as |Group|>
+            <Group />
+            <Group class="au-c-toolbar__group--center">
+              <AuDataTableTextSearch @wait={{500}} @filter={{@listNameFilter}} @placeholder={{search}} />
+            </Group>
+          </AuToolbar>
+        </menu.general>
+      </t.menu>
+      <t.content as |c|>
+        <c.header>
+          <th class="snippet-list-table-select-column">{{select}}</th>
+          <AuDataTableThSortable
+            @field="label"
+            @label={{list}}
+            @currentSorting={{@sort}}
+            @class="data-table__header-title"
+          />
+          <AuDataTableThSortable
+            @field="createdOn"
+            @label={{created}}
+            @currentSorting={{@sort}}
+            @class="data-table__header-title snippet-list-table-created-column"
+          />
+        </c.header>
+        <c.body as |row|>
+          <td class="snippet-list-table-select-column">
+            <AuCheckbox
+              id={{row.label}}
+              @onChange={{fn this.onChange row.id}}
+              @checked={{in-array @assignedSnippetListsIds row.id}}
+            />
+          </td>
+          <td>{{row.label}}</td>
+          <td class="snippet-list-table-created-column">{{row.createdOn}}</td>
+        </c.body>
+      </t.content>
+    </AuDataTable>
+  {{/let}}
+</div>

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-view.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-view.ts
@@ -1,10 +1,13 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { SnippetList } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 
 interface Args {
+  snippetLists: SnippetList[];
   assignedSnippetListsIds: string[];
+  listNameFilter: string | null;
+  isLoading: boolean;
   onChange: (assignedSnippetListsIds: string[]) => void;
-  closeModal: () => void;
 }
 
 export default class SnippetListViewComponent extends Component<Args> {
@@ -24,5 +27,23 @@ export default class SnippetListViewComponent extends Component<Args> {
     );
 
     return this.args.onChange(newSnippetListIds);
+  }
+
+  @action
+  onClickRow(snippetList: SnippetList) {
+    const snippetListId = snippetList.id;
+
+    if (!snippetListId) {
+      return;
+    }
+
+    const isSelected =
+      this.args.assignedSnippetListsIds.includes(snippetListId);
+
+    this.onChange(snippetListId, !isSelected);
+  }
+
+  get snippetLists() {
+    return this.args.snippetLists;
   }
 }

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -17,6 +17,15 @@
   &--list-container {
     overflow: auto;
     flex-grow: 1;
+
+    .snippet-list-table-select-column {
+      width: 100px;
+      text-align: center;
+    }
+
+    .snippet-list-table-created-column {
+      width: 200px;
+    }
   }
 
   .error-code {

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -284,6 +284,7 @@ snippet-plugin:
       table:
         select: Select
         list: List
+        created: Created
 
 template-comments-plugin:
   title: Template comment

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -288,6 +288,7 @@ snippet-plugin:
       table:
         select: Selecteer
         list: Lijst
+        created: Aangemaakt op
 
 template-comments-plugin:
   title: Toelichting


### PR DESCRIPTION
### Overview

GN-4816: Add sorting for snippet lists

* Use `AuDataTable` 
* Add sorting for snippet lists


##### connected issues and PRs:

* https://binnenland.atlassian.net/browse/GN-4816

### Setup

1. Checkout

### How to test/reproduce

See attached video

https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/1ae22625-a71d-4206-8117-31c3a4c9160c

* Filtering should work
* Sorting should work
* Selecting snippet lists when pressing on checkbox should work
* Selecting snippet lists when pressing on table row (new!) should work

### Challenges/uncertainties

`AuDataTable` is not really well documented in appuniversum repo, had to go look for examples, and dive to `ember-data-table` README.


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check if dummy app is correctly updated
- [X] Check cancel/go-back flows
- [X] changelog
- [X] npm lint
- [X] no new deprecations
