### PR TITLE
mandatee-table plugin: replace title `input` by `textarea`

### DIFF
--- a/.changeset/lazy-bananas-add.md
+++ b/.changeset/lazy-bananas-add.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+mandatee-table plugin: replace `input` element by `textarea` element for entering mandatee table titles

--- a/addon/components/mandatee-table-plugin/configure.gts
+++ b/addon/components/mandatee-table-plugin/configure.gts
@@ -4,11 +4,11 @@ import { action } from '@ember/object';
 import AuCard from '@appuniversum/ember-appuniversum/components/au-card';
 import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
 import AuLabel from '@appuniversum/ember-appuniversum/components/au-label';
-import AuInput from '@appuniversum/ember-appuniversum/components/au-input';
 import PowerSelect from 'ember-power-select/components/power-select';
 import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 import { on } from '@ember/modifier';
 import AuFormRow from '@appuniversum/ember-appuniversum/components/au-form-row';
+import AuTextarea from '@appuniversum/ember-appuniversum/components/au-textarea';
 import t from 'ember-intl/helpers/t';
 
 interface Sig {
@@ -105,15 +105,14 @@ export default class ConfigureMandateeTableComponent extends Component<Sig> {
             <AuLabel for='mandatee-table-title-input'>
               {{t 'mandatee-table-plugin.configure.title-input.label'}}
             </AuLabel>
-            <AuInput
+            <AuTextarea
               @width='block'
               placeholder={{t
                 'mandatee-table-plugin.configure.title-input.placeholder'
               }}
               id='mandatee-table-title-input'
-              value={{this.nodeTitle}}
               {{on 'input' this.updateNodeTitle}}
-            />
+            >{{this.nodeTitle}}</AuTextarea>
           </AuFormRow>
         </c.content>
       </AuCard>


### PR DESCRIPTION
### Overview
This PR replaces the `title` `input` element by a `textarea` element. This ensures that it is easier for template creators to input long titles.

##### connected issues and PRs:
None

### How to test/reproduce
- Start the dummy application
- Insert a mandatee table
- Notice that you can now edit the table title using a `textarea` element

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
