### PR TITLE
npx ember-resources-codemod

### DIFF
--- a/addon/components/besluit-topic-plugin/besluit-topic-toolbar-dropdown.ts
+++ b/addon/components/besluit-topic-plugin/besluit-topic-toolbar-dropdown.ts
@@ -2,7 +2,7 @@ import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { SayController } from '@lblod/ember-rdfa-editor';
-import { trackedFunction } from 'ember-resources/util/function';
+import { trackedFunction } from 'reactiveweb/function';
 import { ELI } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { AlertTriangleIcon } from '@appuniversum/ember-appuniversum/components/icons/alert-triangle';
 import { CrossIcon } from '@appuniversum/ember-appuniversum/components/icons/cross';

--- a/addon/components/besluit-type-plugin/toolbar-dropdown.ts
+++ b/addon/components/besluit-type-plugin/toolbar-dropdown.ts
@@ -7,7 +7,7 @@ import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import fetchBesluitTypes, {
   BesluitType,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-type-plugin/utils/fetchBesluitTypes';
-import { trackedFunction } from 'ember-resources/util/function';
+import { trackedFunction } from 'reactiveweb/function';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { BesluitTypePluginOptions } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-type-plugin';
 import { RDF } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';

--- a/addon/components/citation-plugin/citation-card.ts
+++ b/addon/components/citation-plugin/citation-card.ts
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { capitalize } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/strings';
-import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 import {
   Option,
   unwrap,

--- a/addon/components/citation-plugin/citations/legal-document-detail.ts
+++ b/addon/components/citation-plugin/citations/legal-document-detail.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 import { CalendarIcon } from '@appuniversum/ember-appuniversum/components/icons/calendar';
 import { PlusTextIcon } from '@appuniversum/ember-appuniversum/components/icons/plus-text';
 import { LinkExternalIcon } from '@appuniversum/ember-appuniversum/components/icons/link-external';

--- a/addon/components/citation-plugin/citations/search-modal.ts
+++ b/addon/components/citation-plugin/citations/search-modal.ts
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { service } from '@ember/service';
 import { capitalize } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/strings';
-import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 import {
   isGemeenteBesluitType,
   LEGISLATION_TYPE_CONCEPTS,

--- a/addon/components/lmb-plugin/search-modal.ts
+++ b/addon/components/lmb-plugin/search-modal.ts
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency';
-import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 import { LmbPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/lmb-plugin';
 
 import Mandatee from '@lblod/ember-rdfa-editor-lblod-plugins/models/mandatee';

--- a/addon/components/location-plugin/edit.gts
+++ b/addon/components/location-plugin/edit.gts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { restartableTask, timeout } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
 import { trackedReset } from 'tracked-toolbox';
-import { trackedTask } from 'ember-resources/util/ember-concurrency';
+import { trackedTask } from 'reactiveweb/ember-concurrency';
 import { service } from '@ember/service';
 import { on } from '@ember/modifier';
 import type { SafeString } from '@ember/template/-private/handlebars';

--- a/addon/components/lpdc-plugin/lpdc-modal.ts
+++ b/addon/components/lpdc-plugin/lpdc-modal.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 
 import { tracked } from '@glimmer/tracking';
 

--- a/addon/components/roadsign-regulation-plugin/measure-template.ts
+++ b/addon/components/roadsign-regulation-plugin/measure-template.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import includeInstructions from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/utils/includeInstructions';
 import RoadsignRegistryService from '@lblod/ember-rdfa-editor-lblod-plugins/services/roadsign-registry';
-import { trackedFunction } from 'ember-resources/util/function';
+import { trackedFunction } from 'reactiveweb/function';
 
 type Args = {
   template: string;

--- a/addon/components/snippet-plugin/search-modal.ts
+++ b/addon/components/snippet-plugin/search-modal.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 
 import { tracked } from '@glimmer/tracking';
 

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 
 import { tracked } from '@glimmer/tracking';
 

--- a/addon/components/variable-plugin/address/edit.ts
+++ b/addon/components/variable-plugin/address/edit.ts
@@ -11,7 +11,7 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/utils/address-helpers';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { trackedReset } from 'tracked-toolbox';
-import { trackedTask } from 'ember-resources/util/ember-concurrency';
+import { trackedTask } from 'reactiveweb/ember-concurrency';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 import { AlertTriangleIcon } from '@appuniversum/ember-appuniversum/components/icons/alert-triangle';

--- a/addon/components/variable-plugin/codelist/edit.ts
+++ b/addon/components/variable-plugin/codelist/edit.ts
@@ -7,7 +7,7 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/utils/fetch-data';
 import { MULTI_SELECT_CODELIST_TYPE } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/utils/constants';
 import { NodeSelection } from '@lblod/ember-rdfa-editor';
-import { trackedFunction } from 'ember-resources/util/function';
+import { trackedFunction } from 'reactiveweb/function';
 import { trackedReset } from 'tracked-toolbox';
 import { updateCodelistVariable } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/utils/codelist-utils';
 import { getOutgoingTriple } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';

--- a/addon/components/variable-plugin/codelist/insert.ts
+++ b/addon/components/variable-plugin/codelist/insert.ts
@@ -9,7 +9,7 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/utils/fetch-data';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
-import { trackedFunction } from 'ember-resources/util/function';
+import { trackedFunction } from 'reactiveweb/function';
 import { v4 as uuidv4 } from 'uuid';
 import {
   DCT,

--- a/addon/components/variable-plugin/location/edit.ts
+++ b/addon/components/variable-plugin/location/edit.ts
@@ -10,7 +10,7 @@ import { findParentNodeOfType } from '@curvenote/prosemirror-utils';
 import { NodeSelection } from '@lblod/ember-rdfa-editor';
 import { ZONAL_URI } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/utils/constants';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
-import { trackedFunction } from 'ember-resources/util/function';
+import { trackedFunction } from 'reactiveweb/function';
 import { trackedReset } from 'tracked-toolbox';
 import { updateCodelistVariable } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/utils/codelist-utils';
 

--- a/addon/components/worship-plugin/search-modal.ts
+++ b/addon/components/worship-plugin/search-modal.ts
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 import { WorshipPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/worship-plugin';
 import {
   fetchWorshipServices,

--- a/package.json
+++ b/package.json
@@ -65,12 +65,12 @@
     "codemirror": "^6.0.1",
     "crypto-browserify": "^3.12.0",
     "date-fns": "^2.30.0",
-    "ember-auto-import": "~2.6.3",
+    "ember-auto-import": "~2.7.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-concurrency": "^3.1.1",
     "ember-mu-transform-helpers": "^2.1.2",
-    "ember-resources": "^6.5.1",
+    "ember-resources": "^7.0.2",
     "ember-template-imports": "^4.1.1",
     "ember-velcro": "^2.2.0",
     "fetch-sparql-endpoint": "^3.3.3",
@@ -82,7 +82,8 @@
     "stream-browserify": "^3.0.0",
     "tracked-built-ins": "^3.3.0",
     "tracked-toolbox": "^2.0.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "reactiveweb": "^1.3.0"
   },
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "~3.4.2",
@@ -219,7 +220,7 @@
     "node": ">= 18"
   },
   "volta": {
-    "node": "20.11.0"
+    "node": "22.8.0"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Motivation:
- https://majors.nullvoxpopuli.com/q?minors=&old=&packages=ember-resources
  - It doesn't feel like enough people have upgraded -- so I made a codemod to help folks get there

Via 
```bash
npx ember-resources-codemod
```

Here is the code for the codemod:
https://github.com/NullVoxPopuli/ember-resources/pull/1147

----------

There aren't many breaking changes from v5 to v7.

Here are the breaking changes in v6:
- https://github.com/NullVoxPopuli/ember-resources/releases/tag/ember-resources%406.0.0
  - Of note, the `map` utility (which this library uses) has changed its type signature for better inference)
  
Here are the breaking changes in v7:
- https://github.com/NullVoxPopuli/ember-resources/releases/tag/v7.0.0-ember-resources
  - All utilities moved to `reactiveweb`, documentation here: https://reactive.nullvoxpopuli.com/
  - Additionally, the `Resource` class has moved to a separate package, https://github.com/NullVoxPopuli/ember-modify-based-class-resource/
    - This is to align with the ember ecosystem, and the desire to move away from `modify()` hooks -- as they are a sort of backdoor effect, which we don't want to encourage -- instead folks should rely on more data derivation patterns 
    