### PR TITLE
article-structures: fix structure insertion with content

### DIFF
--- a/.changeset/clean-parrots-beam.md
+++ b/.changeset/clean-parrots-beam.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": patch
+---
+
+When passing a `content` argument to the `insertStructure` command, do not run the `wrapStructureContent` command

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -17,7 +17,10 @@ const insertStructure = (
 ): Command => {
   return (state, dispatch) => {
     const { schema, selection, doc } = state;
-    if (wrapStructureContent(structureSpec, intl)(state, dispatch)) {
+    if (
+      !content &&
+      wrapStructureContent(structureSpec, intl)(state, dispatch)
+    ) {
       return true;
     }
     const insertionRange = findInsertionRange({


### PR DESCRIPTION
### Overview
This PR fixes an issue in the `insertStructure` command when passing the `content` argument. It ensures the `wrapStructureContent` command is never attempted when passing the `content` argument.


##### connected issues and PRs:
None

### How to test/reproduce
#### Before this PR
- Insert the sample `DecisionTemplate`
- Insert a roadsign regulation
- Notice that only the article (without any content or roadsign regulation) is inserted.
#### Before this PR
- Insert the sample `DecisionTemplate`
- Insert a roadsign regulation
- The article with the right roadsign regulation should be inserted.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
