### PR TITLE
fix(snippets): make snippet nodes accept any block as content

### DIFF
--- a/.changeset/thick-schools-nail.md
+++ b/.changeset/thick-schools-nail.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Allow any block content in snippet nodes

--- a/addon/plugins/snippet-plugin/nodes/snippet.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet.ts
@@ -41,7 +41,7 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
     config: { default: options },
   },
   component: SnippetComponent,
-  content: '(block | title | chapter | article)*',
+  content: 'block+',
   serialize(node) {
     return renderRdfaAware({
       renderable: node,


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

The previous content spec crashed in a schema without the mentioned nodes, like a decision. It turns out you can only mention things in the content spec that exist in your schema.

In any case, we're moving more and more towards looser content specs as that works way better. We should strive to use `block+` in most block-style nodes. 

This does break compatibility with the "old" article-structures, as they are not part of the block group. But since the feature is built for the IV, this is fine.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
