### PR TITLE
Removed adaptation filters as they prevent users finding specific legislations

### DIFF
--- a/.changeset/wicked-waves-talk.md
+++ b/.changeset/wicked-waves-talk.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": patch
+---
+
+Improve citation search

--- a/addon/plugins/citation-plugin/utils/vlaamse-codex.ts
+++ b/addon/plugins/citation-plugin/utils/vlaamse-codex.ts
@@ -68,17 +68,6 @@ export async function fetchVlaamseCodexLegalDocuments({
       publicationDateFilter += `FILTER (?publicationDate <= "${publicationDateTo}"^^xsd:date) `;
   }
 
-  const excludeAdaptationFilters = [];
-  if (!words.includes('houdende')) {
-    excludeAdaptationFilters.push(
-      'FILTER(! STRSTARTS(LCASE(?title),"houdende"))',
-    );
-  }
-  if (!words.includes('wijziging')) {
-    excludeAdaptationFilters.push(
-      'FILTER(! STRSTARTS(LCASE(?title),"tot wijziging"))',
-    );
-  }
   const totalCount = await executeCountQuery({
     query: `PREFIX eli: <http://data.europa.eu/eli/ontology#>
 
@@ -96,7 +85,6 @@ export async function fetchVlaamseCodexLegalDocuments({
               ).toLowerCase()}"))`,
           )
           .join('\n')}
-        ${excludeAdaptationFilters.join('\n')}
         ${documentDateFilter}
         ${publicationDateFilter}
       }`,
@@ -122,7 +110,6 @@ export async function fetchVlaamseCodexLegalDocuments({
             )
             .join('\n')}
           OPTIONAL { ?expressionUri eli:date_publication ?publicationDate . }
-          ${excludeAdaptationFilters.join('\n')}
           ${documentDateFilter}
           ${publicationDateFilter}
         } ORDER BY ?title LIMIT ${pageSize} OFFSET ${pageNumber * pageSize}`,


### PR DESCRIPTION
### Overview
Not really sure about this, but it seems like these 2 filters prevent users finding legislations that starts with houdende or tot wijziging unless they specifically search for that start, this seems confusing

##### connected issues and PRs:
GN-4819


### Setup
None

### How to test/reproduce
Search for a citation, for example the citation specified in the ticket can be found with more natural terms like Kiesdecreet or verkiezingen instead of having to start your seach with houdende

### Challenges/uncertainties
Not sure if those filters serve any purpose at the moment



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
