### PR TITLE
Remove label when variable is filled

### DIFF
--- a/.changeset/big-pugs-sneeze.md
+++ b/.changeset/big-pugs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": minor
+---
+
+Hide label if the variable is filled

--- a/addon/components/location-plugin/nodeview.ts
+++ b/addon/components/location-plugin/nodeview.ts
@@ -44,7 +44,7 @@ export default class AddressNodeviewComponent extends Component<Args> {
   }
 
   get label() {
-    if(this.address) return ''
+    if (this.address) return '';
     return getOutgoingTriple(this.node.attrs, EXT('label'))?.object.value;
   }
 }

--- a/addon/components/location-plugin/nodeview.ts
+++ b/addon/components/location-plugin/nodeview.ts
@@ -44,6 +44,7 @@ export default class AddressNodeviewComponent extends Component<Args> {
   }
 
   get label() {
+    if(this.address) return ''
     return getOutgoingTriple(this.node.attrs, EXT('label'))?.object.value;
   }
 }

--- a/addon/components/variable-plugin/address/nodeview.ts
+++ b/addon/components/variable-plugin/address/nodeview.ts
@@ -44,7 +44,7 @@ export default class AddressNodeviewComponent extends Component<Args> {
   }
 
   get label() {
-    if(this.address) return ''
+    if (this.address) return '';
     return getOutgoingTriple(this.node.attrs, EXT('label'))?.object.value;
   }
 }

--- a/addon/components/variable-plugin/address/nodeview.ts
+++ b/addon/components/variable-plugin/address/nodeview.ts
@@ -44,6 +44,7 @@ export default class AddressNodeviewComponent extends Component<Args> {
   }
 
   get label() {
+    if(this.address) return ''
     return getOutgoingTriple(this.node.attrs, EXT('label'))?.object.value;
   }
 }

--- a/addon/components/variable-plugin/date/nodeview.ts
+++ b/addon/components/variable-plugin/date/nodeview.ts
@@ -62,7 +62,7 @@ export default class DateNodeviewComponent extends Component<Args> {
   get label() {
     const value = getOutgoingTriple(this.args.node.attrs, EXT('content'))
       ?.object.value;
-    if(value) return ''
+    if (value) return '';
     return getOutgoingTriple(this.args.node.attrs, EXT('label'))?.object.value;
   }
 }

--- a/addon/components/variable-plugin/date/nodeview.ts
+++ b/addon/components/variable-plugin/date/nodeview.ts
@@ -60,6 +60,9 @@ export default class DateNodeviewComponent extends Component<Args> {
   }
 
   get label() {
+    const value = getOutgoingTriple(this.args.node.attrs, EXT('content'))
+      ?.object.value;
+    if(value) return ''
     return getOutgoingTriple(this.args.node.attrs, EXT('label'))?.object.value;
   }
 }

--- a/addon/components/variable-plugin/location/nodeview.ts
+++ b/addon/components/variable-plugin/location/nodeview.ts
@@ -38,6 +38,9 @@ export default class LocationNodeViewComponent extends Component<EmberNodeArgs> 
   }
 
   get label() {
+    if(this.innerView?.state.doc.firstChild?.type.name !== 'placeholder') {
+      return ''
+    }
     return this.args.node.attrs.label as string;
   }
 }

