### PR TITLE
Only show title annotations in the actual document

### DIFF
--- a/.changeset/spicy-buttons-refuse.md
+++ b/.changeset/spicy-buttons-refuse.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Don't show title annotation outside the editor

--- a/app/styles/document-title-plugin.scss
+++ b/app/styles/document-title-plugin.scss
@@ -1,9 +1,11 @@
-[property='eli:title']:before {
-  content: 'Document-titel' !important;
-}
-
-[lang='en-US'] {
+.rdfa-annotations-hover {
   [property='eli:title']:before {
-    content: 'Document title' !important;
+    content: 'Document-titel' !important;
+  }
+
+  [lang='en-US'] {
+    [property='eli:title']:before {
+      content: 'Document title' !important;
+    }
   }
 }


### PR DESCRIPTION
### Overview
I linked the title annotation to the rdfa-annotations-hover class so it only shows in the actual document and not in any of the exported versions, I see that we removed the rdfa-annotations class so maybe we don't want any of the annotations. In this case we can just remove this code, let me know

##### connected issues and PRs:
GN-4960


### Setup
Link to frontend

### How to test/reproduce
then create a meeting with a besluit in it, see that the title annotation now is not shown in any of the html forms of the agendapoint

### Challenges/uncertainties
As I said we might not want to show this annotation at all



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
