### PR TITLE
GN-4899: support for dynamic, synchronizable mandatee tables

### DIFF
--- a/.changeset/early-rivers-chew.md
+++ b/.changeset/early-rivers-chew.md
@@ -1,0 +1,13 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Addition of a mandatee table plugin
+- Addition of a `mandatee_table` node-spec and `mandateeTableView` node-view
+  * `mandatee_table` nodes support two attributes: `tag` and `title` which can be configured by a template-creator
+- Addition of two components used to insert and configure mandatee tables
+  * `MandateeTablePlugin::Insert` allows a user/template-creator to insert empty `mandatee_table` nodes
+  * `MandateeTablePlugin::Configure` allows a user/template-creator to configure the title/tag of a `mandatee_table` node
+- Addition of a `syncDocument` function.
+  * Synchronizes the `mandatee_table` nodes in a document based on a supplied configuration
+  * Can work in a headless way (does not require a prosemirror view). It accepts and outputs a `ProseMirrorState` object.

--- a/addon/commands/insert-data-table.ts
+++ b/addon/commands/insert-data-table.ts
@@ -1,0 +1,48 @@
+import { Command } from '@lblod/ember-rdfa-editor';
+import { buildDataTable } from '../utils/build-data-table';
+interface HasToString {
+  toString(): string;
+}
+
+type Args<T extends string> = {
+  fields: readonly T[];
+  records: Record<T, HasToString>[];
+  includeHeader?: boolean;
+  labels?: Record<T, string>;
+};
+
+export function insertDataTable<T extends string>({
+  fields,
+  records,
+  includeHeader = true,
+  labels,
+}: Args<T>): Command {
+  return (state, dispatch) => {
+    const {
+      schema,
+      selection: { $from },
+    } = state;
+
+    const specAllowSplitByTable = $from.parent.type.spec[
+      'allowSplitByTable'
+    ] as boolean | undefined;
+
+    const allowSplitByTable: boolean =
+      specAllowSplitByTable === undefined ? true : specAllowSplitByTable;
+
+    if (!allowSplitByTable) return false;
+
+    if (dispatch) {
+      const tr = state.tr;
+      dispatch(
+        tr
+          .replaceSelectionWith(
+            buildDataTable({ schema, fields, records, includeHeader, labels }),
+          )
+          .scrollIntoView(),
+      );
+    }
+
+    return true;
+  };
+}

