### PR TITLE
GN-5000: Adjust `article-structure-plugin` stylesheet

### DIFF
--- a/.changeset/five-rocks-shout.md
+++ b/.changeset/five-rocks-shout.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Removal of styles from `article-structure-plugin` stylesheet which removed annotation styles

--- a/app/styles/article-structure-plugin.scss
+++ b/app/styles/article-structure-plugin.scss
@@ -108,9 +108,3 @@
     margin: 0;
   }
 }
-.rdfa-annotations [property] {
-  border-bottom-style: none !important;
-}
-.rdfa-annotations [typeof] {
-  border-bottom-style: none !important;
-}


### PR DESCRIPTION
### Overview
This PR consists of some adjustments to the `article-structure-plugin` stylesheet. Specifically, it removes the following two style rules:
```
.rdfa-annotations [property] {
  border-bottom-style: none !important;
}
.rdfa-annotations [typeof] {
  border-bottom-style: none !important;
}
```
These rules conflict with other style-rules (included in the editor repo) which add a dotted border-bottom to annotated content.

This PR is made as a hotfix on version 19.3.0 (this is the current version of the plugins on GN prod).

##### connected issues and PRs:
[GN-5000](https://binnenland.atlassian.net/browse/GN-5000?atlOrigin=eyJpIjoiOTNkY2JkOTZkZjkzNDhlOThmNDBkMmE0ODEzNDFlMWIiLCJwIjoiaiJ9)

### How to test/reproduce
- Open the dummy app
- Insert a decision template
- Ensure that annotated content (like the decision title, description etc.) is marked with a full dotted line beneath.

### Challenges/uncertainties
I realize this is not an ideal solution, but this should do for now.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
