### PR TITLE
lmb-plugin: ensure independent mandatees (without a fraction) can be selected for insertion

### DIFF
--- a/.changeset/fair-spoons-tell.md
+++ b/.changeset/fair-spoons-tell.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": patch
+---
+
+lbm-plugin: add support for inserting independent mandatees (who are not part of a fraction)

--- a/addon/components/lmb-plugin/search-modal.ts
+++ b/addon/components/lmb-plugin/search-modal.ts
@@ -53,31 +53,33 @@ export default class LmbPluginSearchModalComponent extends Component<Args> {
       },
       body: JSON.stringify({
         query: `
-        PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#> 
-        PREFIX skos: <http://www.w3.org/2004/02/skos/core#> 
+        PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
         PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX regorg: <https://www.w3.org/ns/regorg#>
-        SELECT DISTINCT ?mandatee ?person ?firstName ?lastName ?statusLabel ?fractieLabel ?roleLabel WHERE { 
+        SELECT DISTINCT ?mandatee ?person ?firstName ?lastName ?statusLabel ?fractieLabel ?roleLabel WHERE {
             ?mandatee a mandaat:Mandataris;
               org:holds ?mandaat;
               mandaat:status ?status;
-              mandaat:isBestuurlijkeAliasVan ?person;
-              org:hasMembership ?membership.
+              mandaat:isBestuurlijkeAliasVan ?person.
             ?person foaf:familyName ?lastName;
               persoon:gebruikteVoornaam ?firstName.
             ?status skos:prefLabel ?statusLabel.
-            ?membership org:organisation ?fractie.
-            ?fractie regorg:legalName ?fractieLabel.
             ?mandaat org:role ?role.
             ?role skos:prefLabel ?roleLabel.
             OPTIONAL  {
               ?mandatee mandaat:einde ?endDate
             }
+            OPTIONAL {
+              ?mandatee org:hasMembership ?membership.
+              ?membership org:organisation ?fractie.
+              ?fractie regorg:legalName ?fractieLabel.
+            }
             filter (!bound(?endDate) || ?endDate > now()).
-        }        
+        }
         `,
       }),
     });

--- a/addon/models/mandatee.ts
+++ b/addon/models/mandatee.ts
@@ -9,8 +9,8 @@ export default class Mandatee {
     readonly lastName: string,
     readonly fullName: string,
     readonly status: string,
-    readonly fractie: string,
     readonly role: string,
+    readonly fractie: string,
   ) {}
   static fromBinding(binding: IBindings) {
     const personUri = unwrap(binding['person']?.value);
@@ -19,8 +19,8 @@ export default class Mandatee {
     const lastName = unwrap(binding['lastName']?.value);
     const fullName = `${firstName} ${lastName}`;
     const status = unwrap(binding['statusLabel']?.value);
-    const fractie = unwrap(binding['fractieLabel']?.value);
     const role = unwrap(binding['roleLabel']?.value);
+    const fractie = binding['fractieLabel']?.value ?? 'Onafhankelijk';
     return new Mandatee(
       personUri,
       mandateeUri,
@@ -28,8 +28,8 @@ export default class Mandatee {
       lastName,
       fullName,
       status,
-      fractie,
       role,
+      fractie,
     );
   }
 }


### PR DESCRIPTION
### Overview
This PR modifies the `Mandatee` model and mandatee sparql query so that it supports independent mandatees (who are not part of any fraction).

##### connected issues and PRs:
None

### Setup
This PR requires https://github.com/lblod/app-gelinkt-notuleren/pull/182 to function correctly.

### How to test/reproduce
- Start a local instance of the app-gelinkt-notuleren stack
- Start the test-app of this package
- Open up the mandatee-selector modal
- You should be able to view and insert mandatees without a fraction.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
