### PR TITLE
GN-5009: add option to insert-article component to allow article insertion anywhere in a document

### DIFF
--- a/.changeset/blue-baboons-work.md
+++ b/.changeset/blue-baboons-work.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Introduce opt-in option to `insert-article` component to allow for inserting decision articles everywhere in a document (not just to the article-container of a decision). Useful when e.g. creating snippets.

--- a/addon/components/decision-plugin/insert-article.gts
+++ b/addon/components/decision-plugin/insert-article.gts
@@ -3,36 +3,69 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { AddIcon } from '@appuniversum/ember-appuniversum/components/icons/add';
-import { SayController } from '@lblod/ember-rdfa-editor';
+import { PNode, SayController } from '@lblod/ember-rdfa-editor';
 import { getCurrentBesluitRange } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-topic-plugin/utils/helpers';
 import insertArticle from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/decision-plugin/commands/insert-article-command';
 import { buildArticleStructure } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/decision-plugin/utils/build-article-structure';
-import t from 'ember-intl/helpers/t';
 import { not } from 'ember-truth-helpers';
+import { service } from '@ember/service';
+import IntlService from 'ember-intl/services/intl';
+import { recalculateNumbers } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/structure-plugin/recalculate-structure-numbers';
+import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
 
 export interface InsertArticleOptions {
   uriGenerator?: () => string;
+  insertFreely?: boolean;
 }
 interface Sig {
-  Args: { controller: SayController; options?: InsertArticleOptions };
+  Args: {
+    controller: SayController;
+    label: string;
+    options?: InsertArticleOptions;
+  };
 }
 export default class InsertArticleComponent extends Component<Sig> {
+  @service declare intl: IntlService;
+
   get controller() {
     return this.args.controller;
+  }
+
+  get options() {
+    return this.args.options;
+  }
+
+  get label() {
+    return this.args.label ?? this.intl.t('besluit-plugin.insert.article');
   }
 
   get schema() {
     return this.controller.schema;
   }
+
   get decisionRange() {
     return getCurrentBesluitRange(this.controller);
   }
+
   get decisionLocation() {
     return this.decisionRange
       ? { pos: this.decisionRange.from, node: this.decisionRange.node }
       : null;
   }
+
   get canInsert() {
+    if (this.options?.insertFreely) {
+      return this.canInsertFreely;
+    } else {
+      return this.canInsertInDecision;
+    }
+  }
+
+  get canInsertFreely() {
+    return true;
+  }
+
+  get canInsertInDecision() {
     if (!this.decisionLocation) {
       return false;
     }
@@ -51,15 +84,32 @@ export default class InsertArticleComponent extends Component<Sig> {
       this.schema,
       this.args.options?.uriGenerator,
     );
-    if (!structureNode) {
-      return;
+    if (this.args.options?.insertFreely) {
+      this.insertFreely(structureNode);
+    } else {
+      this.insertInDecision(structureNode);
     }
+  }
+
+  @action
+  insertFreely(node: PNode) {
+    this.controller.withTransaction((tr) => {
+      return transactionCombinator(
+        this.controller.activeEditorState,
+        tr.replaceSelectionWith(node),
+      )([recalculateNumbers]).transaction;
+    });
+    this.controller.focus();
+  }
+
+  @action
+  insertInDecision(node: PNode) {
     if (!this.decisionLocation) {
       return;
     }
     this.controller.doCommand(
       insertArticle({
-        node: structureNode,
+        node,
         decisionLocation: this.decisionLocation,
       }),
     );
@@ -75,7 +125,7 @@ export default class InsertArticleComponent extends Component<Sig> {
         @disabled={{not this.canInsert}}
         {{on 'click' this.doInsert}}
       >
-        {{t 'besluit-plugin.insert.article'}}
+        {{this.label}}
       </AuButton>
     </li>
   </template>

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -96,6 +96,11 @@
             <Sidebar as |Sidebar|>
               <Sidebar.Collapsible @title='Structures'>
                 <this.InsertArticle @controller={{this.controller}} />
+                <this.InsertArticle
+                  @controller={{this.controller}}
+                  @label='Insert article freely'
+                  @options={{hash insertFreely=true}}
+                />
               </Sidebar.Collapsible>
               <Sidebar.Collapsible @title='Insert'>
                 <CitationPlugin::CitationInsert


### PR DESCRIPTION
### Overview
This PR introduces an opt-in option to the `insert-article` component to allow for inserting decision articles anywhere in a document (not just to the article-container of a decision). Useful when e.g. creating snippets.

##### connected issues and PRs:
[GN-5009](https://binnenland.atlassian.net/browse/GN-5009)


### How to test/reproduce
- Start the dummy app
- Under the `Structures` section, you should find a new `Insert article freely` option
- Using that option, you can insert articles everywhere
- Article number should be correctly recalculated

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
