### PR TITLE
GN-4820: Copy variables

### DIFF
--- a/.changeset/wet-parrots-end.md
+++ b/.changeset/wet-parrots-end.md
@@ -1,0 +1,7 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": minor
+---
+
+GN-4820: Paste variables
+
+Pasting variable (which was copied from same editor) will now paste actual variable, not just the text that was contained inside it.

--- a/addon/plugins/variable-plugin/recreateUuidsOnPaste.ts
+++ b/addon/plugins/variable-plugin/recreateUuidsOnPaste.ts
@@ -1,0 +1,95 @@
+import { v4 as uuidv4 } from 'uuid';
+import {
+  Fragment,
+  Slice,
+  Node,
+  Schema,
+  ProsePlugin,
+} from '@lblod/ember-rdfa-editor';
+
+import { recreateUuidsOnPasteKey } from '@lblod/ember-rdfa-editor/plugins/recreateUuidsOnPaste';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
+
+import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
+
+const recreateUuidsOnPaste = new ProsePlugin({
+  key: recreateUuidsOnPasteKey,
+  props: {
+    transformPasted(slice, view) {
+      const schema = view.state.schema;
+      return new Slice(
+        recreateUuidsFromFragment(slice.content, schema),
+        slice.openStart,
+        slice.openEnd,
+      );
+    },
+  },
+});
+
+function recreateUuidsFromFragment(fragment: Fragment, schema: Schema) {
+  const newNodes: Node[] = [];
+
+  fragment.forEach((node) => {
+    const newNode = recreateUuidsOnNode(node, schema);
+    newNodes.push(newNode);
+  });
+
+  return Fragment.fromArray(newNodes);
+}
+
+function recreateUuidsOnNode(node: Node, schema: Schema) {
+  if (node.isText) {
+    return node;
+  }
+
+  const children: Node[] = [];
+
+  node.content.forEach((node) => {
+    const child = recreateUuidsOnNode(node, schema);
+    children.push(child);
+  });
+
+  const type = node.type;
+  const spec = type.spec;
+
+  const uriAttributes = spec['uriAttributes'];
+
+  if (
+    !spec['recreateUri'] ||
+    !uriAttributes ||
+    !Array.isArray(uriAttributes) ||
+    !node.attrs['rdfaNodeType']
+  ) {
+    return schema.node(
+      node.type,
+      node.attrs,
+      Fragment.fromArray(children),
+      node.marks,
+    );
+  }
+
+  const attrs = { ...node.attrs };
+
+  attrs.properties = (attrs.properties as OutgoingTriple[]).map((prop) => {
+    if (prop.predicate === EXT('instance').full) {
+      return {
+        predicate: prop.predicate,
+        object: sayDataFactory.namedNode(
+          `http://data.lblod.info/variables/${uuidv4()}`,
+        ),
+      };
+    }
+
+    return prop;
+  });
+
+  return schema.node(
+    node.type,
+    attrs,
+    Fragment.fromArray(children),
+    node.marks,
+  );
+}
+
+export default recreateUuidsOnPaste;

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@glint/template": "^1.4.0",
     "@graphy/content.ttl.write": "^4.3.7",
     "@graphy/memory.dataset.fast": "4.3.3",
-    "@lblod/ember-rdfa-editor": "^9.8.0",
+    "@lblod/ember-rdfa-editor": "9.10.0-dev.7b17ba162439369afa812d2f0c8006201c679b8d",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^3.1.0",
     "@tsconfig/ember": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@glint/template": "^1.4.0",
     "@graphy/content.ttl.write": "^4.3.7",
     "@graphy/memory.dataset.fast": "4.3.3",
-    "@lblod/ember-rdfa-editor": "9.10.0-dev.7b17ba162439369afa812d2f0c8006201c679b8d",
+    "@lblod/ember-rdfa-editor": "^9.12.0",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^3.1.0",
     "@tsconfig/ember": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,8 @@ devDependencies:
     specifier: 4.3.3
     version: 4.3.3
   '@lblod/ember-rdfa-editor':
-    specifier: 9.10.0-dev.7b17ba162439369afa812d2f0c8006201c679b8d
-    version: 9.10.0-dev.7b17ba162439369afa812d2f0c8006201c679b8d(@appuniversum/ember-appuniversum@3.4.2)(@glint/template@1.4.0)(@lezer/common@1.2.1)(ember-changeset@4.1.2)(ember-cli-sass@11.0.1)(ember-intl@5.7.2)(ember-modifier@3.2.7)(ember-source@4.12.0)(webpack@5.90.3)
+    specifier: ^9.12.0
+    version: 9.12.0(@appuniversum/ember-appuniversum@3.4.2)(@glint/template@1.4.0)(@lezer/common@1.2.1)(ember-changeset@4.1.2)(ember-cli-sass@11.0.1)(ember-intl@5.7.2)(ember-modifier@3.2.7)(ember-source@4.12.0)(webpack@5.90.3)
   '@rdfjs/types':
     specifier: ^1.1.0
     version: 1.1.0