--- a/addon/components/mandatee-table-plugin/configure.gts
+++ b/addon/components/mandatee-table-plugin/configure.gts
@@ -1,0 +1,122 @@
+import Component from '@glimmer/component';
+import { SayController } from '@lblod/ember-rdfa-editor';
+import { action } from '@ember/object';
+import AuCard from '@appuniversum/ember-appuniversum/components/au-card';
+import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
+import AuLabel from '@appuniversum/ember-appuniversum/components/au-label';
+import AuInput from '@appuniversum/ember-appuniversum/components/au-input';
+import PowerSelect from 'ember-power-select/components/power-select';
+import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
+import { on } from '@ember/modifier';
+import AuFormRow from '@appuniversum/ember-appuniversum/components/au-form-row';
+import t from 'ember-intl/helpers/t';
+
+interface Sig {
+  Args: { controller: SayController; supportedTags: string[] };
+}
+
+export default class ConfigureMandateeTableComponent extends Component<Sig> {
+  get controller() {
+    return this.args.controller;
+  }
+
+  get schema() {
+    return this.controller.schema;
+  }
+
+  get mandateeTableNode() {
+    const { mandatee_table } = this.schema.nodes;
+    if (!mandatee_table) {
+      return undefined;
+    }
+    return findParentNodeOfType(mandatee_table)(
+      this.controller.activeEditorState.selection,
+    );
+  }
+
+  get showCard() {
+    return Boolean(this.mandateeTableNode);
+  }
+
+  get currentTag() {
+    return this.mandateeTableNode?.node.attrs.tag as string | undefined;
+  }
+
+  get nodeTitle() {
+    return this.mandateeTableNode?.node.attrs.title as string | undefined;
+  }
+
+  updateAttribute(key: string, value: unknown) {
+    if (this.mandateeTableNode) {
+      const { pos } = this.mandateeTableNode;
+      this.controller.withTransaction((tr) => {
+        return tr.setNodeAttribute(pos, key, value);
+      });
+    }
+  }
+
+  @action
+  updateTag(tag: string) {
+    this.updateAttribute('tag', tag);
+  }
+
+  @action
+  updateNodeTitle(event: InputEvent) {
+    this.updateAttribute('title', (event.target as HTMLInputElement).value);
+  }
+
+  <template>
+    {{#if this.showCard}}
+      <AuCard
+        @flex={{true}}
+        @divided={{true}}
+        @isOpenInitially={{true}}
+        @expandable={{true}}
+        @shadow={{true}}
+        @size='small'
+        as |c|
+      >
+        <c.header>
+          <AuHeading @level='3' @skin='6'>
+            {{t 'mandatee-table-plugin.configure.title'}}
+          </AuHeading>
+        </c.header>
+        <c.content>
+          <AuFormRow>
+            <AuLabel for='mandatee-table-tag-select'>
+              {{t 'mandatee-table-plugin.configure.tag-input.label'}}
+            </AuLabel>
+            <PowerSelect
+              id='mandatee-table-tag-select'
+              @allowClear={{false}}
+              @searchEnabled={{false}}
+              @options={{@supportedTags}}
+              @selected={{this.currentTag}}
+              @onChange={{this.updateTag}}
+              @placeholder={{t
+                'mandatee-table-plugin.configure.tag-input.placeholder'
+              }}
+              as |tag|
+            >
+              {{tag}}
+            </PowerSelect>
+          </AuFormRow>
+          <AuFormRow>
+            <AuLabel for='mandatee-table-title-input'>
+              {{t 'mandatee-table-plugin.configure.title-input.label'}}
+            </AuLabel>
+            <AuInput
+              @width='block'
+              placeholder={{t
+                'mandatee-table-plugin.configure.title-input.placeholder'
+              }}
+              id='mandatee-table-title-input'
+              value={{this.nodeTitle}}
+              {{on 'input' this.updateNodeTitle}}
+            />
+          </AuFormRow>
+        </c.content>
+      </AuCard>
+    {{/if}}
+  </template>
+}

--- a/addon/components/mandatee-table-plugin/insert.gts
+++ b/addon/components/mandatee-table-plugin/insert.gts
@@ -1,0 +1,53 @@
+import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
+import { AddIcon } from '@appuniversum/ember-appuniversum/components/icons/add';
+import { on } from '@ember/modifier';
+import Component from '@glimmer/component';
+import { SayController } from '@lblod/ember-rdfa-editor';
+import { not } from 'ember-truth-helpers';
+import { getCurrentBesluitRange } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-topic-plugin/utils/helpers';
+import { action } from '@ember/object';
+import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
+import t from 'ember-intl/helpers/t';
+
+interface Sig {
+  Args: { controller: SayController; defaultTag: string };
+}
+
+export default class InsertMandateeTableComponent extends Component<Sig> {
+  get controller() {
+    return this.args.controller;
+  }
+  get decisionRange() {
+    return getCurrentBesluitRange(this.controller);
+  }
+
+  @action
+  insert() {
+    const mandatee_table = unwrap(
+      this.controller.schema.nodes.mandatee_table.createAndFill({
+        tag: this.args.defaultTag,
+      }),
+    );
+    this.args.controller.withTransaction((tr) => {
+      return tr.replaceSelectionWith(mandatee_table);
+    });
+  }
+
+  get canInsert() {
+    return Boolean(this.decisionRange);
+  }
+
+  <template>
+    <li class='au-c-list__item'>
+      <AuButton
+        {{on 'click' this.insert}}
+        @icon={{AddIcon}}
+        @iconAlignment='left'
+        @skin='link'
+        @disabled={{not this.canInsert}}
+      >
+        {{t 'mandatee-table-plugin.insert.title'}}
+      </AuButton>
+    </li>
+  </template>
+}

--- a/addon/components/mandatee-table-plugin/node.gts
+++ b/addon/components/mandatee-table-plugin/node.gts
@@ -1,0 +1,52 @@
+import AuIcon from '@appuniversum/ember-appuniversum/components/au-icon';
+
+import { UserIcon } from '@appuniversum/ember-appuniversum/components/icons/user';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
+import IntlService from 'ember-intl/services/intl';
+
+interface Sig {
+  Args: EmberNodeArgs;
+  Blocks: {
+    default: [];
+  };
+}
+export default class MandateeTableNode extends Component<Sig> {
+  @service declare intl: IntlService;
+
+  get controller() {
+    return this.args.controller;
+  }
+
+  get title() {
+    return this.args.node.attrs.title as string | undefined;
+  }
+
+  get documentLanguage() {
+    return this.controller.documentLanguage;
+  }
+
+  get warning() {
+    return this.intl.t('mandatee-table-plugin.node.warning', {
+      locale: this.documentLanguage,
+    });
+  }
+
+  <template>
+    <div class='say-mandatee-table-node'>
+      <div
+        class='say-mandatee-table-header au-u-flex au-u-flex--row au-u-flex--vertical-center'
+      >
+        <AuIcon @icon={{UserIcon}} @size='large' class='au-u-margin-small' />
+        <div>
+          <strong>{{this.title}}</strong>
+          <p>
+            {{this.warning}}
+          </p>
+        </div>
+      </div>
+      <div class='say-mandatee-table-content'>{{yield}}</div>
+    </div>
+  </template>
+}

--- a/addon/plugins/besluit-topic-plugin/utils/helpers.ts
+++ b/addon/plugins/besluit-topic-plugin/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { PNode, SayController } from '@lblod/ember-rdfa-editor';
+import { EditorState, PNode, SayController } from '@lblod/ember-rdfa-editor';
 import {
   BESLUIT,
   RDF,
@@ -9,9 +9,13 @@ import { ElementPNode } from '@lblod/ember-rdfa-editor/plugins/datastore';
 import { findAncestors } from '@lblod/ember-rdfa-editor/utils/position-utils';
 
 export const getCurrentBesluitRange = (
-  controller: SayController,
+  controllerOrState: SayController | EditorState,
 ): ElementPNode | undefined => {
-  const selection = controller.mainEditorState.selection;
+  const state =
+    controllerOrState instanceof SayController
+      ? controllerOrState.mainEditorState
+      : controllerOrState;
+  const selection = state.selection;
 
   const besluit =
     findAncestors(selection.$from, (node: PNode) => {

--- a/addon/plugins/lmb-plugin/utils/fetchMandatees.ts
+++ b/addon/plugins/lmb-plugin/utils/fetchMandatees.ts
@@ -1,0 +1,55 @@
+import Mandatee from '@lblod/ember-rdfa-editor-lblod-plugins/models/mandatee';
+import { IBindings } from 'fetch-sparql-endpoint';
+
+type SparqlResponse = {
+  results: {
+    bindings: IBindings[];
+  };
+};
+
+type FetchMandateesArgs = {
+  endpoint: string;
+};
+
+export async function fetchMandatees({ endpoint }: FetchMandateesArgs) {
+  const queryResponse = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: `
+      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+      PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX regorg: <https://www.w3.org/ns/regorg#>
+      SELECT DISTINCT ?mandatee ?person ?firstName ?lastName ?statusLabel ?fractieLabel ?roleLabel WHERE {
+          ?mandatee a mandaat:Mandataris;
+            org:holds ?mandaat;
+            mandaat:status ?status;
+            mandaat:isBestuurlijkeAliasVan ?person.
+          ?person foaf:familyName ?lastName;
+            persoon:gebruikteVoornaam ?firstName.
+          ?status skos:prefLabel ?statusLabel.
+          ?mandaat org:role ?role.
+          ?role skos:prefLabel ?roleLabel.
+          OPTIONAL  {
+            ?mandatee mandaat:einde ?endDate
+          }
+          OPTIONAL {
+            ?mandatee org:hasMembership ?membership.
+            ?membership org:organisation ?fractie.
+            ?fractie regorg:legalName ?fractieLabel.
+          }
+          filter (!bound(?endDate) || ?endDate > now()).
+      }
+      `,
+    }),
+  });
+  const queryJson: SparqlResponse = await queryResponse.json();
+  const mandatees = queryJson.results.bindings.map(Mandatee.fromBinding);
+  return mandatees;
+}

--- a/addon/plugins/mandatee-table-plugin/index.ts
+++ b/addon/plugins/mandatee-table-plugin/index.ts
@@ -1,0 +1,2 @@
+export * from './sync-document';
+export * from './node';

--- a/addon/plugins/mandatee-table-plugin/node.ts
+++ b/addon/plugins/mandatee-table-plugin/node.ts
@@ -1,0 +1,58 @@
+import type { ComponentLike } from '@glint/template';
+import {
+  createEmberNodeSpec,
+  createEmberNodeView,
+  EmberNodeConfig,
+} from '@lblod/ember-rdfa-editor/utils/ember-node';
+import MandateeTableNode from '@lblod/ember-rdfa-editor-lblod-plugins/components/mandatee-table-plugin/node';
+
+export const emberNodeConfig: () => EmberNodeConfig = () => {
+  return {
+    name: 'mandatee-table',
+    component: MandateeTableNode as unknown as ComponentLike,
+    inline: false,
+    content: 'block+',
+    group: 'block',
+    draggable: false,
+    selectable: true,
+    editable: true,
+    atom: false,
+    isolating: true,
+    attrs: {
+      tag: {},
+      title: {
+        default: 'Mandatarissen',
+      },
+    },
+    serialize(node) {
+      const tag = node.attrs.tag as string;
+      const title = node.attrs.title as string;
+      return [
+        'div',
+        {
+          'data-mandatee-table': true,
+          'data-tag': tag,
+          'data-title': title,
+        },
+        0,
+      ];
+    },
+    parseDOM: [
+      {
+        tag: 'div',
+        getAttrs(element: HTMLElement) {
+          if (element.dataset.mandateeTable && element.dataset.tag) {
+            return {
+              tag: element.dataset.tag,
+              title: element.dataset.title,
+            };
+          }
+          return false;
+        },
+      },
+    ],
+  };
+};
+
+export const mandatee_table = createEmberNodeSpec(emberNodeConfig());
+export const mandateeTableView = createEmberNodeView(emberNodeConfig());

--- a/addon/plugins/mandatee-table-plugin/sync-document.ts
+++ b/addon/plugins/mandatee-table-plugin/sync-document.ts
@@ -1,0 +1,40 @@
+import { EditorState } from '@lblod/ember-rdfa-editor';
+import {
+  TransactionMonad,
+  transactionCombinator,
+} from '@lblod/ember-rdfa-editor/utils/transaction-utils';
+
+export type MandateeTableTag = string;
+export type MandateeTableConfig<R> = Record<
+  MandateeTableTag,
+  MandateeTableConfigEntry<R>
+>;
+export type MandateeTableConfigEntry<R> = {
+  query: () => Promise<R>;
+  updateContent: (pos: number, queryResult: R) => TransactionMonad<boolean>;
+};
+
+export async function syncDocument<R>(
+  state: EditorState,
+  config: MandateeTableConfig<R>,
+) {
+  const { doc, schema } = state;
+
+  const nodesToSync: { pos: number; tag: MandateeTableTag }[] = [];
+  const queries: Promise<R>[] = [];
+  doc.descendants((node, pos) => {
+    if (node.type === schema.nodes.mandatee_table) {
+      const tag = node.attrs.tag as MandateeTableTag;
+      nodesToSync.push({ pos, tag });
+      queries.push(config[node.attrs.tag as MandateeTableTag].query());
+    }
+  });
+  const queryResults = await Promise.all(queries);
+  const transactionMonads = [];
+  for (let i = nodesToSync.length - 1; i >= 0; i--) {
+    const { pos, tag } = nodesToSync[i];
+    transactionMonads.push(config[tag].updateContent(pos, queryResults[i]));
+  }
+  const { transaction } = transactionCombinator(state)(transactionMonads);
+  return state.applyTransaction(transaction).state;
+}

--- a/addon/utils/build-data-table.ts
+++ b/addon/utils/build-data-table.ts
@@ -1,0 +1,68 @@
+import { PNode, Schema } from '@lblod/ember-rdfa-editor';
+import { unwrap } from '../utils/option';
+interface HasToString {
+  toString(): string;
+}
+
+type Args<T extends string> = {
+  schema: Schema;
+  fields: readonly T[];
+  records: Record<T, HasToString>[];
+  includeHeader?: boolean;
+  labels?: Record<T, string>;
+};
+
+export function buildDataTable<T extends string>({
+  schema,
+  fields,
+  records,
+  includeHeader = true,
+  labels,
+}: Args<T>) {
+  const rows: PNode[] = [];
+  const proportionalWidth = 100 / fields.length;
+  if (includeHeader) {
+    const headerCells = [];
+    for (const field of fields) {
+      headerCells.push(
+        unwrap(
+          schema.nodes['table_header'].createAndFill(
+            proportionalWidth
+              ? {
+                  colwidth: [proportionalWidth],
+                }
+              : undefined,
+            schema.nodes.paragraph.create(
+              null,
+              schema.text(labels?.[field] ?? field),
+            ),
+          ),
+        ),
+      );
+    }
+    rows.push(schema.node('table_row', null, headerCells));
+  }
+
+  for (const record of records) {
+    const cells = [];
+    for (const field of fields) {
+      cells.push(
+        unwrap(
+          schema.nodes['table_cell'].createAndFill(
+            proportionalWidth
+              ? {
+                  colwidth: [proportionalWidth],
+                }
+              : undefined,
+            schema.nodes.paragraph.create(
+              null,
+              schema.text(record[field].toString()),
+            ),
+          ),
+        ),
+      );
+    }
+    rows.push(schema.node('table_row', null, cells));
+  }
+  return schema.node('table', null, rows);
+}

--- a/app/components/mandatee-table-plugin/configure.js
+++ b/app/components/mandatee-table-plugin/configure.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/mandatee-table-plugin/configure';

--- a/app/components/mandatee-table-plugin/insert.js
+++ b/app/components/mandatee-table-plugin/insert.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/mandatee-table-plugin/insert';

--- a/app/styles/mandatee-table-plugin.scss
+++ b/app/styles/mandatee-table-plugin.scss
@@ -1,0 +1,14 @@
+.say-mandatee-table-node {
+  border: 1px solid var(--au-blue-300);
+  .say-mandatee-table-header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background-color: var(--au-blue-300);
+    padding: 0.6rem 0.6rem 0.6rem 0;
+    cursor: default;
+  }
+  .say-mandatee-table-content {
+    padding: 1.2rem;
+  }
+}

--- a/tests/dummy/app/components/synchronize-mandatees.gts
+++ b/tests/dummy/app/components/synchronize-mandatees.gts
@@ -1,0 +1,40 @@
+import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
+import { on } from '@ember/modifier';
+import Component from '@glimmer/component';
+import { SayController } from '@lblod/ember-rdfa-editor';
+import { restartableTask } from 'ember-concurrency';
+import perform from 'ember-concurrency/helpers/perform';
+import {
+  MandateeTableConfig,
+  syncDocument,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/mandatee-table-plugin';
+import { SynchronizeIcon } from '@appuniversum/ember-appuniversum/components/icons/synchronize';
+
+interface Sig<R> {
+  Args: { controller: SayController; config: MandateeTableConfig<R> };
+}
+
+export default class SychronizeMandateesComponent<R> extends Component<Sig<R>> {
+  get controller() {
+    return this.args.controller;
+  }
+
+  synchronize = restartableTask(async () => {
+    const newState = await syncDocument(
+      this.controller.mainEditorState,
+      this.args.config,
+    );
+    this.controller.mainEditorView.updateState(newState);
+  });
+
+  <template>
+    <AuButton
+      {{on 'click' (perform this.synchronize)}}
+      @icon={{SynchronizeIcon}}
+      @iconAlignment='left'
+      @loading={{this.synchronize.isRunning}}
+    >
+      Synchronise mandatees
+    </AuButton>
+  </template>
+}

--- a/tests/dummy/app/components/synchronize-mandatees.gts
+++ b/tests/dummy/app/components/synchronize-mandatees.gts
@@ -34,6 +34,7 @@ export default class SychronizeMandateesComponent<R> extends Component<Sig<R>> {
       @iconAlignment='left'
       @loading={{this.synchronize.isRunning}}
     >
+      {{! template-lint-disable no-bare-strings  }}
       Synchronise mandatees
     </AuButton>
   </template>

--- a/tests/dummy/app/config/mandatee-table-sample-config.ts
+++ b/tests/dummy/app/config/mandatee-table-sample-config.ts
@@ -1,0 +1,242 @@
+import { findParentNodeClosestToPos } from '@curvenote/prosemirror-utils';
+import {
+  Fragment,
+  PNode,
+  ResolvedPos,
+  Schema,
+  Transaction,
+} from '@lblod/ember-rdfa-editor';
+import { MandateeTableConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/mandatee-table-plugin';
+import {
+  BESLUIT,
+  EXT,
+  RDF,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { hasOutgoingNamedNodeTriple } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import {
+  QueryResult,
+  executeQuery,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/sparql-helpers';
+import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
+import { addPropertyToNode } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
+import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
+
+function tableCell(schema: Schema, value: string, width: number) {
+  return schema.nodes.table_cell.create(
+    null,
+    schema.nodes.paragraph.create(
+      {
+        colwidth: [width],
+      },
+      schema.text(value),
+    ),
+  );
+}
+
+function resourceCell(
+  schema: Schema,
+  value: string,
+  resource: string,
+  width: number,
+) {
+  return schema.nodes.table_cell.create(
+    {
+      colwidth: [width],
+    },
+    schema.nodes.paragraph.create(
+      null,
+      schema.nodes.inline_rdfa.create(
+        {
+          rdfaNodeType: 'resource',
+          subject: resource,
+        },
+        schema.text(value),
+      ),
+    ),
+  );
+}
+
+function tableHeaderCell(schema: Schema, value: string, width: number) {
+  return schema.nodes.table_header.create(
+    null,
+    schema.nodes.paragraph.create(
+      {
+        colwidth: [width],
+      },
+      schema.text(value),
+    ),
+  );
+}
+
+function replaceContent(
+  tr: Transaction,
+  $pos: ResolvedPos,
+  content: Fragment | PNode,
+) {
+  const rangeToReplace = {
+    from: $pos.pos + 1,
+    to: $pos.pos + unwrap($pos.nodeAfter).nodeSize - 1,
+  };
+  return tr.replaceWith(rangeToReplace.from, rangeToReplace.to, content);
+}
+
+export const MANDATEE_TABLE_SAMPLE_CONFIG: MandateeTableConfig<QueryResult> = {
+  eedafleggingen: {
+    query: () => {
+      const sparqlQuery = `PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+        SELECT DISTINCT ?mandatee ?name ?start WHERE {
+          ?mandatee a mandaat:Mandataris;
+                  mandaat:isBestuurlijkeAliasVan ?person;
+                  mandaat:start ?start.
+
+          ?person foaf:familyName ?lastName;
+                  persoon:gebruikteVoornaam ?firstName.
+          BIND(CONCAT(STR( ?firstName ), " ", STR( ?lastName ) ) AS ?name ) .
+        }
+        LIMIT 10`;
+      return executeQuery({
+        query: sparqlQuery,
+        endpoint: 'http://localhost/vendor-proxy/query',
+      });
+    },
+    updateContent: (pos, queryResult) => {
+      return (state) => {
+        const { schema, doc } = state;
+        const $pos = doc.resolve(pos);
+        const decisionUri = unwrap(
+          findParentNodeClosestToPos($pos, (node) => {
+            return hasOutgoingNamedNodeTriple(
+              node.attrs,
+              RDF('type'),
+              BESLUIT('Besluit'),
+            );
+          }),
+        ).node.attrs.subject;
+        if (!decisionUri) {
+          return { result: false, initialState: state, transaction: state.tr };
+        }
+
+        const mandatees = queryResult.results.bindings;
+        const cellWidth = 50;
+        const tableHeader = schema.nodes.table_row.create(null, [
+          tableHeaderCell(schema, 'Naam verkozene', cellWidth),
+          tableHeaderCell(schema, 'Datum eedaflegging', cellWidth),
+        ]);
+        const rows = mandatees.map((mandatee) => {
+          const name = mandatee['name'].value;
+          const start = mandatee['start'].value;
+          const mandateeUri = mandatee['mandatee'].value;
+          return schema.nodes.table_row.create(null, [
+            resourceCell(schema, name, mandateeUri, cellWidth),
+            tableCell(schema, start, cellWidth),
+          ]);
+        });
+        const content = schema.nodes.table.create(null, [tableHeader, ...rows]);
+        const factory = new SayDataFactory();
+        const result = transactionCombinator(
+          state,
+          replaceContent(state.tr, $pos, content),
+        )(
+          mandatees.map((mandatee) => {
+            return addPropertyToNode({
+              resource: decisionUri,
+              property: {
+                predicate: EXT('appoints').full,
+                object: factory.resourceNode(mandatee['mandatee'].value),
+              },
+            });
+          }),
+        );
+        return {
+          transaction: result.transaction,
+          result: true,
+          initialState: state,
+        };
+      };
+    },
+  },
+  'naam-status-rol': {
+    query: () => {
+      const sparqlQuery = `PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+        PREFIX org: <http://www.w3.org/ns/org#>
+        SELECT DISTINCT ?mandatee ?name ?status ?role WHERE {
+            ?mandatee a mandaat:Mandataris;
+              mandaat:status/skos:prefLabel ?status;
+              mandaat:isBestuurlijkeAliasVan ?person.
+            ?person foaf:familyName ?lastName;
+              persoon:gebruikteVoornaam ?firstName.
+            ?mandaat org:role/skos:prefLabel ?role.
+            BIND(CONCAT(STR( ?firstName ), " ", STR( ?lastName ) ) AS ?name ) .
+        }
+        LIMIT 10`;
+      return executeQuery({
+        query: sparqlQuery,
+        endpoint: 'http://localhost/vendor-proxy/query',
+      });
+    },
+    updateContent: (pos: number, queryResult: QueryResult) => {
+      return (state) => {
+        const { doc, schema } = state;
+        const $pos = doc.resolve(pos);
+        const decisionUri = unwrap(
+          findParentNodeClosestToPos($pos, (node) => {
+            return hasOutgoingNamedNodeTriple(
+              node.attrs,
+              RDF('type'),
+              BESLUIT('Besluit'),
+            );
+          }),
+        ).node.attrs.subject;
+        if (!decisionUri) {
+          return { initialState: state, result: false, transaction: state.tr };
+        }
+        const mandatees = queryResult.results.bindings;
+        const cellWidth = 100 / 3;
+        const tableHeader = schema.nodes.table_row.create(null, [
+          tableHeaderCell(schema, 'Naam verkozene', cellWidth),
+          tableHeaderCell(schema, 'Status', cellWidth),
+          tableHeaderCell(schema, 'Rol', cellWidth),
+        ]);
+        const rows = mandatees.map((mandatee) => {
+          const name = mandatee['name'].value;
+          const status = mandatee['status'].value;
+          const role = mandatee['role'].value;
+          const mandateeUri = mandatee['mandatee'].value;
+          return schema.nodes.table_row.create(null, [
+            resourceCell(schema, name, mandateeUri, cellWidth),
+            tableCell(schema, status, cellWidth),
+            tableCell(schema, role, cellWidth),
+          ]);
+        });
+        const content = schema.nodes.table.create(null, [tableHeader, ...rows]);
+        const factory = new SayDataFactory();
+        const result = transactionCombinator(
+          state,
+          replaceContent(state.tr, $pos, content),
+        )(
+          mandatees.map((mandatee) => {
+            return addPropertyToNode({
+              resource: decisionUri,
+              property: {
+                predicate: EXT('appoints').full,
+                object: factory.resourceNode(mandatee['mandatee'].value),
+              },
+            });
+          }),
+        );
+        return {
+          transaction: result.transaction,
+          result: true,
+          initialState: state,
+        };
+      };
+    },
+  },
+};

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -105,6 +105,11 @@ import applyDevTools from 'prosemirror-dev-tools';
 import recreateUuidsOnPaste from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/recreateUuidsOnPaste';
 import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
 import { getOwner } from '@ember/application';
+import {
+  mandatee_table,
+  mandateeTableView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/mandatee-table-plugin/node';
+import { MANDATEE_TABLE_SAMPLE_CONFIG } from '../config/mandatee-table-sample-config';
 
 export default class BesluitSampleController extends Controller {
   DebugInfo = DebugInfo;
@@ -159,6 +164,7 @@ export default class BesluitSampleController extends Controller {
         codelist,
         oslo_location: osloLocation(this.config.location),
         roadsign_regulation,
+        mandatee_table,
         heading: headingWithConfig({ rdfaAware: true }),
         blockquote,
 
@@ -272,6 +278,11 @@ export default class BesluitSampleController extends Controller {
         defaultAddressUriRoot:
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
       },
+      mandateeTable: {
+        config: MANDATEE_TABLE_SAMPLE_CONFIG,
+        tags: Object.keys(MANDATEE_TABLE_SAMPLE_CONFIG),
+        defaultTag: Object.keys(MANDATEE_TABLE_SAMPLE_CONFIG)[0],
+      },
     };
   }
 
@@ -300,6 +311,7 @@ export default class BesluitSampleController extends Controller {
       oslo_location: osloLocationView(this.config.location)(controller),
       inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
       structure: structureView(controller),
+      mandatee_table: mandateeTableView(controller),
     } satisfies Record<string, SayNodeViewConstructor>;
   };
   @tracked plugins: Plugin[] = [

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -19,6 +19,7 @@
 @import 'worship-plugin';
 @import 'structure-plugin';
 @import 'location-plugin';
+@import 'mandatee-table-plugin';
 
 div.table-of-contents {
   padding: $au-unit-small !important;

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -89,6 +89,10 @@
         </:default>
         <:aside>
           {{#if this.controller}}
+            <SynchronizeMandatees
+              @controller={{this.controller}}
+              @config={{this.config.mandateeTable.config}}
+            />
             <Sidebar as |Sidebar|>
               <Sidebar.Collapsible @title='Structures'>
                 <this.InsertArticle @controller={{this.controller}} />
@@ -120,6 +124,10 @@
                   @controller={{this.controller}}
                   @config={{this.config.lmb}}
                 />
+                <MandateeTablePlugin::Insert
+                  @controller={{this.controller}}
+                  @defaultTag={{this.config.mandateeTable.defaultTag}}
+                />
                 <LpdcPlugin::LpdcInsert
                   @controller={{this.controller}}
                   @config={{this.config.lpdc}}
@@ -135,6 +143,10 @@
                 @config={{this.config.citation}}
               />
               <ImportSnippetPlugin::Card @controller={{this.controller}} />
+              <MandateeTablePlugin::Configure
+                @controller={{this.controller}}
+                @supportedTags={{this.config.mandateeTable.tags}}
+              />
               <VariablePlugin::Codelist::Edit
                 @controller={{this.controller}}
                 @options={{this.codelistOptions}}

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -516,7 +516,7 @@ lpdc-plugin:
 
 mandatee-table-plugin:
   insert:
-      title: Insert mandatee table
+    title: Insert mandatee table
   configure:
     title: Configure mandatee table
     tag-input:
@@ -527,4 +527,4 @@ mandatee-table-plugin:
       placeholder: Title
   node:
     warning: Information which you enter below may be removed upon
-             synchronisation of the inauguration meeting.
+      synchronisation of the inauguration meeting.

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -513,3 +513,18 @@ lpdc-plugin:
       name: Name
   search:
     placeholder: LPDC Name/Description
+
+mandatee-table-plugin:
+  insert:
+      title: Insert mandatee table
+  configure:
+    title: Configure mandatee table
+    tag-input:
+      label: Tag
+      placeholder: Select tag
+    title-input:
+      label: Title
+      placeholder: Title
+  node:
+    warning: Information which you enter below may be removed upon
+             synchronisation of the inauguration meeting.

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -512,3 +512,18 @@ lpdc-plugin:
       name: Naam
   search:
     placeholder: LPDC-naam/beschrijving
+
+mandatee-table-plugin:
+  insert:
+    title: Mandatarissen-tabel invoegen
+  configure:
+    title: Mandatarissen-tabel configureren
+    tag-input:
+      label: Tag
+      placeholder: Selecteer tag
+    title-input:
+      label: Titel
+      placeholder: Titel
+  node:
+    warning: Informatie die u hieronder manueel ingeeft, wordt mogelijks
+             verwijderd bij synchronisatie van de installatievergadering.

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -526,4 +526,4 @@ mandatee-table-plugin:
       placeholder: Titel
   node:
     warning: Informatie die u hieronder manueel ingeeft, wordt mogelijks
-             verwijderd bij synchronisatie van de installatievergadering.
+      verwijderd bij synchronisatie van de installatievergadering.


### PR DESCRIPTION
### Overview
This PR includes a new mandatee table plugin which includes the following features:
- Addition of a `mandatee_table` node-spec and `mandateeTableView` node-view
  * `mandatee_table` nodes support two attributes: `tag` and `title` which can be configured by a template-creator
- Addition of two components used to insert and configure mandatee tables
  * `MandateeTablePlugin::Insert` allows a user/template-creator to insert empty `mandatee_table` nodes
  * `MandateeTablePlugin::Configure` allows a user/template-creator to configure the title/tag of a `mandatee_table` node
- Addition of a `syncDocument` function.
  * Synchronizes the `mandatee_table` nodes in a document based on a supplied configuration
  * Can work in a headless way (does not require a prosemirror view). It accepts and outputs a `ProseMirrorState` object.

Addition this PR also includes a sample configuration (with two types of tables) and a dummy 'synchronize' button to test the plugin.

TODO:

- [x] merge, release and apply https://github.com/lblod/ember-rdfa-editor/pull/1208
- [ ] add docs

##### connected issues and PRs:
[GN-4899](https://binnenland.atlassian.net/browse/GN-4899)
(optional) https://github.com/lblod/ember-rdfa-editor/pull/1208


### Setup
- Ensure you are running https://github.com/lblod/app-gelinkt-notuleren/pull/182 on port 80. You can modify the sample configuration found in https://github.com/lblod/ember-rdfa-editor-lblod-plugins/blob/b1e79b259a81b28df58e637fc0b3d560f9841ea0/tests/dummy/app/config/mandatee-table-sample-config.ts if you are running the backend on another port.
(optional) pnpm link https://github.com/lblod/ember-rdfa-editor/pull/1208

### How to test/reproduce
- Start the dummy application with the 'Besluit sample' page
- Insert an empty 'mandatee table' node in a decision. This node should have the default 'eedafleggingen' tag and a default title of 'Mandatarissen'.
- Ensure it is possible to change the tag and title of a mandatee table node
- When pressing the `synchronise mandatees` button, the mandatee table should be updated.
- Add another table, and test if synchronisation still works
- Synchronisation should remove any modifications inside the nodes made by users
- Specifically for the two sample configurations: a relation between the decision and mandatee URI (around the name of the mandatee) should be inserted. It now uses the sample `ext:appoints` predicate.
- When also using https://github.com/lblod/ember-rdfa-editor/pull/1208: when re-synchronizing, there should be no duplicates in the properties of the decision

### Challenges/uncertainties
I've implemented the plugin in an as generic as possible way. This means it may be useful outside of the context of inauguration meetings. Currently I've left the naming inauguration-meeting specific though.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
