### PR TITLE
GN-4949: person-variable-plugin: fix issue with unresponsive edit/insert button

### DIFF
--- a/.changeset/strange-fishes-lay.md
+++ b/.changeset/strange-fishes-lay.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Fix issue with unresponsive edit/insert button when person variable is selected

--- a/addon/components/variable-plugin/codelist/edit.ts
+++ b/addon/components/variable-plugin/codelist/edit.ts
@@ -33,7 +33,7 @@ export default class CodelistEditComponent extends Component<Args> {
     return this.args.controller;
   }
 
-  selectedCodelist = trackedFunction(this, () => {
+  get selectedCodelist() {
     const { selection } = this.controller.mainEditorState;
     if (
       selection instanceof NodeSelection &&
@@ -46,11 +46,11 @@ export default class CodelistEditComponent extends Component<Args> {
       return codelist;
     }
     return;
-  });
+  }
 
   get source() {
-    if (this.selectedCodelist.value) {
-      const { node } = this.selectedCodelist.value;
+    if (this.selectedCodelist) {
+      const { node } = this.selectedCodelist;
       const source = getOutgoingTriple(node.attrs, DCT('source'))?.object
         .value as Option<string>;
       if (source) {
@@ -61,8 +61,8 @@ export default class CodelistEditComponent extends Component<Args> {
   }
 
   get codelistUri() {
-    if (this.selectedCodelist.value) {
-      const { node } = this.selectedCodelist.value;
+    if (this.selectedCodelist) {
+      const { node } = this.selectedCodelist;
       const codelistUri = getOutgoingTriple(node.attrs, EXT('codelist'))?.object
         .value as Option<string>;
       if (codelistUri) {
@@ -73,11 +73,11 @@ export default class CodelistEditComponent extends Component<Args> {
   }
 
   get showCard() {
-    return !!this.selectedCodelist.value;
+    return !!this.selectedCodelist;
   }
 
   get label() {
-    return this.selectedCodelist.value?.node.attrs.label as string | undefined;
+    return this.selectedCodelist?.node.attrs.label as string | undefined;
   }
 
   codelistOptions = trackedFunction(this, async () => {
@@ -89,7 +89,7 @@ export default class CodelistEditComponent extends Component<Args> {
   });
 
   get multiSelect() {
-    const localStyle = this.selectedCodelist.value?.node.attrs
+    const localStyle = this.selectedCodelist?.node.attrs
       .selectionStyle as string;
     if (localStyle) {
       return localStyle === 'multi';
@@ -99,11 +99,11 @@ export default class CodelistEditComponent extends Component<Args> {
 
   @action
   insert() {
-    if (!this.selectedCodelist.value || !this.selectedCodelistOption) {
+    if (!this.selectedCodelist || !this.selectedCodelistOption) {
       return;
     }
     updateCodelistVariable(
-      this.selectedCodelist.value,
+      this.selectedCodelist,
       this.selectedCodelistOption,
       this.controller,
     );

--- a/addon/components/variable-plugin/person/edit.ts
+++ b/addon/components/variable-plugin/person/edit.ts
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { SayController, PNode } from '@lblod/ember-rdfa-editor';
 import { NodeSelection } from '@lblod/ember-rdfa-editor';
-import { trackedFunction } from 'ember-resources/util/function';
 import { tracked } from '@glimmer/tracking';
 import { LmbPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/lmb-plugin';
 import Mandatee from '@lblod/ember-rdfa-editor-lblod-plugins/models/mandatee';
@@ -24,7 +23,7 @@ export default class PersonEditComponent extends Component<Args> {
     return this.args.controller;
   }
 
-  selectedPersonNode = trackedFunction(this, () => {
+  get selectedPersonNode() {
     const { selection } = this.controller.mainEditorState;
     if (
       selection instanceof NodeSelection &&
@@ -37,19 +36,20 @@ export default class PersonEditComponent extends Component<Args> {
       return personNode;
     }
     return;
-  });
+  }
 
   get showCard() {
-    return !!this.selectedPersonNode.value;
+    return !!this.selectedPersonNode;
   }
 
   get isEditing() {
-    const personNode = this.selectedPersonNode.value;
+    const personNode = this.selectedPersonNode;
     return !!personNode?.node.attrs.mandatee;
   }
 
   @action
   openModal() {
+    console.log('Open modal!!!');
     this.controller.focus();
     this.showModal = true;
   }
@@ -60,7 +60,7 @@ export default class PersonEditComponent extends Component<Args> {
   }
   @action
   onInsert(mandatee: Mandatee) {
-    const personNode = this.selectedPersonNode.value as PersonNode;
+    const personNode = this.selectedPersonNode as PersonNode;
     this.controller.withTransaction((tr) => {
       tr.setNodeAttribute(personNode.pos, 'mandatee', mandatee);
       return tr.setNodeAttribute(


### PR DESCRIPTION
### Overview
This PR fixes the issue with the unresponsive edit/insert button when a person variable is selected.
Specifically, it replaces the `trackedFunction`  by a simple getter.

**Cause of the issue**
   -  The edit/insert card is only shown when selectedPersonNode is not loading and has resolved to a value
   - The selectedPersonNode trackedFunction is dependent on the editor state
   - When clicking on the edit/insert button outside the editor, a click event is fired => this causes the editor state to change (as the selection is no longer visible)
   - The selectedPersonNode trackedFunction is triggered due to a state change and goes into 'loading' mode, which means it no longer has a value (as it is pending) => this causes the card to hide (for only a few ms, but that's enough)
   - Due to the card being hidden for a few ms, the click event never reaches the button handler => the click handler is never triggered

##### connected issues and PRs:
[GN-4949](https://binnenland.atlassian.net/browse/GN-4949?atlOrigin=eyJpIjoiYzFiNTc5ZjgwODA3NDU0OWI1MDUwZjdmNmIyZDhmZTgiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the dummy app
- Insert a person variable + click outside the variable
- Select the person variable again
- Notice that the edit/insert buttons are now directly responsive

### Challenges/uncertainties
I do not directly see a reason why to use a `trackedFunction` in this situation, especially as we aren't dealing with an async function/loading states. Correct me if I'm mistaken.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
