### PR TITLE
mandatee-table plugin: remove insertion constraint on mandatee table insertion

### DIFF
--- a/.changeset/cold-schools-heal.md
+++ b/.changeset/cold-schools-heal.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Remove constraint on mandatee table insertion. Mandatee table can now be inserted everywhere in a document.

--- a/addon/components/mandatee-table-plugin/insert.gts
+++ b/addon/components/mandatee-table-plugin/insert.gts
@@ -17,9 +17,6 @@ export default class InsertMandateeTableComponent extends Component<Sig> {
   get controller() {
     return this.args.controller;
   }
-  get decisionRange() {
-    return getCurrentBesluitRange(this.controller);
-  }
 
   @action
   insert() {
@@ -33,10 +30,6 @@ export default class InsertMandateeTableComponent extends Component<Sig> {
     });
   }
 
-  get canInsert() {
-    return Boolean(this.decisionRange);
-  }
-
   <template>
     <li class='au-c-list__item'>
       <AuButton
@@ -44,7 +37,6 @@ export default class InsertMandateeTableComponent extends Component<Sig> {
         @icon={{AddIcon}}
         @iconAlignment='left'
         @skin='link'
-        @disabled={{not this.canInsert}}
       >
         {{t 'mandatee-table-plugin.insert.title'}}
       </AuButton>

--- a/addon/components/mandatee-table-plugin/insert.gts
+++ b/addon/components/mandatee-table-plugin/insert.gts
@@ -3,8 +3,6 @@ import { AddIcon } from '@appuniversum/ember-appuniversum/components/icons/add';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import { SayController } from '@lblod/ember-rdfa-editor';
-import { not } from 'ember-truth-helpers';
-import { getCurrentBesluitRange } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-topic-plugin/utils/helpers';
 import { action } from '@ember/object';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import t from 'ember-intl/helpers/t';


### PR DESCRIPTION
### Overview
This PR removes the insertion constraint on mandatee tables. This means mandatee tables may be inserted everywhere (including snippets).

##### connected issues and PRs:
None

### How to test/reproduce
- Start the dummy app
- Notice that you can insert a mandatee table everywhere in the document (not just in a decision)
- Note: the synchronization of a mandatee table can only be done inside a decision (with the current config).

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
