### PR TITLE
Correctly export empty person nodes

### DIFF
--- a/.changeset/modern-cougars-compete.md
+++ b/.changeset/modern-cougars-compete.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Correctly export empty person nodes

--- a/.changeset/old-weeks-swim.md
+++ b/.changeset/old-weeks-swim.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Correctly export empty person node

--- a/addon/plugins/variable-plugin/variables/person.ts
+++ b/addon/plugins/variable-plugin/variables/person.ts
@@ -9,6 +9,7 @@ import {
 } from '@lblod/ember-rdfa-editor/utils/ember-node';
 import {
   DOMOutputSpec,
+  EditorState,
   getRdfaAttrs,
   PNode,
   rdfaAttrSpec,
@@ -19,6 +20,11 @@ import type { ComponentLike } from '@glint/template';
 import { hasOutgoingNamedNodeTriple } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 import { renderRdfaAware } from '@lblod/ember-rdfa-editor/core/schema';
 import Mandatee from '@lblod/ember-rdfa-editor-lblod-plugins/models/mandatee';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
+
+const TRANSLATION_FALLBACKS = {
+  nodeview_placeholder: 'persoon',
+};
 
 const rdfaAware = true;
 const parseDOM = [
@@ -50,7 +56,8 @@ const parseDOM = [
   },
 ];
 
-const toDOM = (node: PNode): DOMOutputSpec => {
+const serialize = (node: PNode, state: EditorState): DOMOutputSpec => {
+  const t = getTranslationFunction(state);
   const mandatee = node.attrs.mandatee as Mandatee;
   return renderRdfaAware({
     renderable: node,
@@ -59,7 +66,7 @@ const toDOM = (node: PNode): DOMOutputSpec => {
       ...node.attrs,
       'data-mandatee': JSON.stringify(mandatee),
     },
-    content: mandatee ? `${mandatee.fullName}` : '',
+    content: mandatee ? `${mandatee.fullName}` : t('variable-plugin.person.nodeview-placeholder', TRANSLATION_FALLBACKS.nodeview_placeholder),
   });
 };
 
@@ -85,7 +92,7 @@ const emberNodeConfig: EmberNodeConfig = {
       default: null,
     },
   },
-  toDOM,
+  serialize,
   parseDOM,
 };
 

--- a/addon/plugins/variable-plugin/variables/person.ts
+++ b/addon/plugins/variable-plugin/variables/person.ts
@@ -66,7 +66,12 @@ const serialize = (node: PNode, state: EditorState): DOMOutputSpec => {
       ...node.attrs,
       'data-mandatee': JSON.stringify(mandatee),
     },
-    content: mandatee ? `${mandatee.fullName}` : t('variable-plugin.person.nodeview-placeholder', TRANSLATION_FALLBACKS.nodeview_placeholder),
+    content: mandatee
+      ? `${mandatee.fullName}`
+      : t(
+          'variable-plugin.person.nodeview-placeholder',
+          TRANSLATION_FALLBACKS.nodeview_placeholder,
+        ),
   });
 };
 

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -268,7 +268,7 @@ variable-plugin:
     to: to
   person:
     card-title: Insert person
-    nodeview-placeholder: person
+    nodeview-placeholder: Insert person
 
 table-of-contents-plugin:
   title: Table of Contents

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -272,7 +272,7 @@ variable-plugin:
     to: tot
   person:
     card-title: Persoon invoegen
-    nodeview-placeholder: persoon
+    nodeview-placeholder: Voeg persoon in
 dummy:
   validation-card:
     title: Documentvalidatie


### PR DESCRIPTION
### Overview
Added export to an empty person node to mimic what the user sees in the nodeview. To discuss if this should be like this or we should change both texts (or any of the two at least) to something like "Insert person".

##### connected issues and PRs:
GN-4978


### Setup
None

### How to test/reproduce
Go to the regulatory statements tab, insert a person variable and click on the show raw export button to see that the variable gets correclty exported

### Challenges/uncertainties
As I said maybe we should change the text



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
