### PR TITLE
Improve `mandatee_table` serialization

### DIFF
--- a/.changeset/calm-berries-give.md
+++ b/.changeset/calm-berries-give.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Improve serialization of `mandatee_table` node

--- a/addon/components/mandatee-table-plugin/node.gts
+++ b/addon/components/mandatee-table-plugin/node.gts
@@ -36,9 +36,13 @@ export default class MandateeTableNode extends Component<Sig> {
   <template>
     <div class='say-mandatee-table-node'>
       <div
-        class='say-mandatee-table-header au-u-flex au-u-flex--row au-u-flex--vertical-center'
+        class='say-mandatee-table-header au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--spaced-tiny'
       >
-        <AuIcon @icon={{UserIcon}} @size='large' class='au-u-margin-small' />
+        <AuIcon
+          @icon={{UserIcon}}
+          @size='large'
+          class='au-u-margin-left-tiny au-u-margin-right-tiny'
+        />
         <div>
           <strong>{{this.title}}</strong>
           <p>

--- a/addon/plugins/mandatee-table-plugin/node.ts
+++ b/addon/plugins/mandatee-table-plugin/node.ts
@@ -30,25 +30,38 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
       return [
         'div',
         {
-          'data-mandatee-table': true,
-          'data-tag': tag,
-          'data-title': title,
+          'data-say-mandatee-table': true,
+          'data-say-mandatee-table-tag': tag,
+          'data-say-mandatee-table-title': title,
+          class: 'say-mandatee-table-node',
         },
-        0,
+        ['p', { class: 'say-mandatee-table-header' }, ['strong', {}, title]],
+        [
+          'div',
+          {
+            class: 'say-mandatee-table-content',
+            'data-say-mandatee-table-content': true,
+          },
+          0,
+        ],
       ];
     },
     parseDOM: [
       {
         tag: 'div',
         getAttrs(element: HTMLElement) {
-          if (element.dataset.mandateeTable && element.dataset.tag) {
+          if (
+            element.dataset.sayMandateeTable &&
+            element.dataset.sayMandateeTableTag
+          ) {
             return {
-              tag: element.dataset.tag,
-              title: element.dataset.title,
+              tag: element.dataset.sayMandateeTableTag,
+              title: element.dataset.sayMandateeTableTitle,
             };
           }
           return false;
         },
+        contentElement: `div[data-say-mandatee-table-content]`,
       },
     ],
   };

--- a/app/styles/mandatee-table-plugin.scss
+++ b/app/styles/mandatee-table-plugin.scss
@@ -5,7 +5,7 @@
     flex-direction: row;
     align-items: center;
     background-color: var(--au-blue-300);
-    padding: 0.6rem 0.6rem 0.6rem 0;
+    padding: 0.6rem 0.6rem 0.6rem 0.6rem;
     cursor: default;
   }
   .say-mandatee-table-content {


### PR DESCRIPTION
### Overview
This PR includes two adjustments to the `mandatee_table` node:
- Improvements to the serialization: inclusion of css classes for styling and inclusion of the mandatee_table title
- Improvements to the naming of the data-attributes used by the mandatee_table node

### How to test/reproduce
- Open the dummy app
- Insert a mandatee table
- Synchronize
- Reload, all attributes of the mandatee table should remain intact
- The styled export should include some css and the title of the mandatee table

### Challenges/uncertainties
This PR is technically breaking, but as the mandatee-table node is not yet deployed anywhere (even not on QA/dev), it does not seem worth it to make a breaking release for this. This PR does not break the API of the plugin.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