--- a/addon/components/variable-plugin/location/nodeview.ts
+++ b/addon/components/variable-plugin/location/nodeview.ts
@@ -38,8 +38,8 @@ export default class LocationNodeViewComponent extends Component<EmberNodeArgs> 
   }
 
   get label() {
-    if(this.innerView?.state.doc.firstChild?.type.name !== 'placeholder') {
-      return ''
+    if (this.innerView?.state.doc.firstChild?.type.name !== 'placeholder') {
+      return '';
     }
     return this.args.node.attrs.label as string;
   }

--- a/addon/components/variable-plugin/number/nodeview.ts
+++ b/addon/components/variable-plugin/number/nodeview.ts
@@ -93,6 +93,9 @@ export default class NumberNodeviewComponent extends Component<Args> {
   }
 
   get label(): string | undefined {
+    if(this.inputNumber) {
+      return ''
+    }
     return getOutgoingTriple(this.args.node.attrs, EXT('label'))?.object.value;
   }
 

--- a/addon/components/variable-plugin/number/nodeview.ts
+++ b/addon/components/variable-plugin/number/nodeview.ts
@@ -93,9 +93,7 @@ export default class NumberNodeviewComponent extends Component<Args> {
   }
 
   get label(): string | undefined {
-    if(this.inputNumber) {
-      return ''
-    }
+    if (this.inputNumber) return '';
     return getOutgoingTriple(this.args.node.attrs, EXT('label'))?.object.value;
   }
 

--- a/addon/components/variable-plugin/text/insert.ts
+++ b/addon/components/variable-plugin/text/insert.ts
@@ -77,7 +77,9 @@ export default class TextVariableInsertComponent extends Component<Args> {
           },
         ],
       },
-      this.schema.text('text'),
+      this.schema.node('placeholder', {
+        placeholderText: 'text',
+      }),
     );
 
     this.label = undefined;

--- a/addon/components/variable-plugin/variable/nodeview.ts
+++ b/addon/components/variable-plugin/variable/nodeview.ts
@@ -41,8 +41,8 @@ export default class VariableNodeViewComponent extends Component<EmberNodeArgs> 
   }
 
   get label() {
-    if(this.innerView?.state.doc.firstChild?.type.name !== 'placeholder') {
-      return ''
+    if (this.innerView?.state.doc.firstChild?.type.name !== 'placeholder') {
+      return '';
     }
     return getOutgoingTriple(this.args.node.attrs, EXT('label'))?.object.value;
   }

--- a/addon/components/variable-plugin/variable/nodeview.ts
+++ b/addon/components/variable-plugin/variable/nodeview.ts
@@ -41,6 +41,9 @@ export default class VariableNodeViewComponent extends Component<EmberNodeArgs> 
   }
 
   get label() {
+    if(this.innerView?.state.doc.firstChild?.type.name !== 'placeholder') {
+      return ''
+    }
     return getOutgoingTriple(this.args.node.attrs, EXT('label'))?.object.value;
   }
 }

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -52,6 +52,7 @@
 .ember-node {
   white-space: normal !important;
   .variable {
+    min-height: 30px;
     [contenteditable] {
       white-space: break-spaces;
       word-break: break-all;

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -64,6 +64,7 @@
       font-size: var(--au-tiny);
       color: var(--au-blue-700);
       user-select: none;
+      margin: 0.3rem;
     }
     .au-c-icon {
       margin: 0;

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -52,7 +52,7 @@
 .ember-node {
   white-space: normal !important;
   .variable {
-    height: 30px;
+    min-height: 30px;
     [contenteditable] {
       white-space: break-spaces;
       word-break: break-all;

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -52,7 +52,7 @@
 .ember-node {
   white-space: normal !important;
   .variable {
-    min-height: 30px;
+    height: 30px;
     [contenteditable] {
       white-space: break-spaces;
       word-break: break-all;
@@ -61,10 +61,9 @@
       padding: 2px;
     }
     .label {
-      font-size: var(--au-base);
+      font-size: var(--au-tiny);
       color: var(--au-blue-700);
       user-select: none;
-      margin: 0.5rem;
     }
     .au-c-icon {
       margin: 0;


### PR DESCRIPTION
### Overview
I made so the label is not shown when you fill a variable

##### connected issues and PRs:
GN-4824


### How to test/reproduce
You can insert one of each variables and fill it, appreciate that the label is indeed hidden, in some variables you can go back to an unfilled status, and the variable should reappear, but on others this is just not possible because of how the variable UI is made


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
