### PR TITLE
Added the lists of the snippet placeholder in the prosemirror node

### DIFF
--- a/.changeset/kind-forks-smoke.md
+++ b/.changeset/kind-forks-smoke.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": minor
+---
+
+Changed UI of snippet placeholder to show which lists you can insert from

--- a/addon/components/snippet-plugin/nodes/placeholder.gts
+++ b/addon/components/snippet-plugin/nodes/placeholder.gts
@@ -9,19 +9,45 @@ interface Signature {
   Args: EmberNodeArgs;
 }
 
+import { service } from '@ember/service';
+import IntlService from 'ember-intl/services/intl';
 // We don't have a way to type template only components without ember-source 5, so create an empty
 // class to allow for type checking
 // eslint-disable-next-line ember/no-empty-glimmer-component-classes
 export default class SnippetPluginPlaceholder extends Component<Signature> {
+  @service declare intl: IntlService;
+  get listNames() {
+    return this.args.node.attrs.listNames;
+  }
+  get isSingleList() {
+    return this.listNames.length === 1;
+  }
+  get alertTitle() {
+    if (this.isSingleList) {
+      return this.intl.t('snippet-plugin.placeholder.title-single', {
+        listName: this.listNames[0],
+      });
+    } else {
+      return this.intl.t('snippet-plugin.placeholder.title-multiple');
+    }
+  }
   <template>
     <AuAlert
-      @title={{t 'snippet-plugin.placeholder.title'}}
+      @title={{this.alertTitle}}
       @skin='warning'
       @icon={{PlusTextIcon}}
       @size='small'
       class='say-snippet-placeholder'
       {{on 'click' @selectNode}}
     >
+      {{#unless this.isSingleList}}
+        {{t 'snippet-plugin.placeholder.active-lists'}}
+        <ul>
+          {{#each this.listNames as |listName|}}
+            <li>{{listName}}</li>
+          {{/each}}
+        </ul>
+      {{/unless}}
       {{t 'snippet-plugin.placeholder.text'}}
     </AuAlert>
   </template>

--- a/addon/components/snippet-plugin/nodes/placeholder.gts
+++ b/addon/components/snippet-plugin/nodes/placeholder.gts
@@ -4,13 +4,13 @@ import t from 'ember-intl/helpers/t';
 import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
 import { PlusTextIcon } from '@appuniversum/ember-appuniversum/components/icons/plus-text';
 import { type EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/_private/ember-node';
+import { service } from '@ember/service';
+import IntlService from 'ember-intl/services/intl';
 
 interface Signature {
   Args: EmberNodeArgs;
 }
 
-import { service } from '@ember/service';
-import IntlService from 'ember-intl/services/intl';
 // We don't have a way to type template only components without ember-source 5, so create an empty
 // class to allow for type checking
 // eslint-disable-next-line ember/no-empty-glimmer-component-classes

--- a/addon/components/snippet-plugin/snippet-insert-placeholder.gts
+++ b/addon/components/snippet-plugin/snippet-insert-placeholder.gts
@@ -36,7 +36,11 @@ export default class SnippetPluginSnippetInsertPlaceholder extends Component<Sig
 
   @action
   insertPlaceholder(listIds: string[], listNames: string[]) {
-    const node = createSnippetPlaceholder(listIds, listNames, this.args.controller.schema);
+    const node = createSnippetPlaceholder(
+      listIds,
+      listNames,
+      this.args.controller.schema,
+    );
 
     this.args.controller.withTransaction(
       (tr) => {
@@ -56,7 +60,6 @@ export default class SnippetPluginSnippetInsertPlaceholder extends Component<Sig
         {{on 'click' this.openModal}}
       >
         {{t 'snippet-plugin.insert.placeholder'}}
-        {{this.args.listNames}}
       </AuButton>
     </li>
     <SnippetListModal

--- a/addon/components/snippet-plugin/snippet-insert-placeholder.gts
+++ b/addon/components/snippet-plugin/snippet-insert-placeholder.gts
@@ -35,8 +35,8 @@ export default class SnippetPluginSnippetInsertPlaceholder extends Component<Sig
   }
 
   @action
-  insertPlaceholder(listIds: string[]) {
-    const node = createSnippetPlaceholder(listIds, this.args.controller.schema);
+  insertPlaceholder(listIds: string[], listNames: string[]) {
+    const node = createSnippetPlaceholder(listIds, listNames, this.args.controller.schema);
 
     this.args.controller.withTransaction(
       (tr) => {
@@ -56,6 +56,7 @@ export default class SnippetPluginSnippetInsertPlaceholder extends Component<Sig
         {{on 'click' this.openModal}}
       >
         {{t 'snippet-plugin.insert.placeholder'}}
+        {{this.args.listNames}}
       </AuButton>
     </li>
     <SnippetListModal

--- a/addon/components/snippet-plugin/snippet-list-select-rdfa.ts
+++ b/addon/components/snippet-plugin/snippet-list-select-rdfa.ts
@@ -49,8 +49,11 @@ export default class SnippetListSelectRdfaComponent extends Component<Args> {
     );
   }
 
-  saveChanges = (snippetIds: string[]) => {
+  saveChanges = (snippetIds: string[], snippetNames: string[]) => {
     if (this.currentResource) {
+      this.controller.withTransaction((tr) => {
+        return tr.setNodeAttribute(this.node.pos, 'listNames', snippetNames);
+      });
       this.args.controller?.doCommand(
         updateSnippetIds({
           resource: this.currentResource,

--- a/addon/components/snippet-plugin/snippet-list-select-rdfa.ts
+++ b/addon/components/snippet-plugin/snippet-list-select-rdfa.ts
@@ -7,7 +7,7 @@ import {
   getAssignedSnippetListsIdsFromProperties,
   getSnippetListIdsProperties,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
-import { updateSnippetIds } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/commands';
+import { updateSnippetPlaceholder } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/commands';
 import { ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
 import { SayController } from '@lblod/ember-rdfa-editor';
 import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
@@ -51,14 +51,13 @@ export default class SnippetListSelectRdfaComponent extends Component<Args> {
 
   saveChanges = (snippetIds: string[], snippetNames: string[]) => {
     if (this.currentResource) {
-      this.controller.withTransaction((tr) => {
-        return tr.setNodeAttribute(this.node.pos, 'listNames', snippetNames);
-      });
       this.args.controller?.doCommand(
-        updateSnippetIds({
+        updateSnippetPlaceholder({
           resource: this.currentResource,
           oldSnippetProperties: this.snippetListIdsProperties ?? [],
           newSnippetIds: snippetIds,
+          node: this.node,
+          snippetNames,
         }),
         {
           view: this.args.controller.mainEditorView,

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
@@ -50,6 +50,8 @@ export default class SnippetListModalComponent extends Component<Signature> {
 
   @action
   saveAndClose() {
+    const snippetListNames = this.snippetListResource.value?.filter((snippetList) => this.assignedSnippetListsIds.includes(snippetList.id))
+    console.log(snippetListNames)
     this.args.onSaveSnippetListIds(this.assignedSnippetListsIds);
     this.args.closeModal();
     // Clear selection for next time

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
@@ -55,7 +55,6 @@ export default class SnippetListModalComponent extends Component<Signature> {
         this.assignedSnippetListsIds.includes(snippetList.id as string),
       )
       .map((snippetList) => snippetList.label) as string[];
-    console.log(snippetListNames);
     this.args.onSaveSnippetListIds(
       this.assignedSnippetListsIds,
       snippetListNames,

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
@@ -52,7 +52,7 @@ export default class SnippetListModalComponent extends Component<Signature> {
   saveAndClose() {
     const snippetListNames = this.snippetListResource.value?.filter((snippetList) => this.assignedSnippetListsIds.includes(snippetList.id))
     console.log(snippetListNames)
-    this.args.onSaveSnippetListIds(this.assignedSnippetListsIds);
+    this.args.onSaveSnippetListIds(this.assignedSnippetListsIds, snippetListNames);
     this.args.closeModal();
     // Clear selection for next time
     this.assignedSnippetListsIds = [];

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
@@ -19,7 +19,7 @@ import { trackedReset } from 'tracked-toolbox';
 interface Signature {
   Args: {
     config: SnippetPluginConfig;
-    onSaveSnippetListIds: (listIds: string[]) => void;
+    onSaveSnippetListIds: (listIds: string[], listNames: string[]) => void;
     assignedSnippetListsIds: string[];
     closeModal: () => void;
     open: boolean;
@@ -50,9 +50,16 @@ export default class SnippetListModalComponent extends Component<Signature> {
 
   @action
   saveAndClose() {
-    const snippetListNames = this.snippetListResource.value?.filter((snippetList) => this.assignedSnippetListsIds.includes(snippetList.id))
-    console.log(snippetListNames)
-    this.args.onSaveSnippetListIds(this.assignedSnippetListsIds, snippetListNames);
+    const snippetListNames: string[] = this.snippetListResource.value
+      ?.filter((snippetList) =>
+        this.assignedSnippetListsIds.includes(snippetList.id as string),
+      )
+      .map((snippetList) => snippetList.label) as string[];
+    console.log(snippetListNames);
+    this.args.onSaveSnippetListIds(
+      this.assignedSnippetListsIds,
+      snippetListNames,
+    );
     this.args.closeModal();
     // Clear selection for next time
     this.assignedSnippetListsIds = [];

--- a/addon/plugins/snippet-plugin/commands/index.ts
+++ b/addon/plugins/snippet-plugin/commands/index.ts
@@ -1,1 +1,1 @@
-export { default as updateSnippetIds } from './update-snippet-ids';
+export { default as updateSnippetPlaceholder } from './update-snippet-ids';

--- a/addon/plugins/snippet-plugin/commands/update-snippet-ids.ts
+++ b/addon/plugins/snippet-plugin/commands/update-snippet-ids.ts
@@ -11,7 +11,7 @@ const updateSnippetPlaceholder = ({
   oldSnippetProperties,
   newSnippetIds,
   node,
-  snippetNames
+  snippetNames,
 }: {
   resource: string;
   oldSnippetProperties: OutgoingTriple[];
@@ -23,7 +23,7 @@ const updateSnippetPlaceholder = ({
     if (dispatch) {
       let transaction = state.tr;
       let newState = state;
-      
+
       oldSnippetProperties.forEach((property) => {
         newState = state.apply(transaction);
 
@@ -50,7 +50,11 @@ const updateSnippetPlaceholder = ({
           transaction = newTransaction;
         });
       });
-      transaction = transaction.setNodeAttribute(node.pos, 'listNames', snippetNames);
+      transaction = transaction.setNodeAttribute(
+        node.pos,
+        'listNames',
+        snippetNames,
+      );
 
       dispatch(transaction);
     }

--- a/addon/plugins/snippet-plugin/commands/update-snippet-ids.ts
+++ b/addon/plugins/snippet-plugin/commands/update-snippet-ids.ts
@@ -4,21 +4,26 @@ import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { SNIPPET_LIST_RDFA_PREDICATE } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { getSnippetUriFromId } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
+import { ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
 
-const updateSnippetIds = ({
+const updateSnippetPlaceholder = ({
   resource,
   oldSnippetProperties,
   newSnippetIds,
+  node,
+  snippetNames
 }: {
   resource: string;
   oldSnippetProperties: OutgoingTriple[];
   newSnippetIds: string[];
+  node: ResolvedPNode;
+  snippetNames: string[];
 }): Command => {
   return (state, dispatch) => {
     if (dispatch) {
       let transaction = state.tr;
       let newState = state;
-
+      
       oldSnippetProperties.forEach((property) => {
         newState = state.apply(transaction);
 
@@ -45,6 +50,7 @@ const updateSnippetIds = ({
           transaction = newTransaction;
         });
       });
+      transaction = transaction.setNodeAttribute(node.pos, 'listNames', snippetNames);
 
       dispatch(transaction);
     }
@@ -52,4 +58,4 @@ const updateSnippetIds = ({
   };
 };
 
-export default updateSnippetIds;
+export default updateSnippetPlaceholder;

--- a/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
@@ -21,11 +21,12 @@ import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/u
 import { getSnippetUriFromId } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import { SNIPPET_LIST_RDFA_PREDICATE } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 
-export function createSnippetPlaceholder(listIds: string[], schema: Schema) {
+export function createSnippetPlaceholder(listIds: string[], listNames: string[], schema: Schema) {
   const mappingResource = `http://example.net/lblod-snippet-placeholder/${uuidv4()}`;
 
   return schema.nodes.snippet_placeholder.create({
     rdfaNodeType: 'resource',
+    listNames,
     subject: mappingResource,
     properties: [
       {
@@ -50,6 +51,7 @@ const emberNodeConfig: EmberNodeConfig = {
   attrs: {
     ...rdfaAttrSpec({ rdfaAware: true }),
     typeof: { default: EXT('SnippetPlaceholder') },
+    listNames: { default: [] }
   },
   component: SnippetPlaceholderComponent,
   serialize(node, editorState) {

--- a/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
@@ -21,7 +21,11 @@ import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/u
 import { getSnippetUriFromId } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import { SNIPPET_LIST_RDFA_PREDICATE } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 
-export function createSnippetPlaceholder(listIds: string[], listNames: string[], schema: Schema) {
+export function createSnippetPlaceholder(
+  listIds: string[],
+  listNames: string[],
+  schema: Schema,
+) {
   const mappingResource = `http://example.net/lblod-snippet-placeholder/${uuidv4()}`;
 
   return schema.nodes.snippet_placeholder.create({
@@ -51,7 +55,7 @@ const emberNodeConfig: EmberNodeConfig = {
   attrs: {
     ...rdfaAttrSpec({ rdfaAware: true }),
     typeof: { default: EXT('SnippetPlaceholder') },
-    listNames: { default: [] }
+    listNames: { default: [] },
   },
   component: SnippetPlaceholderComponent,
   serialize(node, editorState) {
@@ -62,6 +66,7 @@ const emberNodeConfig: EmberNodeConfig = {
       attrs: {
         ...node.attrs,
         class: 'say-snippet-placeholder-node',
+        'data-list-names': node.attrs.listNames.join(','),
       },
       content: [
         'text',
@@ -85,7 +90,10 @@ const emberNodeConfig: EmberNodeConfig = {
             EXT('SnippetPlaceholder'),
           )
         ) {
-          return rdfaAttrs;
+          return {
+            ...rdfaAttrs,
+            listNames: node.getAttribute('data-list-names')?.split(','),
+          };
         }
         return false;
       },

--- a/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
@@ -66,7 +66,7 @@ const emberNodeConfig: EmberNodeConfig = {
       attrs: {
         ...node.attrs,
         class: 'say-snippet-placeholder-node',
-        'data-list-names': node.attrs.listNames.join(','),
+        'data-list-names': (node.attrs.listNames as string[]).join(','),
       },
       content: [
         'text',

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -360,7 +360,7 @@ export default class RegulatoryStatementSampleController extends Controller {
   @action
   async rdfaEditorInit(controller: SayController) {
     this.controller = controller;
-    applyDevTools(controller.mainEditorView);
+    //applyDevTools(controller.mainEditorView);
     await this.importRdfaSnippet.downloadSnippet({
       omitCredentials: 'true',
       source:

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -360,7 +360,7 @@ export default class RegulatoryStatementSampleController extends Controller {
   @action
   async rdfaEditorInit(controller: SayController) {
     this.controller = controller;
-    //applyDevTools(controller.mainEditorView);
+    applyDevTools(controller.mainEditorView);
     await this.importRdfaSnippet.downloadSnippet({
       omitCredentials: 'true',
       source:

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -272,8 +272,10 @@ snippet-plugin:
     title: Insert snippet
     placeholder: Insert snippet placeholder
   placeholder:
-    title: Insert snippet here
+    title-single: Snippet from the list "{listName}"
+    title-multiple: Snippet from multiple lists
     text: Select this then insert the desired snippet
+    active-lists: 'Active lists:'
   modal:
     title: Choose a snippet
     select: Select

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -275,7 +275,7 @@ snippet-plugin:
   placeholder:
     title-single: Fragment uit de lijst "{listName}"
     title-multiple: Fragment uit meerdere lijsten
-    text: Selecteer dit en voeg het gewenste fragment in"
+    text: Selecteer dit en voeg het gewenste fragment in
     active-lists: 'Actieve lijsten:'
   modal:
     title: Kies een fragment

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -273,8 +273,10 @@ snippet-plugin:
     title: Fragment invoegen
     placeholder: Plaatshouder voor fragment invoegen
   placeholder:
-    title: Fragment hier invoegen
-    text: Selecteer dit en voeg het gewenste fragment in
+    title-single: Fragment uit de lijst "{listName}"
+    title-multiple: Fragment uit meerdere lijsten
+    text: Selecteer dit en voeg het gewenste fragment in"
+    active-lists: 'Actieve lijsten:'
   modal:
     title: Kies een fragment
     select: Selecteer


### PR DESCRIPTION
### Overview
Changed the UI of the snippet placeholder to specify which lists you can insert from.

##### connected issues and PRs:
GN-4852

### How to test/reproduce
Insert a snippet placeholder with only a snippet list and check that it shows as described in the ticket, then change it to multiple lists, it should change the UI to show the multiple lists you can insert from 

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
