### PR TITLE
Switch some name based icons to use AU icon components

### DIFF
--- a/.changeset/young-donkeys-develop.md
+++ b/.changeset/young-donkeys-develop.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Use icon classes in order to support embeddable editor

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
       legacyDecorators: true,
     },
   },
+  reportUnusedDisableDirectives: true,
   plugins: ['ember', '@typescript-eslint'],
   extends: [
     'eslint:recommended',
@@ -50,7 +51,6 @@ module.exports = {
         node: true,
       },
       plugins: ['node'],
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
       rules: Object.assign(
         {},
         require('eslint-plugin-node').configs.recommended.rules,

--- a/addon/components/confidentiality-plugin/redact.gts
+++ b/addon/components/confidentiality-plugin/redact.gts
@@ -1,13 +1,20 @@
-import Mark from '@lblod/ember-rdfa-editor/components/toolbar/mark';
+import { TemplateOnlyComponent } from '@ember/component/template-only';
 import t from 'ember-intl/helpers/t';
 import { NotVisibleIcon } from '@appuniversum/ember-appuniversum/components/icons/not-visible';
+import { SayController } from '@lblod/ember-rdfa-editor';
+import Mark from '@lblod/ember-rdfa-editor/components/toolbar/mark';
 
-<template>
+interface Sig {
+  Args: {
+    controller: SayController;
+  };
+}
+
+export const redact: TemplateOnlyComponent<Sig> = <template>
   <Mark
     @icon={{NotVisibleIcon}}
     @title={{t 'confidentiality-plugin.redact'}}
     @mark='redacted'
-    {{! @glint-expect-error: not typesafe yet }}
     @controller={{@controller}}
   />
-</template>
+</template>;

--- a/addon/components/confidentiality-plugin/redact.gts
+++ b/addon/components/confidentiality-plugin/redact.gts
@@ -10,7 +10,7 @@ interface Sig {
   };
 }
 
-export const redact: TemplateOnlyComponent<Sig> = <template>
+const Redact: TemplateOnlyComponent<Sig> = <template>
   <Mark
     @icon={{NotVisibleIcon}}
     @title={{t 'confidentiality-plugin.redact'}}
@@ -18,3 +18,4 @@ export const redact: TemplateOnlyComponent<Sig> = <template>
     @controller={{@controller}}
   />
 </template>;
+export default Redact;

--- a/addon/components/decision-plugin/insert-article.gts
+++ b/addon/components/decision-plugin/insert-article.gts
@@ -2,6 +2,7 @@ import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { AddIcon } from '@appuniversum/ember-appuniversum/components/icons/add';
 import { SayController } from '@lblod/ember-rdfa-editor';
 import { getCurrentBesluitRange } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-topic-plugin/utils/helpers';
 import insertArticle from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/decision-plugin/commands/insert-article-command';
@@ -68,7 +69,7 @@ export default class InsertArticleComponent extends Component<Sig> {
   <template>
     <li class='au-csidebar-list__item'>
       <AuButton
-        @icon='add'
+        @icon={{AddIcon}}
         @iconAlignment='left'
         @skin='link'
         @disabled={{not this.canInsert}}

--- a/addon/components/snippet-plugin/nodes/placeholder.gts
+++ b/addon/components/snippet-plugin/nodes/placeholder.gts
@@ -11,9 +11,6 @@ interface Signature {
   Args: EmberNodeArgs;
 }
 
-// We don't have a way to type template only components without ember-source 5, so create an empty
-// class to allow for type checking
-// eslint-disable-next-line ember/no-empty-glimmer-component-classes
 export default class SnippetPluginPlaceholder extends Component<Signature> {
   @service declare intl: IntlService;
   get listNames() {

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -32,9 +32,6 @@ interface Signature {
   };
 }
 
-// We don't have a way to type template only components without ember-source 5, so create an empty
-// class to allow for type checking
-// eslint-disable-next-line ember/no-empty-glimmer-component-classes
 export default class SnippetNode extends Component<Signature> {
   @tracked showModal: boolean = false;
   @tracked mode: string = '';

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -5,6 +5,9 @@ import { type EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/_private/embe
 import SearchModal from '../search-modal';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { SynchronizeIcon } from '@appuniversum/ember-appuniversum/components/icons/synchronize';
+import { BinIcon } from '@appuniversum/ember-appuniversum/components/icons/bin';
+import { AddIcon } from '@appuniversum/ember-appuniversum/components/icons/add';
 import {
   PNode,
   ProseParser,
@@ -154,7 +157,7 @@ export default class SnippetNode extends Component<Signature> {
             type='button'
             {{on 'click' this.editFragment}}
           >
-            <AuIcon @icon='synchronize' @size='large' />
+            <AuIcon @icon={{SynchronizeIcon}} @size='large' />
             <div class='say-snippet-button-text'>
               {{t 'snippet-plugin.snippet-node.change-fragment'}}
             </div>
@@ -164,7 +167,7 @@ export default class SnippetNode extends Component<Signature> {
             type='button'
             {{on 'click' this.deleteFragment}}
           >
-            <AuIcon @icon='bin' />
+            <AuIcon @icon={{BinIcon}} />
             <div class='say-snippet-button-text'>
               {{t 'snippet-plugin.snippet-node.remove-fragment'}}
             </div>
@@ -174,7 +177,7 @@ export default class SnippetNode extends Component<Signature> {
             type='button'
             {{on 'click' this.addFragment}}
           >
-            <AuIcon @icon='add' />
+            <AuIcon @icon={{AddIcon}} />
             <div class='say-snippet-button-text'>
               {{t 'snippet-plugin.snippet-node.add-fragment'}}
             </div>

--- a/tests/integration/rdfa/blackbox-test.ts
+++ b/tests/integration/rdfa/blackbox-test.ts
@@ -1,7 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 //@ts-nocheck
 


### PR DESCRIPTION
### Overview
I spotted some of these in my adventures through the codebase, so thought to change them. I also spotted that my comment about template only components that wasn't necessary (or true), so removed it, and added the eslint config to warn on unused ignores, as well as adding a single demo of a typed template only component.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Everything still works!

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
