### PR TITLE
GN-4976: disable fingerprinting on ember-leaflet assets

### DIFF
--- a/.changeset/honest-geckos-remember.md
+++ b/.changeset/honest-geckos-remember.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+test-app: exclude fingerprinting on ember-leaflet related images to ensure production builds behave as expected

--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ related to the LBLOD Project.
 ember install ember-rdfa-editor-lblod-plugins
 ```
 
+If you are using the location-plugin, you should also add the following configuration to your `ember-cli-build.js` file:
+```js
+fingerprint: {
+  exclude: [
+    'images/layers-2x.png',
+    'images/layers.png',
+    'images/marker-icon-2x.png',
+    'images/marker-icon.png',
+    'images/marker-shadow.png'
+  ]
+}
+```
+This ensures the map-view behaves as expected in production builds.
+
+Check-out https://github.com/miguelcobain/ember-leaflet?tab=readme-ov-file#production-builds for more information.
+
 ## General addon information
 
 This addon contains the following editor plugins:

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,6 +13,15 @@ module.exports = function (defaults) {
     'ember-cli-babel': {
       enableTypeScriptTransform: true,
     },
+    fingerprint: {
+      exclude: [
+        'images/layers-2x.png',
+        'images/layers.png',
+        'images/marker-icon-2x.png',
+        'images/marker-icon.png',
+        'images/marker-shadow.png',
+      ],
+    },
   });
 
   /*


### PR DESCRIPTION
### Overview
This PR disables fingerprinting on ember-leaflet assets for the test-app. This ensures that the assets are correctly sourced in production builds. For more information, see https://github.com/miguelcobain/ember-leaflet?tab=readme-ov-file#production-builds. 
This PR also includes a section in the README on how to disable fingerprinting in the host app.

##### connected issues and PRs:
[GN-4976](https://binnenland.atlassian.net/browse/GN-4976?atlOrigin=eyJpIjoiMTM5ZjEzZmUzZWFmNDZjYWI3ZTJmZWI5OWI1MmJhN2YiLCJwIjoiaiJ9)

### How to test/reproduce
- `pnpm ember build --prod`
- serve the outputted files in dist with a static file server of choice
- Ensure that the map marker is correctly visible


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
