### PR TITLE
Add dockerignore to avoid overwriting image node_modules with system

### DIFF
--- a/.changeset/orange-cooks-brake.md
+++ b/.changeset/orange-cooks-brake.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": patch
+---
+
+Fix docker image builds

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.eslintcache


### PR DESCRIPTION
### Overview
Add dockerignore to avoid overwriting image node_modules with system node_modules.
This fixes `docker build .` locally, so should also fix it on woodpecker.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
`docker build .`

### Challenges/uncertainties
It's not clear why [some docker images](https://hub.docker.com/r/lblod/ember-rdfa-editor-lblod-plugins/tags) exist for recent tags. It's also not clear what node_modules dir will exist on the woodpecker build, so it's most likely that it worked by chance for some versions of the copied-in node_modules.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
