### PR TITLE
LMB-plugin: query mandatees using `form-urlencoded` approach

### DIFF
--- a/.changeset/khaki-ligers-march.md
+++ b/.changeset/khaki-ligers-march.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+LMB-plugin: query mandatees using `application/x-www-form-urlencoded` approach

--- a/addon/plugins/lmb-plugin/utils/fetchMandatees.ts
+++ b/addon/plugins/lmb-plugin/utils/fetchMandatees.ts
@@ -1,24 +1,12 @@
 import Mandatee from '@lblod/ember-rdfa-editor-lblod-plugins/models/mandatee';
-import { IBindings } from 'fetch-sparql-endpoint';
-
-type SparqlResponse = {
-  results: {
-    bindings: IBindings[];
-  };
-};
+import { executeQuery } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/sparql-helpers';
 
 type FetchMandateesArgs = {
   endpoint: string;
 };
 
 export async function fetchMandatees({ endpoint }: FetchMandateesArgs) {
-  const queryResponse = await fetch(endpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      query: `
+  const query = `
       PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
       PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
@@ -46,10 +34,11 @@ export async function fetchMandatees({ endpoint }: FetchMandateesArgs) {
           }
           filter (!bound(?endDate) || ?endDate > now()).
       }
-      `,
-    }),
+      `;
+  const response = await executeQuery({
+    query,
+    endpoint,
   });
-  const queryJson: SparqlResponse = await queryResponse.json();
-  const mandatees = queryJson.results.bindings.map(Mandatee.fromBinding);
+  const mandatees = response.results.bindings.map(Mandatee.fromBinding);
   return mandatees;
 }


### PR DESCRIPTION
### Overview
This PR modifies the approach taken to query the mandatees in the LMB-plugin. It now makes use of the `executeQuery` utility function, which sends a SPARQL query in the `application/x-www-form-urlencoded` format. This also ensures that the service is compatible with any SPARQL endpoint as the plugin now uses a standardized way to send the SPARQL query.

##### connected issues and PRs:
None

### Setup
You can test this PR with both the current version of the `vendor-proxy` service (0.1.0) or with https://github.com/lblod/vendor-proxy-service/pull/3

You should have a GN stack running containing the `vendor-proxy` service.

### How to test/reproduce
The plugin should work as before:
- Open the LMB-mandatee modal
- The correct mandatees should load

### Challenges/uncertainties
Unsure why a custom `json`-based approach was taken to send SPARQL queries. LMK if there is something I missed about disadvantages/advantages of using the `urlencoded` approach.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
