### PR TITLE
Move back to address plugin for RS to allow for testing both

### DIFF
--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -59,6 +59,8 @@ import {
 import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
 import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
 import {
+  address,
+  addressView,
   codelist,
   codelistView,
   location,
@@ -68,10 +70,6 @@ import {
   textVariableView,
   text_variable,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
-import {
-  address,
-  addressView,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/address';
 import { VariableConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/insert-variable-card';
 import {
   templateComment,

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -103,7 +103,9 @@
                 <TemplateCommentsPlugin::Insert
                   @controller={{this.controller}}
                 />
-                <LocationPlugin::Insert @controller={{this.controller}} />
+                <VariablePlugin::Address::Insert
+                  @controller={{this.controller}}
+                />
                 <WorshipPlugin::Insert
                   @controller={{this.controller}}
                   @config={{this.config.worship}}
@@ -121,7 +123,7 @@
                 @controller={{this.controller}}
                 @options={{this.config.structures}}
               />
-              <LocationPlugin::Edit
+              <VariablePlugin::Address::Edit
                 @controller={{this.controller}}
                 @defaultMunicipality='Gent'
               />


### PR DESCRIPTION
### Overview
I half moved over on RS-sample, and it caused weird issues. So, move back for now, we'll move both over to the location-plugin and deprecate the variable-plugin version later.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Inserting addresses on both sample pages should work, but have different UX.

### Challenges/uncertainties
No changelog as it's only a change on the test app. Is that the right thing to do?

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