@@ -2792,8 +2792,8 @@ packages:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@lblod/ember-rdfa-editor@9.10.0-dev.7b17ba162439369afa812d2f0c8006201c679b8d(@appuniversum/ember-appuniversum@3.4.2)(@glint/template@1.4.0)(@lezer/common@1.2.1)(ember-changeset@4.1.2)(ember-cli-sass@11.0.1)(ember-intl@5.7.2)(ember-modifier@3.2.7)(ember-source@4.12.0)(webpack@5.90.3):
-    resolution: {integrity: sha512-rfgXghJehT7Yyy1JuHDc08zf1jTvaj95DAb0/zaLHOFTFx/yTUApmaRGfqe7sEknrqj7rN0bS4jmTGDA960dcg==}
+  /@lblod/ember-rdfa-editor@9.12.0(@appuniversum/ember-appuniversum@3.4.2)(@glint/template@1.4.0)(@lezer/common@1.2.1)(ember-changeset@4.1.2)(ember-cli-sass@11.0.1)(ember-intl@5.7.2)(ember-modifier@3.2.7)(ember-source@4.12.0)(webpack@5.90.3):
+    resolution: {integrity: sha512-dLIpf86CIDAoy0lvd56ZJqpWbTrzUAfcPaOrfa3qejZkm5+lSuhrv8rMgpR0ZglG2mg4lTxSgC2juqs9B5dG4A==}
     engines: {node: 16.* || 18.* || >= 20}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^2.15.0 || ^3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,8 @@ devDependencies:
     specifier: 4.3.3
     version: 4.3.3
   '@lblod/ember-rdfa-editor':
-    specifier: ^9.8.0
-    version: 9.9.0(@appuniversum/ember-appuniversum@3.4.2)(@glint/template@1.4.0)(@lezer/common@1.2.1)(ember-changeset@4.1.2)(ember-cli-sass@11.0.1)(ember-intl@5.7.2)(ember-modifier@3.2.7)(ember-source@4.12.0)(webpack@5.90.3)
+    specifier: 9.10.0-dev.7b17ba162439369afa812d2f0c8006201c679b8d
+    version: 9.10.0-dev.7b17ba162439369afa812d2f0c8006201c679b8d(@appuniversum/ember-appuniversum@3.4.2)(@glint/template@1.4.0)(@lezer/common@1.2.1)(ember-changeset@4.1.2)(ember-cli-sass@11.0.1)(ember-intl@5.7.2)(ember-modifier@3.2.7)(ember-source@4.12.0)(webpack@5.90.3)
   '@rdfjs/types':
     specifier: ^1.1.0
     version: 1.1.0
@@ -2792,8 +2792,8 @@ packages:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@lblod/ember-rdfa-editor@9.9.0(@appuniversum/ember-appuniversum@3.4.2)(@glint/template@1.4.0)(@lezer/common@1.2.1)(ember-changeset@4.1.2)(ember-cli-sass@11.0.1)(ember-intl@5.7.2)(ember-modifier@3.2.7)(ember-source@4.12.0)(webpack@5.90.3):
-    resolution: {integrity: sha512-BY8zxQHFSRXOKvMCE+YOMumEzFJJVwbernmeRaBNPuiwCIpmMptu7ajYTDbyUb0J6VSvwoDRZRa2RoiVAJQntQ==}
+  /@lblod/ember-rdfa-editor@9.10.0-dev.7b17ba162439369afa812d2f0c8006201c679b8d(@appuniversum/ember-appuniversum@3.4.2)(@glint/template@1.4.0)(@lezer/common@1.2.1)(ember-changeset@4.1.2)(ember-cli-sass@11.0.1)(ember-intl@5.7.2)(ember-modifier@3.2.7)(ember-source@4.12.0)(webpack@5.90.3):
+    resolution: {integrity: sha512-rfgXghJehT7Yyy1JuHDc08zf1jTvaj95DAb0/zaLHOFTFx/yTUApmaRGfqe7sEknrqj7rN0bS4jmTGDA960dcg==}
     engines: {node: 16.* || 18.* || >= 20}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^2.15.0 || ^3.0.0

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -108,6 +108,7 @@ import {
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
 import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
+import recreateUuidsOnPaste from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/recreateUuidsOnPaste';
 
 export default class BesluitSampleController extends Controller {
   DebugInfo = DebugInfo;
@@ -349,6 +350,7 @@ export default class BesluitSampleController extends Controller {
       shouldShowInvisibles: false,
     }),
     editableNodePlugin(),
+    recreateUuidsOnPaste,
   ];
 
   @action

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -113,6 +113,7 @@ import {
   snippetPlaceholder,
   snippetPlaceholderView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet-placeholder';
+import recreateUuidsOnPaste from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/recreateUuidsOnPaste';
 
 export default class RegulatoryStatementSampleController extends Controller {
   SnippetInsert = SnippetInsertRdfaComponent;
@@ -339,6 +340,7 @@ export default class RegulatoryStatementSampleController extends Controller {
     }),
     emberApplication({ application: getOwner(this) }),
     editableNodePlugin(),
+    recreateUuidsOnPaste,
   ];
 
   @action


### PR DESCRIPTION
### Overview

Copying variable now copies actual variable, not just the text that was inside.

##### connected issues and PRs:

* https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/435
* https://github.com/lblod/ember-rdfa-editor/pull/1195

### Setup

Should be tested from https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/435

1. Checkout `plugins` PR - https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/435
2. In `plugins` repo `pnpm i` 
3. In `plugins` repo `pnpm run start` 

### How to test/reproduce

Variables should be copied verbatim

https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/416d5362-1372-419e-9ca6-d64916e55a47

### Challenges

`ember-rdfa-editor` configures `recreateUuidsOnPaste` plugin by default, which _does not_ work with "new" RDFa aware nodes. To avoid breaking change in editor, I've decided to make that particular plugin overridable. `ember-rdfa-editor` is also not aware of actual RDFa structure used by plugins, so I can't just update `recreateUuidsOnPaste` in `ember-rdfa-editor` to accommodate plugins, hence an override appoach.



### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check if dummy app is correctly updated
- [X] Check cancel/go-back flows
- [x] changelog
- [X] npm lint
- [X] no new deprecations
