### PR TITLE
GN-4810: get the `roadsign-regulation` plugin working with the `rdfa-aware` decision nodes

### DIFF
--- a/addon/components/roadsign-regulation-plugin/roadsign-regulation-card.ts
+++ b/addon/components/roadsign-regulation-plugin/roadsign-regulation-card.ts
@@ -4,6 +4,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { SayController } from '@lblod/ember-rdfa-editor';
 import { AddIcon } from '@appuniversum/ember-appuniversum/components/icons/add';
+import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
+import { RDF } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 
 /**
  * Card displaying a hint of the Date plugin
@@ -54,12 +56,18 @@ export default class RoadsignRegulationCard extends Component<Args> {
     const selection = this.controller.mainEditorState.selection;
     const besluitNode = findParentNode((node) => {
       if (node.type === this.schema.nodes['besluit']) {
-        const rdfTypes = (node.attrs['typeof'] as string | undefined)?.split(
-          ' ',
+        const properties = node.attrs.properties as OutgoingTriple[];
+        const decisionHasAcceptedType = Boolean(
+          properties.find((property) => {
+            const { predicate, object } = property;
+            return (
+              RDF('type').matches(predicate) &&
+              object.termType === 'NamedNode' &&
+              acceptedTypes.includes(object.value)
+            );
+          }),
         );
-        if (rdfTypes?.some((t) => acceptedTypes.includes(t))) {
-          return true;
-        }
+        return decisionHasAcceptedType;
       }
       return false;
     })(selection);


### PR DESCRIPTION
### Overview
This PR includes some updates to the `roadsign-regulation` plugin to ensure it works correctly in combination with the `rdfa-aware` system.
For now, I've decided to keep using the classic RDFa system for the roadsign regulations.

##### connected issues and PRs:
[GN-4810](https://binnenland.atlassian.net/browse/GN-4810?atlOrigin=eyJpIjoiOTQ5MDNjMDVlN2U4NGNlM2E2MzRmNWZmYzhiNmFlYTIiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the dummy app
- Insert a sample decision with decision-type 'Reglementen en verordeningen'
- Ensure that the `Insert traffic measure` inserts a `roadsign_regulation` node correctly in a new article node
- The roadsign regulation should be preserved correctly across reloads

### Challenges/uncertainties
I have decided to hold off moving the `roadsign_regulation` node to the rdfa-aware system as I did not really yet see the point of moving these over.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
