### PR TITLE
Fix CRS URI used in location plugin to use correct http: protocol

### DIFF
--- a/.changeset/rude-dogs-fry.md
+++ b/.changeset/rude-dogs-fry.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Correct CRS URI used in location plugin to correctly use http: instead of https:

--- a/addon/plugins/location-plugin/utils/geo-helpers.ts
+++ b/addon/plugins/location-plugin/utils/geo-helpers.ts
@@ -110,7 +110,7 @@ export type GeoPos = {
 };
 
 export function constructLambert72GMLString({ x, y }: Lambert72Coordinates) {
-  return `<gml:Point srsName="https://www.opengis.net/def/crs/EPSG/0/31370" xmlns:gml="http://www.opengis.net/gml/3.2"><gml:pos>${x} ${y}</gml:pos></gml:Point>`;
+  return `<gml:Point srsName="http://www.opengis.net/def/crs/EPSG/0/31370" xmlns:gml="http://www.opengis.net/gml/3.2"><gml:pos>${x} ${y}</gml:pos></gml:Point>`;
 }
 /**
  * Use a regex to parse a simple point as a GML string and return the coordinates.
@@ -122,7 +122,7 @@ export function parseLambert72GMLString(gml: string): GeoPos {
   // which can be represented. Since we handle only simple points, it's much less complex to just
   // use a simple regex.
   const [_, crs, x, y] =
-    /<gml.Point .*srsName="https:\/\/www.opengis.net\/def\/crs\/([^"]+)".+<gml.pos>(\S+) ([^<]+)<\/gml:pos>/.exec(
+    /<gml.Point .*srsName="https?:\/\/www.opengis.net\/def\/crs\/([^"]+)".+<gml.pos>(\S+) ([^<]+)<\/gml:pos>/.exec(
       gml,
     ) || [];
   if (!crs || crs !== 'EPSG/0/31370') {
@@ -144,11 +144,11 @@ export function constructLambert72WKTString(
 ) {
   if (!Array.isArray(coords)) {
     const { x, y } = coords;
-    return `<https://www.opengis.net/def/crs/EPSG/0/31370> POINT(${x} ${y})`;
+    return `<http://www.opengis.net/def/crs/EPSG/0/31370> POINT(${x} ${y})`;
   } else {
     const points = coords.map(({ x, y }) => `${x} ${y}`).join(', ');
     // Double brackets are not a mistake...
-    return `<https://www.opengis.net/def/crs/EPSG/0/31370> POLYGON((${points}))`;
+    return `<http://www.opengis.net/def/crs/EPSG/0/31370> POLYGON((${points}))`;
   }
 }
 
@@ -171,7 +171,7 @@ export function parseLambert72WKTString(gml: string): GeoPos | GeoPos[] {
   // cases, it's much less complex to just use a simple regex.
 
   const [_, crs, shape, dimensions] =
-    /<https:\/\/www.opengis.net\/def\/crs\/([^"]+)> (POLYGON|POINT)\(\(?([\d,. ]+)\)\)?/.exec(
+    /<https?:\/\/www.opengis.net\/def\/crs\/([^"]+)> (POLYGON|POINT)\(\(?([\d,. ]+)\)\)?/.exec(
       gml,
     ) || [];
   if (crs && crs === 'EPSG/0/31370') {

--- a/addon/plugins/variable-plugin/utils/address-helpers.ts
+++ b/addon/plugins/variable-plugin/utils/address-helpers.ts
@@ -342,7 +342,7 @@ export type Lambert72Coordinates = {
 };
 
 export function constructLambert72GMLString({ x, y }: Lambert72Coordinates) {
-  return `<gml:Point srsName="https://www.opengis.net/def/crs/EPSG/0/31370" xmlns:gml="http://www.opengis.net/gml/3.2"><gml:pos>${x} ${y}</gml:pos></gml:Point>`;
+  return `<gml:Point srsName="http://www.opengis.net/def/crs/EPSG/0/31370" xmlns:gml="http://www.opengis.net/gml/3.2"><gml:pos>${x} ${y}</gml:pos></gml:Point>`;
 }
 /**
  * Use a regex to parse a simple point as a GML string and return the coordinates.
@@ -354,7 +354,7 @@ export function parseLambert72GMLString(gml: string): Lambert72Coordinates {
   // which can be represented. Since we handle only simple points, it's much less complex to just
   // use a simple regex.
   const [_, crs, x, y] =
-    /<gml.Point .*srsName="https:\/\/www.opengis.net\/def\/crs\/([^"]+)".+<gml.pos>(\S+) ([^<]+)<\/gml:pos>/.exec(
+    /<gml.Point .*srsName="https?:\/\/www.opengis.net\/def\/crs\/([^"]+)".+<gml.pos>(\S+) ([^<]+)<\/gml:pos>/.exec(
       gml,
     ) || [];
   if (!crs || crs !== 'EPSG/0/31370') {
@@ -370,7 +370,7 @@ export function parseLambert72GMLString(gml: string): Lambert72Coordinates {
  * [the GeoSPARQL spec]{@link https://docs.ogc.org/is/22-047r1/22-047r1.html#10-8-1-%C2%A0-well-known-text}
  */
 export function constructLambert72WKTString({ x, y }: Lambert72Coordinates) {
-  return `<https://www.opengis.net/def/crs/EPSG/0/31370> POINT(${x} ${y})`;
+  return `<http://www.opengis.net/def/crs/EPSG/0/31370> POINT(${x} ${y})`;
 }
 /**
  * Use a regex to parse a simple point as a WKT string and return the coordinates.
@@ -382,7 +382,7 @@ export function parseLambert72WKTString(gml: string): Lambert72Coordinates {
   // which can be represented or within untyped libraries (e.g. wicket). Since we handle only simple
   // points, it's much less complex to just use a simple regex.
   const [_, crs, x, y] =
-    /<https:\/\/www.opengis.net\/def\/crs\/([^"]+)> POINT\((\S+) ([^)]+)\)/.exec(
+    /<https?:\/\/www.opengis.net\/def\/crs\/([^"]+)> POINT\((\S+) ([^)]+)\)/.exec(
       gml,
     ) || [];
   if (!crs || crs !== 'EPSG/0/31370') {


### PR DESCRIPTION
### Overview
Noted by @nbittich. I lost the message to reply to, but made a note to fix it.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Location plugin still works as before but the RDFa produced works with geosparql tools (I don't know details unfortunately).

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
