### PR TITLE
Add error handling to lmb-plugin

### DIFF
--- a/.changeset/yellow-tables-live.md
+++ b/.changeset/yellow-tables-live.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Add error handling to lmb-plugin

--- a/addon/components/lmb-plugin/list.hbs
+++ b/addon/components/lmb-plugin/list.hbs
@@ -37,7 +37,7 @@
     </tr>
   </:header>
   <:body>
-    {{#unless (or @services.isRunning @error)}}
+    {{#unless @services.isRunning}}
       {{#if @services.value.totalCount}}
         {{#each @services.value.results as |row|}}
           <tr>

--- a/addon/components/lmb-plugin/search-modal.hbs
+++ b/addon/components/lmb-plugin/search-modal.hbs
@@ -36,13 +36,16 @@
       </mc.sidebar>
       <mc.content @scroll={{true}}>
         <div class='worship-modal--list-container'>
-          <LmbPlugin::List
-            @error={{this.error}}
-            @services={{this.servicesResource}}
-            @sort={{this.sort}}
-            @setSort={{this.setSort}}
-            @insert={{@onInsert}}
-          />
+          {{#if this.error}}
+            <Common::Search::AlertLoadError @error={{this.error}} />
+          {{else}}
+            <LmbPlugin::List
+              @services={{this.servicesResource}}
+              @sort={{this.sort}}
+              @setSort={{this.setSort}}
+              @insert={{@onInsert}}
+            />
+          {{/if}}
         </div>
         {{#if this.servicesResource.value.totalCount}}
           {{#let

--- a/addon/components/lmb-plugin/search-modal.ts
+++ b/addon/components/lmb-plugin/search-modal.ts
@@ -42,10 +42,17 @@ export default class LmbPluginSearchModalComponent extends Component<Args> {
     return fetchMandatees({ endpoint: this.args.config.endpoint });
   });
 
+  // TODO Either make this a trackedFunction or do filtering on the query and correctly pass an
+  // AbortController
   search = restartableTask(async () => {
     // Can't do what I want, so if the user modifies the filter before resolving the query will run again
     if (!this.fetchData.lastComplete) {
-      await this.fetchData.perform();
+      try {
+        await this.fetchData.perform();
+      } catch (err) {
+        console.error('Got an error fetching LMB data', err);
+        this.error = err;
+      }
     }
 
     if (!this.fetchData.lastComplete?.value) return;


### PR DESCRIPTION
### Overview
Discovered that this wasn't wired up when looking into QA feedback.

##### connected issues and PRs:
Related to problems on GN: https://github.com/lblod/app-gelinkt-notuleren/pull/192
And RB: https://github.com/lblod/frontend-reglementaire-bijlage/pull/269
From Jira issue: [binnenland.atlassian.net/browse/GN-5018](https://binnenland.atlassian.net/browse/GN-5018)

### Setup
Just running the test-app without setting a reasonable endpoint works well as a demonstration of a network error.

### How to test/reproduce
Insert a person variable and then insert a person to open the modal.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
