### PR TITLE
fix: allow templates with no restrictions everywhere

### DIFF
--- a/.changeset/calm-seals-look.md
+++ b/.changeset/calm-seals-look.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor-lblod-plugins": patch
+---
+
+fix: allow basic templates to be inserted again

--- a/addon/components/standard-template-plugin/template-provider.ts
+++ b/addon/components/standard-template-plugin/template-provider.ts
@@ -63,6 +63,7 @@ export default class TemplateProviderComponent extends Component<Args> {
   templateIsApplicable(template: StandardTemplate) {
     const { $from } = this.controller.mainEditorState.selection;
     const containsTypes =
+      template.contexts.length === 0 ||
       this.controller.externalContextStore
         .match(null, 'a')
         .dataset.some((quad) => {


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

The filtering for templates was wrong: instead of allowing templates that have an empty contexts array anywhere, we were blocking them, this meant that you couldn't insert the 2 main decision templates from the meeting page anymore.
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
