### PR TITLE
Ensure `zonality` is set up as optional when fetching traffic signs

### DIFF
--- a/.changeset/few-dragons-kick.md
+++ b/.changeset/few-dragons-kick.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": patch
+---
+
+Ensure `zonality` is set up as optional when fetching traffic signs

--- a/addon/models/sign.ts
+++ b/addon/models/sign.ts
@@ -8,7 +8,7 @@ export default class Sign {
     readonly classifications: string[] = [],
     readonly uri: string,
     readonly order: string,
-    readonly zonality: string,
+    readonly zonality?: string,
   ) {}
   static fromBinding(binding: IBindings) {
     const code = unwrap(binding['code']?.value);
@@ -21,7 +21,7 @@ export default class Sign {
     const order = unwrap(binding['order']?.value);
 
     const classifications = binding['classifications']?.value.split('|') ?? [];
-    const zonality = unwrap(binding['zonality']?.value);
+    const zonality = binding['zonality']?.value;
     return new Sign(code, image, classifications, uri, order, zonality);
   }
 

--- a/addon/services/roadsign-registry.ts
+++ b/addon/services/roadsign-registry.ts
@@ -247,8 +247,10 @@ WHERE {
             ext:concept ?uri.
   ?uri a ?type;
         skos:prefLabel ?code;
-        ext:zonality ?zonality;
         mobiliteit:grafischeWeergave ?image.
+  OPTIONAL {
+      ?uri ext:zonality ?zonality.
+  }
   OPTIONAL {
     ?uri org:classification/skos:prefLabel ?classification.
   }


### PR DESCRIPTION
### Overview
When fetching traffic measures from the MOW endpoint, we are also fetching their included traffic signs. These traffic signs may include road signs, traffic lights or road markings. While road signs include a `zonality` property, traffic lights and road markings do not. This PR ensures that the `zonality` property is marked as 'optional' when fetching the traffic signs.

##### connected issues and PRs:
This PR is a more permanent solution for the temporary solution introduced in https://github.com/lblod/frontend-mow-registry/pull/250

### How to test/reproduce
- Start the application
- Insert a decision with a decision type which supports insertion of traffic measures
- Ensure insert traffic measures still works. The plugin should now also support inserting traffic measures with traffic signs which do not have a `zonality` property.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
