### PR TITLE
Add support for relative urls to lpdc service endpoint

### DIFF
--- a/.changeset/seven-days-begin.md
+++ b/.changeset/seven-days-begin.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Add support for relative urls to lpdc endpoint configuration

--- a/addon/plugins/lpdc-plugin/api.ts
+++ b/addon/plugins/lpdc-plugin/api.ts
@@ -60,9 +60,11 @@ export const fetchLpdcs = async ({
     };
   };
 }> => {
-  const endpoint = config?.endpoint;
+  const endpoint = `${config?.endpoint}/doc/instantie`;
 
-  const url = new URL(`${endpoint}/doc/instantie`);
+  const url = endpoint.startsWith('/')
+    ? new URL(endpoint, window.location.origin)
+    : new URL(endpoint);
 
   if (filter?.name) {
     url.searchParams.append('zoekterm', filter.name);
@@ -72,7 +74,7 @@ export const fetchLpdcs = async ({
     url.searchParams.append('pageIndex', pageNumber.toString());
   }
 
-  const results = await fetch(url.toString(), {
+  const results = await fetch(url, {
     method: 'GET',
     headers: {
       Accept: 'application/json',

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -258,7 +258,7 @@ export default class BesluitSampleController extends Controller {
         endpoint: 'http://localhost/vendor-proxy/query',
       },
       lpdc: {
-        // Needs to point at the same port as the ember app
+        // Needs to be exposed locally without authentication as otherwise calls fail
         endpoint: 'http://localhost/lpdc-service',
       },
       location: {


### PR DESCRIPTION
### Overview
Allows for convenient use when proxying in an ember app, as the url is relative to the origin and that ensures that cookies are passed correctly for authentication.

##### connected issues and PRs:
Makes configuration of https://github.com/lblod/frontend-gelinkt-notuleren/pull/667 easier.

### Setup
Should be tested linked to frontend-gn. Tested and working with a local app-gn, dev app-gn gets a 502 response, but that seems unrelated to this change.

### How to test/reproduce
Link to frontend-gn on the `GN-4693` branch, set `ENV.lpdcEndpoint` to be `/lpdc-service` and test that 'insert LPDC' in agendapoints works.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
