### PR TITLE
Use OSLO model for addresses

### DIFF
--- a/.changeset/nervous-paws-yawn.md
+++ b/.changeset/nervous-paws-yawn.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": minor
+---
+
+Use OSLO model for addresses in variable-plugin

--- a/.changeset/sour-peas-hear.md
+++ b/.changeset/sour-peas-hear.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": patch
+---
+
+Change format for geodata used by the address plugin to WKT instead of GML to match the OSLO spec

--- a/.changeset/warm-geese-cheer.md
+++ b/.changeset/warm-geese-cheer.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": patch
+---
+
+Correct typo in adres: prefix

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,7 +70,7 @@ module.exports = {
         semi: 'off',
         '@typescript-eslint/no-unused-vars': [
           'error',
-          { argsIgnorePattern: '^_' },
+          { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
         ],
         '@typescript-eslint/semi': ['error', 'always'],
 

--- a/addon/components/loading-alert.hbs
+++ b/addon/components/loading-alert.hbs
@@ -6,7 +6,9 @@
     data-test-alert
     ...attributes
   >
-    <AuLoader />
+    <AuLoader @hideMessage={{true}}>
+      {{t 'common.search.loading'}}
+    </AuLoader>
     <div class='au-c-alert__content'>
       {{#if @title}}
         <p class='au-c-alert__title' data-test-alert-title>{{@title}}</p>

--- a/addon/components/variable-plugin/address/edit.ts
+++ b/addon/components/variable-plugin/address/edit.ts
@@ -1,8 +1,8 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { NodeSelection, SayController } from '@lblod/ember-rdfa-editor';
-import { Address } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 import {
+  Address,
   AddressError,
   fetchMunicipalities,
   fetchStreets,

--- a/addon/components/variable-plugin/address/nodeview.ts
+++ b/addon/components/variable-plugin/address/nodeview.ts
@@ -4,7 +4,7 @@ import IntlService from 'ember-intl/services/intl';
 import { PencilIcon } from '@appuniversum/ember-appuniversum/components/icons/pencil';
 
 import { PNode, SayController } from '@lblod/ember-rdfa-editor';
-import { Address } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/address';
+import { Address } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/utils/address-helpers';
 import { getOutgoingTriple } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 

--- a/addon/plugins/variable-plugin/utils/address-helpers.ts
+++ b/addon/plugins/variable-plugin/utils/address-helpers.ts
@@ -93,9 +93,9 @@ export class AddressError extends Error {
 }
 
 const LOC_GEOPUNT_ENDPOINT = `https://geo.api.vlaanderen.be/geolocation/v4/Location`;
-const BASISREGISTER_ADRESMATCH =
-  'https://api.basisregisters.vlaanderen.be/v2/adresmatch';
-const BASISREGISTER_ADRES = `https://basisregisters.vlaanderen.be/api/v2/adressen`;
+const BASISREGISTER = 'https://api.basisregisters.vlaanderen.be/v2';
+const BASISREGISTER_ADRESMATCH = `${BASISREGISTER}/adresmatch`;
+const BASISREGISTER_ADRES = `${BASISREGISTER}/adressen`;
 
 export const replaceAccents = (string: string) =>
   string.normalize('NFD').replace(/([\u0300-\u036f])/g, '');

--- a/addon/plugins/variable-plugin/utils/address-helpers.ts
+++ b/addon/plugins/variable-plugin/utils/address-helpers.ts
@@ -1,16 +1,29 @@
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
-import { Address } from '../variables/address';
 
+type GeoCoordinate = {
+  Lat_WGS84: number;
+  Lon_WGS84: number;
+  X_Lambert72: number;
+  Y_Lambert72: number;
+};
+/**
+ * Specified [in the API docs]{@link https://geo.api.vlaanderen.be/geolocation/}.
+ * It is not specified which fields can be null, so these might be incorrect.
+ */
 type LocationRegisterSearchResult = {
   LocationResult: [
     {
+      ID: number;
       Municipality: string;
       Zipcode: string | null;
       Thoroughfarename: string | null;
       Housenumber: string | null;
-      Location: {
-        X_Lambert72: number;
-        Y_Lambert72: number;
+      FormattedAddress: string | null;
+      Location: GeoCoordinate;
+      LocationType: string | null;
+      BoundingBox: {
+        LowerLeft: GeoCoordinate;
+        UpperRight: GeoCoordinate;
       };
     },
   ];
@@ -40,6 +53,9 @@ type AddressSearchResult = {
   }[];
 };
 
+/**
+ * {@link https://docs.basisregisters.vlaanderen.be/docs/api-documentation.html#operation/GetAddressV2}
+ */
 type AddressDetailResult = {
   identificator: {
     id: string;
@@ -71,6 +87,58 @@ type AddressDetailResult = {
     };
   };
 };
+
+export class Address {
+  declare id?: string;
+  declare street: string;
+  declare zipcode: string;
+  declare municipality: string;
+  declare housenumber?: string;
+  declare busnumber?: string;
+  declare location: Lambert72Coordinates;
+  constructor(
+    args: Pick<
+      Address,
+      | 'street'
+      | 'housenumber'
+      | 'zipcode'
+      | 'municipality'
+      | 'id'
+      | 'busnumber'
+      | 'location'
+    >,
+  ) {
+    Object.assign(this, args);
+  }
+
+  get formatted() {
+    if (this.housenumber && this.busnumber) {
+      return `${this.street} ${this.housenumber} bus ${this.busnumber}, ${this.zipcode} ${this.municipality}`;
+    } else if (this.housenumber) {
+      return `${this.street} ${this.housenumber}, ${this.zipcode} ${this.municipality}`;
+    } else {
+      return `${this.street}, ${this.zipcode} ${this.municipality}`;
+    }
+  }
+
+  sameAs(
+    other?: Pick<
+      Address,
+      'street' | 'housenumber' | 'busnumber' | 'municipality'
+    > | null,
+  ) {
+    return (
+      this.street === other?.street &&
+      this.housenumber === other?.housenumber &&
+      this.busnumber === other?.busnumber &&
+      this.municipality === other?.municipality
+    );
+  }
+
+  get hasHouseNumber() {
+    return !!this.housenumber;
+  }
+}
 
 export class AddressError extends Error {
   translation: string;
@@ -175,10 +243,10 @@ export async function resolveStreet(info: StreetInfo) {
         street: unwrap(streetinfo.Thoroughfarename),
         municipality: streetinfo.Municipality,
         zipcode: unwrap(streetinfo.Zipcode),
-        gml: constructLambert72GMLString({
+        location: {
           x: streetinfo.Location.X_Lambert72,
           y: streetinfo.Location.Y_Lambert72,
-        }),
+        },
       });
     } else {
       throw new AddressError({
@@ -215,7 +283,7 @@ export async function resolveAddress(info: AddressInfo) {
         zipcode: result.postinfo.objectId,
         municipality: result.gemeente.gemeentenaam.geografischeNaam.spelling,
         id: result.identificator.id,
-        gml: result.adresPositie.geometrie.gml,
+        location: parseLambert72GMLString(result.adresPositie.geometrie.gml),
       });
     } else {
       throw new AddressError({
@@ -267,11 +335,61 @@ export async function searchAddress(
   }
 }
 
-type Lambert72Coordinates = {
+/** Representation of a location in the `BD72 / Belgian Lambert 72` Coordinate Reference System */
+export type Lambert72Coordinates = {
   x: number;
   y: number;
 };
 
-function constructLambert72GMLString({ x, y }: Lambert72Coordinates) {
+export function constructLambert72GMLString({ x, y }: Lambert72Coordinates) {
   return `<gml:Point srsName="https://www.opengis.net/def/crs/EPSG/0/31370" xmlns:gml="http://www.opengis.net/gml/3.2"><gml:pos>${x} ${y}</gml:pos></gml:Point>`;
+}
+/**
+ * Use a regex to parse a simple point as a GML string and return the coordinates.
+ * Throws an error if the format or CRS are not recognised
+ */
+export function parseLambert72GMLString(gml: string): Lambert72Coordinates {
+  // Parsers for GML exist in other libraries, but mostly within much larger projects (e.g.
+  // openlayers) in a way that is hard to extract due to the potential complexity of the geometries
+  // which can be represented. Since we handle only simple points, it's much less complex to just
+  // use a simple regex.
+  const [_, crs, x, y] =
+    /<gml.Point .*srsName="https:\/\/www.opengis.net\/def\/crs\/([^"]+)".+<gml.pos>(\S+) ([^<]+)<\/gml:pos>/.exec(
+      gml,
+    ) || [];
+  if (!crs || crs !== 'EPSG/0/31370') {
+    throw new AddressError({
+      translation: 'editor-plugins.address.edit.errors.http-error',
+      message: 'An error occured when querying the address register',
+    });
+  }
+  return { x: Number(x), y: Number(y) };
+}
+/**
+ * Construct a string to represent a geolocation, using the Lambert 72 reference system according to
+ * [the GeoSPARQL spec]{@link https://docs.ogc.org/is/22-047r1/22-047r1.html#10-8-1-%C2%A0-well-known-text}
+ */
+export function constructLambert72WKTString({ x, y }: Lambert72Coordinates) {
+  return `<https://www.opengis.net/def/crs/EPSG/0/31370> POINT(${x} ${y})`;
+}
+/**
+ * Use a regex to parse a simple point as a WKT string and return the coordinates.
+ * Throws an error if the format or CRS are not recognised
+ */
+export function parseLambert72WKTString(gml: string): Lambert72Coordinates {
+  // Parsers for WKT exist in other libraries, but either within much larger projects (e.g.
+  // openlayers) in a way that is hard to extract due to the potential complexity of the geometries
+  // which can be represented or within untyped libraries (e.g. wicket). Since we handle only simple
+  // points, it's much less complex to just use a simple regex.
+  const [_, crs, x, y] =
+    /<https:\/\/www.opengis.net\/def\/crs\/([^"]+)> POINT\((\S+) ([^)]+)\)/.exec(
+      gml,
+    ) || [];
+  if (!crs || crs !== 'EPSG/0/31370') {
+    throw new AddressError({
+      translation: 'editor-plugins.address.edit.errors.http-error',
+      message: 'An error occured when querying the address register',
+    });
+  }
+  return { x: Number(x), y: Number(y) };
 }

--- a/addon/plugins/variable-plugin/variables/address.ts
+++ b/addon/plugins/variable-plugin/variables/address.ts
@@ -1,5 +1,5 @@
 import {
-  ADRES,
+  ADRES_TYPO,
   DCT,
   EXT,
   GENERIEK,
@@ -98,7 +98,7 @@ export class Address {
 const constructLocationNode = (gml: string) => {
   return span(
     {
-      property: ADRES('positie').full,
+      property: ADRES_TYPO('positie').full,
       typeof: GENERIEK('GeografischePositie').full,
     },
     span({
@@ -115,7 +115,7 @@ const constructAddressNode = (address: Address) => {
         ' ',
         span(
           {
-            property: ADRES('huisnummer').full,
+            property: ADRES_TYPO('huisnummer').full,
           },
           address.housenumber,
         ),
@@ -126,17 +126,17 @@ const constructAddressNode = (address: Address) => {
         ' bus ',
         span(
           {
-            property: ADRES('busnummer').full,
+            property: ADRES_TYPO('busnummer').full,
           },
           address.busnumber,
         ),
       ]
     : [];
   return contentSpan(
-    { resource: address.id, typeof: ADRES('Adres').full },
+    { resource: address.id, typeof: ADRES_TYPO('Adres').full },
     span(
       {
-        property: ADRES('heeftStraatnaam').full,
+        property: ADRES_TYPO('heeftStraatnaam').full,
       },
       address.street,
     ),
@@ -145,12 +145,12 @@ const constructAddressNode = (address: Address) => {
     ', ',
     span(
       {
-        property: ADRES('heeftPostinfo').full,
-        typeof: ADRES('Postinfo').full,
+        property: ADRES_TYPO('heeftPostinfo').full,
+        typeof: ADRES_TYPO('Postinfo').full,
       },
       span(
         {
-          property: ADRES('postcode').full,
+          property: ADRES_TYPO('postcode').full,
         },
         address.zipcode,
       ),
@@ -158,7 +158,7 @@ const constructAddressNode = (address: Address) => {
     ' ',
     span(
       {
-        property: ADRES('gemeentenaam').full,
+        property: ADRES_TYPO('gemeentenaam').full,
       },
       address.municipality,
     ),
@@ -171,37 +171,37 @@ const parseAddressNode = (addressNode: Element): Address | undefined => {
   const street = findChildWithRdfaAttribute(
     addressNode,
     'property',
-    ADRES('heeftStraatnaam'),
+    ADRES_TYPO('heeftStraatnaam'),
   )?.textContent;
   const housenumber = findChildWithRdfaAttribute(
     addressNode,
     'property',
-    ADRES('huisnummer'),
+    ADRES_TYPO('huisnummer'),
   )?.textContent;
   const busnumber = findChildWithRdfaAttribute(
     addressNode,
     'property',
-    ADRES('busnummer'),
+    ADRES_TYPO('busnummer'),
   )?.textContent;
   const postInfoNode = findChildWithRdfaAttribute(
     addressNode,
     'property',
-    ADRES('heeftPostinfo'),
+    ADRES_TYPO('heeftPostinfo'),
   );
   const zipcode =
     postInfoNode &&
-    findChildWithRdfaAttribute(postInfoNode, 'property', ADRES('postcode'))
+    findChildWithRdfaAttribute(postInfoNode, 'property', ADRES_TYPO('postcode'))
       ?.textContent;
   const municipality = findChildWithRdfaAttribute(
     addressNode,
     'property',
-    ADRES('gemeentenaam'),
+    ADRES_TYPO('gemeentenaam'),
   )?.textContent;
 
   const locationNode = findChildWithRdfaAttribute(
     addressNode,
     'property',
-    ADRES('positie'),
+    ADRES_TYPO('positie'),
   );
   const gml =
     locationNode &&

--- a/addon/utils/constants.ts
+++ b/addon/utils/constants.ts
@@ -35,3 +35,4 @@ export const GEOSPARQL = namespace(
   'http://www.opengis.net/ont/geosparql#',
   'geosparql',
 );
+export const LOCN = namespace('http://www.w3.org/ns/locn#', 'locn');

--- a/addon/utils/constants.ts
+++ b/addon/utils/constants.ts
@@ -21,7 +21,11 @@ export const MOBILITEIT = namespace(
   'mobiliteit',
 );
 
-export const ADRES = namespace('https://data.vlaanderen.be/ns/adres/', 'adres');
+export const ADRES_TYPO = namespace(
+  'https://data.vlaanderen.be/ns/adres/',
+  'adres',
+);
+export const ADRES = namespace('https://data.vlaanderen.be/ns/adres#', 'adres');
 export const GENERIEK = namespace(
   'https://data.vlaanderen.be/ns/generiek/#',
   'generiek',


### PR DESCRIPTION
### Overview
Tweak the representation of addresses produced by variable-plugin to conform to the OSLO model.

Includes converting GML location data to WKT as that is used in the spec. The conversion used only works for simple points, but we don't handle anything but this already. Notes as to why I used a regex instead of a full parser are in comments.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4838

### Setup
N/A

### How to test/reproduce
Inserting and editing addresses should work correctly. The exported HTML should match the OSLO data model for addresses.

### Challenges/uncertainties
We slightly abuse the model by re-using the id of the address as the resource id, which their examples do not. I assumed this was fine though.
I reverted my changes to use language correctly as it caused too many issues to be worth it, given everything will be in 'nl' (even the name of the field returned by the API is 'taal').
~~I also haven't converted the location point to use WKT, which is implied as being required in their docs. We could easily add a module to handle conversions from GML and do that however.~~

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
