### PR TITLE
Fix behaviour of rdfa-aware decision articles

### DIFF
--- a/.changeset/loud-coins-bathe.md
+++ b/.changeset/loud-coins-bathe.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": patch
+---
+
+article-structure-plugin: Make `setStartNumber` and `getStartNumber` properties optional

--- a/addon/components/article-structure-plugin/structure-card.hbs
+++ b/addon/components/article-structure-plugin/structure-card.hbs
@@ -80,39 +80,41 @@
 
           </AuButtonGroup>
         </Item>
-        <Item class="au-u-padding-left-small">
-          <AuFormRow>
-            {{#let (unique-id) as |id|}}
-              <AuLabel for={{id}}>
-                {{t 'article-structure-plugin.start-number.start-number'}}
-              </AuLabel>
-              <AuInput
-                id={{id}}
-                value={{this.startNumberInputValue}}
-                {{on "change" this.onStartNumberChange}}
-                placeholder={{t 'article-structure-plugin.start-number.start-number'}}
-                type="number"
-                min="1"
-              />
-            {{/let}}
-          </AuFormRow>
-          <AuButton
-            @iconAlignment="left"
-            class="au-u-margin-top-tiny"
-            {{on 'click' this.setStructureStartNumber}}
-          >
-            {{t 'article-structure-plugin.start-number.set'}}
-          </AuButton>
-          <AuButton
-            @iconAlignment="left"
-            @skin="secondary"
-            @disabled={{not this.structureStartNumber}}
-            class="au-u-margin-top-tiny"
-            {{on 'click' this.resetStructureStartNumber}}
-          >
-            {{t 'article-structure-plugin.start-number.reset'}}
-          </AuButton>
-        </Item>
+        {{#if this.currentStructureType.getStartNumber}}
+          <Item class="au-u-padding-left-small">
+            <AuFormRow>
+              {{#let (unique-id) as |id|}}
+                <AuLabel for={{id}}>
+                  {{t 'article-structure-plugin.start-number.start-number'}}
+                </AuLabel>
+                <AuInput
+                  id={{id}}
+                  value={{this.startNumberInputValue}}
+                  {{on "change" this.onStartNumberChange}}
+                  placeholder={{t 'article-structure-plugin.start-number.start-number'}}
+                  type="number"
+                  min="1"
+                />
+              {{/let}}
+            </AuFormRow>
+            <AuButton
+              @iconAlignment="left"
+              class="au-u-margin-top-tiny"
+              {{on 'click' this.setStructureStartNumber}}
+            >
+              {{t 'article-structure-plugin.start-number.set'}}
+            </AuButton>
+            <AuButton
+              @iconAlignment="left"
+              @skin="secondary"
+              @disabled={{not this.structureStartNumber}}
+              class="au-u-margin-top-tiny"
+              {{on 'click' this.resetStructureStartNumber}}
+            >
+              {{t 'article-structure-plugin.start-number.reset'}}
+            </AuButton>
+          </Item>
+        {{/if}}
       </AuList>
     </c.content>
   </AuCard>

--- a/addon/components/article-structure-plugin/structure-card.ts
+++ b/addon/components/article-structure-plugin/structure-card.ts
@@ -111,7 +111,7 @@ export default class EditorPluginsStructureCardComponent extends Component<Args>
   }
 
   get structureStartNumber() {
-    if (this.structure && this.currentStructureType) {
+    if (this.structure && this.currentStructureType?.getStartNumber) {
       return this.currentStructureType.getStartNumber({
         pos: this.structure.pos,
         transaction: this.controller.mainEditorState.tr,

--- a/addon/components/roadsign-regulation-plugin/roadsign-regulation-card.ts
+++ b/addon/components/roadsign-regulation-plugin/roadsign-regulation-card.ts
@@ -4,6 +4,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { SayController } from '@lblod/ember-rdfa-editor';
 import { AddIcon } from '@appuniversum/ember-appuniversum/components/icons/add';
+import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
+import { RDF } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 
 /**
  * Card displaying a hint of the Date plugin
@@ -54,12 +56,18 @@ export default class RoadsignRegulationCard extends Component<Args> {
     const selection = this.controller.mainEditorState.selection;
     const besluitNode = findParentNode((node) => {
       if (node.type === this.schema.nodes['besluit']) {
-        const rdfTypes = (node.attrs['typeof'] as string | undefined)?.split(
-          ' ',
+        const properties = node.attrs.properties as OutgoingTriple[];
+        const decisionHasAcceptedType = Boolean(
+          properties.find((property) => {
+            const { predicate, object } = property;
+            return (
+              RDF('type').matches(predicate) &&
+              object.termType === 'NamedNode' &&
+              acceptedTypes.includes(object.value)
+            );
+          }),
         );
-        if (rdfTypes?.some((t) => acceptedTypes.includes(t))) {
-          return true;
-        }
+        return decisionHasAcceptedType;
       }
       return false;
     })(selection);

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -15,7 +15,10 @@ import { StructureSpec } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/ar
 import wrapStructureContent from './wrap-structure-content';
 import IntlService from 'ember-intl/services/intl';
 import { findInsertionRange } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/_private/find-insertion-range';
-import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import {
+  PROV,
+  SAY,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 
 const addPropertyToContainer = ({
   state,
@@ -41,8 +44,11 @@ const addPropertyToContainer = ({
   }
 
   const incoming = containerAttrs.backlinks;
-  const subject = incoming?.find((backlink) =>
-    SAY('body').matches(backlink.predicate),
+  // Also add PROV('value') to the check in order to support decision articles
+  const subject = incoming?.find(
+    (backlink) =>
+      SAY('body').matches(backlink.predicate) ||
+      PROV('value').matches(backlink.predicate),
   )?.subject;
 
   if (!subject) {

--- a/addon/plugins/article-structure-plugin/commands/recalculate-structure-numbers.ts
+++ b/addon/plugins/article-structure-plugin/commands/recalculate-structure-numbers.ts
@@ -72,7 +72,7 @@ export default function recalculateStructureNumbers(
           contexts[i] = parent;
         }
 
-        const startNumber = spec.getStartNumber({ pos, transaction });
+        const startNumber = spec.getStartNumber?.({ pos, transaction });
 
         if (startNumber) {
           indices[i] = startNumber;

--- a/addon/plugins/article-structure-plugin/commands/recalculate-structure-numbers.ts
+++ b/addon/plugins/article-structure-plugin/commands/recalculate-structure-numbers.ts
@@ -80,7 +80,7 @@ export default function recalculateStructureNumbers(
 
         spec.setNumber({ transaction, pos, number: indices[i] });
 
-        if ('convertNumber' in spec.numberConfig) {
+        if (spec.numberConfig.convertNumber) {
           updateNumberCalls.push({
             transaction,
             schema,

--- a/addon/plugins/article-structure-plugin/commands/set-structure-start-number.ts
+++ b/addon/plugins/article-structure-plugin/commands/set-structure-start-number.ts
@@ -13,6 +13,9 @@ const setStructureStartNumber = (
     const currentStructureSpec = unwrap(
       options.find((spec) => spec.name === structure.node.type.name),
     );
+    if (!currentStructureSpec.setStartNumber) {
+      return false;
+    }
 
     if (dispatch) {
       const transaction = state.tr;

--- a/addon/plugins/article-structure-plugin/index.ts
+++ b/addon/plugins/article-structure-plugin/index.ts
@@ -47,12 +47,12 @@ export type StructureSpec = {
     transaction: Transaction;
   }) => Transaction;
   getNumber: (args: { pos: number; transaction: Transaction }) => number | null;
-  setStartNumber: (args: {
+  setStartNumber?: (args: {
     number: number | null;
     pos: number;
     transaction: Transaction;
   }) => Transaction;
-  getStartNumber: (args: {
+  getStartNumber?: (args: {
     pos: number;
     transaction: Transaction;
   }) => number | null;

--- a/addon/plugins/article-structure-plugin/index.ts
+++ b/addon/plugins/article-structure-plugin/index.ts
@@ -39,7 +39,7 @@ export type StructureSpec = {
   }) => SpecConstructorResult;
   numberConfig: {
     numberPredicate?: Resource;
-    convertNumber: (number: number) => string;
+    convertNumber?: (number: number) => string;
   };
   setNumber: (args: {
     number: number;

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -291,7 +291,7 @@ export const enhanceAttributesWithNumberAttributes = (attrs: Attrs) => {
   };
 };
 
-const getNodeNumberAttrsFromElement = (element: Element) => {
+export const getNodeNumberAttrsFromElement = (element: Element) => {
   const number = element.getAttribute('data-number');
   const startNumber = element.getAttribute('data-start-number');
   const numberDisplayStyle = element.getAttribute('data-number-display-style');
@@ -303,7 +303,7 @@ const getNodeNumberAttrsFromElement = (element: Element) => {
   };
 };
 
-const maybeNumber = (number: string | number | null | undefined) => {
+export const maybeNumber = (number: string | number | null | undefined) => {
   if (typeof number === 'string' && number.length > 0) {
     return parseInt(number, 10);
   }

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -491,10 +491,6 @@ export const besluit: NodeSpec = {
   canSplit: false,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    typeof: {
-      default: 'besluit:Besluit ext:BesluitNieuweStijl',
-    },
-    subject: {},
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -514,37 +510,15 @@ export const besluit: NodeSpec = {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
         if (
           hasBacklink(rdfaAttrs, PROV('generated')) &&
-          hasOutgoingNamedNodeTriple(
-            rdfaAttrs,
-            RDF('type'),
-            BESLUIT('Besluit'),
-          ) &&
-          hasRdfaContentChild(element)
+          hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), BESLUIT('Besluit'))
         ) {
           return {
-            typeof: element.getAttribute('typeof'),
             ...rdfaAttrs,
           };
         }
         return false;
       },
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        if (
-          hasRDFaAttribute(element, 'property', PROV('generated')) &&
-          hasRDFaAttribute(element, 'typeof', BESLUIT('Besluit'))
-        ) {
-          return {
-            typeof: element.getAttribute('typeof'),
-            ...getRdfaAttrs(element, { rdfaAware }),
-          };
-        }
-        return false;
-      },
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -178,10 +178,6 @@ export const besluit_article: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    typeof: {
-      default: BESLUIT('Artikel').prefixed,
-    },
-    subject: {},
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -201,31 +197,13 @@ export const besluit_article: NodeSpec = {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
         if (
           hasBacklink(rdfaAttrs, ELI('has_part')) &&
-          hasOutgoingNamedNodeTriple(
-            rdfaAttrs,
-            RDF('type'),
-            BESLUIT('Artikel'),
-          ) &&
-          hasRdfaContentChild(element)
+          hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), BESLUIT('Artikel'))
         ) {
           return rdfaAttrs;
         }
         return false;
       },
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        if (
-          hasRDFaAttribute(element, 'property', ELI('has_part')) &&
-          hasRDFaAttribute(element, 'typeof', BESLUIT('Artikel'))
-        ) {
-          return getRdfaAttrs(element, { rdfaAware });
-        }
-        return false;
-      },
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -1,7 +1,6 @@
 import { getRdfaAttrs, NodeSpec, rdfaAttrSpec } from '@lblod/ember-rdfa-editor';
 import {
   getRdfaContentElement,
-  hasRdfaContentChild,
   renderRdfaAware,
   sharedRdfaNodeSpec,
 } from '@lblod/ember-rdfa-editor/core/schema';

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -292,6 +292,8 @@ export const besluit_article_header: NodeSpec = {
       renderRdfaAware({
         renderable: node,
         tag: 'span',
+        rdfaContainerTag: 'span',
+        contentContainerTag: 'span',
         attrs: {
           ...attrs,
           class: 'say-inline-rdfa',

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -1,6 +1,7 @@
 import { getRdfaAttrs, NodeSpec, rdfaAttrSpec } from '@lblod/ember-rdfa-editor';
 import {
   getRdfaContentElement,
+  RdfaAttrs,
   renderRdfaAware,
   sharedRdfaNodeSpec,
 } from '@lblod/ember-rdfa-editor/core/schema';
@@ -10,6 +11,7 @@ import {
   PROV,
   RDF,
   SKOS,
+  XSD,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import {
   hasBacklink,
@@ -20,7 +22,8 @@ import { StructureSpec } from '../../article-structure-plugin';
 import { v4 as uuid } from 'uuid';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
-import { getNumberUtils } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/utils/structure';
+import { maybeNumber } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/utils/structure';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 
 const rdfaAware = true;
 export const besluit_title: NodeSpec = {
@@ -194,11 +197,17 @@ export const besluit_article: NodeSpec = {
       tag: 'div',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
+
         if (
-          hasBacklink(rdfaAttrs, ELI('has_part')) &&
+          rdfaAttrs &&
+          rdfaAttrs.rdfaNodeType === 'resource' &&
           hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), BESLUIT('Artikel'))
         ) {
-          return rdfaAttrs;
+          // Filter out properties we handle ourselves (like the article number)
+          const filteredProperties = rdfaAttrs.properties.filter(
+            (prop) => !ELI('number').matches(prop.predicate),
+          );
+          return { ...rdfaAttrs, properties: filteredProperties };
         }
         return false;
       },
@@ -218,40 +227,60 @@ export const besluitArticleStructure: StructureSpec = {
     remove: 'article-structure-plugin.remove.article',
   },
   limitTo: 'besluit',
+  relationshipPredicate: ELI('has_part'),
   constructor: ({ schema, number, content, intl, state }) => {
     const translationWithDocLang = getTranslationFunction(state);
     const articleRdfaId = uuid();
+    const bodyRdfaId = uuid();
     const subject = `http://data.lblod.info/articles/${articleRdfaId}`;
-    const node = schema.node(
-      `besluit_article`,
-      {
-        subject,
-        rdfaNodeType: 'resource',
-        __rdfaId: articleRdfaId,
-      },
-      [
-        schema.node('besluit_article_header', {
-          number: number ?? 1,
-        }),
-        schema.node(
-          `besluit_article_content`,
-          {},
-          content ??
-            schema.node(
-              'paragraph',
-              {},
-              schema.node('placeholder', {
-                placeholderText: translationWithDocLang(
-                  'article-structure-plugin.placeholder.article.body',
-                  intl?.t(
-                    'article-structure-plugin.placeholder.article.body',
-                  ) || '',
-                ),
-              }),
-            ),
-        ),
+
+    const articleAttrs: RdfaAttrs = {
+      __rdfaId: articleRdfaId,
+      rdfaNodeType: 'resource',
+      subject,
+      properties: [
+        {
+          predicate: RDF('type').prefixed,
+          object: sayDataFactory.namedNode(BESLUIT('Artikel').full),
+        },
+        {
+          predicate: PROV('value').prefixed,
+          object: sayDataFactory.literalNode(bodyRdfaId),
+        },
       ],
-    );
+      backlinks: [],
+    };
+    const bodyAttrs: RdfaAttrs = {
+      __rdfaId: bodyRdfaId,
+      rdfaNodeType: 'literal',
+      backlinks: [
+        {
+          subject: sayDataFactory.literalNode(subject),
+          predicate: PROV('value').prefixed,
+        },
+      ],
+    };
+    const node = schema.node(`besluit_article`, articleAttrs, [
+      schema.node('besluit_article_header', {
+        number: number ?? 1,
+      }),
+      schema.node(
+        `besluit_article_content`,
+        bodyAttrs,
+        content ??
+          schema.node(
+            'paragraph',
+            {},
+            schema.node('placeholder', {
+              placeholderText: translationWithDocLang(
+                'article-structure-plugin.placeholder.article.body',
+                intl?.t('article-structure-plugin.placeholder.article.body') ||
+                  '',
+              ),
+            }),
+          ),
+      ),
+    ]);
 
     return {
       node,
@@ -262,9 +291,20 @@ export const besluitArticleStructure: StructureSpec = {
       },
     };
   },
-  ...getNumberUtils({
-    offset: 1,
-  }),
+  setNumber: ({ number, pos, transaction }) =>
+    transaction.setNodeAttribute(pos + 1, 'number', number),
+  getNumber: ({ pos, transaction }) => {
+    const node = unwrap(transaction.doc.nodeAt(pos + 1));
+
+    const number = maybeNumber(node.attrs.number);
+
+    if (number !== null) {
+      return number;
+    }
+
+    return null;
+  },
+  numberConfig: {},
   content: ({ pos, state }) => {
     const node = unwrap(state.doc.nodeAt(pos));
     return unwrap(node.lastChild).content;
@@ -278,28 +318,21 @@ export const besluit_article_header: NodeSpec = {
   isLeaf: true,
   ...sharedRdfaNodeSpec,
   attrs: {
-    ...rdfaAttrSpec({ rdfaAware }),
     number: {
       default: 1,
     },
   },
   toDOM(node) {
-    const { number, ...attrs } = node.attrs;
+    const { number } = node.attrs;
     return [
       'div',
       { contenteditable: false },
       'Artikel ',
-      renderRdfaAware({
-        renderable: node,
-        tag: 'span',
-        rdfaContainerTag: 'span',
-        contentContainerTag: 'span',
-        attrs: {
-          ...attrs,
-          class: 'say-inline-rdfa',
-        },
-        content: (number as number).toString() ?? '1',
-      }),
+      [
+        'span',
+        { property: ELI('number').prefixed, datatype: XSD('integer').prefixed },
+        (number as number).toString() ?? '1',
+      ],
     ];
   },
   parseDOM: [
@@ -316,7 +349,6 @@ export const besluit_article_header: NodeSpec = {
             ? parseInt(numberNode.textContent, 10)
             : 1;
           return {
-            ...getRdfaAttrs(numberNode as HTMLElement, { rdfaAware }),
             number,
           };
         }

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -33,12 +33,6 @@ export const besluit_title: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    property: {
-      default: 'eli:title',
-    },
-    datatype: {
-      default: 'xsd:string',
-    },
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -58,29 +52,12 @@ export const besluit_title: NodeSpec = {
       tag: 'h1,h2,h3,h4,h5',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-        if (
-          hasBacklink(rdfaAttrs, ELI('title')) &&
-          hasRdfaContentChild(element)
-        ) {
+        if (hasBacklink(rdfaAttrs, ELI('title'))) {
           return rdfaAttrs;
         }
         return false;
       },
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'h1,h2,h3,h4,h5',
-      getAttrs(element: HTMLElement) {
-        if (hasRDFaAttribute(element, 'property', ELI('title'))) {
-          const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-          return {
-            ...rdfaAttrs,
-            subject: element.getAttribute('resource'),
-          };
-        }
-        return false;
-      },
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -333,9 +333,6 @@ export const besluit_article_content: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    datatype: {
-      default: 'xsd:string',
-    },
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -353,27 +350,13 @@ export const besluit_article_content: NodeSpec = {
       tag: 'div',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-        if (
-          hasBacklink(rdfaAttrs, PROV('value')) &&
-          hasRdfaContentChild(element)
-        ) {
+        if (hasBacklink(rdfaAttrs, PROV('value'))) {
           return getRdfaAttrs(element, { rdfaAware });
         }
         return false;
       },
       contentElement: getRdfaContentElement,
       context: 'besluit_article/',
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        if (hasRDFaAttribute(element, 'property', PROV('value'))) {
-          return getRdfaAttrs(element, { rdfaAware });
-        }
-        return false;
-      },
-      context: 'besluit_article//',
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -106,12 +106,6 @@ export const motivering: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    property: {
-      default: 'besluit:motivering',
-    },
-    lang: {
-      default: 'nl',
-    },
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -129,25 +123,12 @@ export const motivering: NodeSpec = {
       tag: 'div',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-        if (
-          hasBacklink(rdfaAttrs, BESLUIT('motivering')) &&
-          hasRdfaContentChild(element)
-        ) {
+        if (hasBacklink(rdfaAttrs, BESLUIT('motivering'))) {
           return rdfaAttrs;
         }
         return false;
       },
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        if (hasRDFaAttribute(element, 'property', BESLUIT('motivering'))) {
-          return getRdfaAttrs(element, { rdfaAware });
-        }
-        return false;
-      },
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -142,12 +142,6 @@ export const article_container: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    property: {
-      default: 'prov:value',
-    },
-    datatype: {
-      default: 'xsd:string',
-    },
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -165,27 +159,13 @@ export const article_container: NodeSpec = {
       tag: 'div',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-        if (
-          hasBacklink(rdfaAttrs, PROV('value')) &&
-          hasRdfaContentChild(element)
-        ) {
+        if (hasBacklink(rdfaAttrs, PROV('value'))) {
           return rdfaAttrs;
         }
         return false;
       },
       context: 'besluit/',
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div',
-      getAttrs(element: HTMLElement) {
-        if (hasRDFaAttribute(element, 'property', PROV('value'))) {
-          return getRdfaAttrs(element, { rdfaAware });
-        }
-        return false;
-      },
-      context: 'besluit/',
     },
   ],
 };

--- a/addon/plugins/standard-template-plugin/utils/nodes.ts
+++ b/addon/plugins/standard-template-plugin/utils/nodes.ts
@@ -71,12 +71,6 @@ export const description: NodeSpec = {
   editable: true,
   attrs: {
     ...rdfaAttrSpec({ rdfaAware }),
-    property: {
-      default: 'eli:description',
-    },
-    datatype: {
-      default: 'xsd:string',
-    },
   },
   toDOM(node) {
     return renderRdfaAware({
@@ -94,25 +88,12 @@ export const description: NodeSpec = {
       tag: 'div,p',
       getAttrs(element: HTMLElement) {
         const rdfaAttrs = getRdfaAttrs(element, { rdfaAware });
-        if (
-          hasBacklink(rdfaAttrs, ELI('description')) &&
-          hasRdfaContentChild(element)
-        ) {
+        if (hasBacklink(rdfaAttrs, ELI('description'))) {
           return rdfaAttrs;
         }
         return false;
       },
       contentElement: getRdfaContentElement,
-    },
-    // Compatibility with pre-RDFa-aware HTML
-    {
-      tag: 'div,p',
-      getAttrs(element: HTMLElement) {
-        if (hasRDFaAttribute(element, 'property', ELI('description'))) {
-          return getRdfaAttrs(element, { rdfaAware });
-        }
-        return false;
-      },
     },
   ],
 };

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -91,14 +91,24 @@ import LocationInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/comp
 import CodelistInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/codelist/insert';
 import VariablePluginAddressInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/insert-variable';
 import { redacted } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/confidentiality-plugin/marks/redacted';
-import { inlineRdfaWithConfig, inlineRdfaWithConfigView } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
+import {
+  inlineRdfaWithConfig,
+  inlineRdfaWithConfigView,
+} from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
 import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
 import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
 import SnippetListSelectRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-list-select-rdfa';
-import { CitationPluginConfig, citationPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
-import { editableNodePlugin, getActiveEditableNode } from '@lblod/ember-rdfa-editor/plugins/editable-node';
+import {
+  CitationPluginConfig,
+  citationPlugin,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
+import {
+  editableNodePlugin,
+  getActiveEditableNode,
+} from '@lblod/ember-rdfa-editor/plugins/editable-node';
+import { ComponentLike } from '@glint/template';
 
 export default class RegulatoryStatementSampleController extends Controller {
   SnippetInsert = SnippetInsertRdfaComponent;
@@ -215,29 +225,30 @@ export default class RegulatoryStatementSampleController extends Controller {
     return [
       {
         label: 'text',
-        component: TextVariableInsertComponent,
+        component: TextVariableInsertComponent as unknown as ComponentLike,
       },
       {
         label: 'number',
-        component: NumberInsertComponent,
+        component: NumberInsertComponent as unknown as ComponentLike,
       },
       {
         label: 'date',
-        component: DateInsertVariableComponent,
+        component: DateInsertVariableComponent as unknown as ComponentLike,
       },
       {
         label: 'location',
-        component: LocationInsertComponent,
+        component: LocationInsertComponent as unknown as ComponentLike,
         options: this.locationOptions,
       },
       {
         label: 'codelist',
-        component: CodelistInsertComponent,
+        component: CodelistInsertComponent as unknown as ComponentLike,
         options: this.codelistOptions,
       },
       {
         label: 'address',
-        component: VariablePluginAddressInsertVariableComponent,
+        component:
+          VariablePluginAddressInsertVariableComponent as unknown as ComponentLike,
       },
     ];
   }
@@ -286,7 +297,6 @@ export default class RegulatoryStatementSampleController extends Controller {
   }
 
   get activeNode() {
-    console.log('Get active Node: ', getActiveEditableNode(this.controller.activeEditorState))
     if (this.controller) {
       return getActiveEditableNode(this.controller.activeEditorState);
     }


### PR DESCRIPTION
### Overview
This PR fixes some of the issues related to the rdfa-aware version of decision articles (the `besluit_article` node).
Specifically, this PR includes the following changes:
- The `setStartNumber` and `getStartNumber` properties are now optional. If these are not provided, the feature is not enabled.
- Adjust the `besluit_article` node to work in the `rdfa-aware` system
   * The `besluit_article` node is `rdfa-aware`, except for the `eli:number` property
   * The `besluit_article_header` node still works using the classic RDFa approach
   * The `besluit_article_content` node works using the `rdfa-aware approach
- Adjust `insertStructure` with hacky fix to support decision articles correctly (ensure `ELI('has_part')` predicate is correctly inserted)

### How to test/reproduce
- Inserting, moving and removing decision articles should now work as before.
- When reloading a decision containing articles, the articles should be parsed correctly.

### Challenges/uncertainties
I realize that this hybrid 'classic RDFa'/'rdfa-aware' approach for decision articles is not ideal, I did not however find a more feasible solution for now.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
