### PR TITLE
Make snippet buttons invisible rather than hidden to prevent issues

### DIFF
--- a/.changeset/gorgeous-taxis-join.md
+++ b/.changeset/gorgeous-taxis-join.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Fix bug where snippet hover buttons were not always functional on Chrome

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -75,6 +75,7 @@ export default class SnippetNode extends Component<Signature> {
     this.showModal = false;
   }
   openModal() {
+    this.controller.focus();
     this.showModal = true;
   }
   @action
@@ -166,7 +167,7 @@ export default class SnippetNode extends Component<Signature> {
     <div class='say-snippet-card'>
       <div class='say-snippet-title'>{{this.node.attrs.title}}</div>
       <div class='say-snippet-content'>{{yield}}</div>
-      <div class='say-snippet-icons'>
+      <div class='say-snippet-icons' contenteditable='false'>
         <SnippetButton
           @icon={{SynchronizeIcon}}
           @helpText='snippet-plugin.snippet-node.change-fragment'

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -3,8 +3,12 @@ import { on } from '@ember/modifier';
 import SearchModal from '../search-modal';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { TemplateOnlyComponent } from '@ember/component/template-only';
 import t from 'ember-intl/helpers/t';
-import AuIcon from '@appuniversum/ember-appuniversum/components/au-icon';
+import { not } from 'ember-truth-helpers';
+import AuIcon, {
+  type AuIconSignature,
+} from '@appuniversum/ember-appuniversum/components/au-icon';
 import { SynchronizeIcon } from '@appuniversum/ember-appuniversum/components/icons/synchronize';
 import { BinIcon } from '@appuniversum/ember-appuniversum/components/icons/bin';
 import { AddIcon } from '@appuniversum/ember-appuniversum/components/icons/add';
@@ -22,6 +26,33 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { hasOutgoingNamedNodeTriple } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 import { createAndInsertSnippet } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet';
+
+interface ButtonSig {
+  Args: {
+    isActive: boolean;
+    onClick: () => void;
+    icon: AuIconSignature['Args']['icon'];
+    helpText: string;
+  };
+  Element: HTMLButtonElement;
+}
+
+const SnippetButton: TemplateOnlyComponent<ButtonSig> = <template>
+  <button
+    class='say-snippet-button {{if @isActive "" "say-snippet-hidden"}}'
+    disabled={{(not @isActive)}}
+    type='button'
+    {{on 'click' @onClick}}
+    ...attributes
+  >
+    {{#if @isActive}}
+      <AuIcon @icon={{@icon}} @size='large' {{on 'click' @onClick}} />
+      <div class='say-snippet-button-text'>
+        {{t @helpText}}
+      </div>
+    {{/if}}
+  </button>
+</template>;
 
 interface Signature {
   Args: EmberNodeArgs;
@@ -130,44 +161,32 @@ export default class SnippetNode extends Component<Signature> {
     );
     this.closeModal();
   }
+
   <template>
     <div class='say-snippet-card'>
       <div class='say-snippet-title'>{{this.node.attrs.title}}</div>
       <div class='say-snippet-content'>{{yield}}</div>
-      {{#if this.isActive}}
-        <div class='say-snippet-icons'>
-          <button
-            class='say-snippet-button'
-            type='button'
-            {{on 'click' this.editFragment}}
-          >
-            <AuIcon @icon={{SynchronizeIcon}} @size='large' />
-            <div class='say-snippet-button-text'>
-              {{t 'snippet-plugin.snippet-node.change-fragment'}}
-            </div>
-          </button>
-          <button
-            class='say-snippet-button say-snippet-remove-button'
-            type='button'
-            {{on 'click' this.deleteFragment}}
-          >
-            <AuIcon @icon={{BinIcon}} />
-            <div class='say-snippet-button-text'>
-              {{t 'snippet-plugin.snippet-node.remove-fragment'}}
-            </div>
-          </button>
-          <button
-            class='say-snippet-button'
-            type='button'
-            {{on 'click' this.addFragment}}
-          >
-            <AuIcon @icon={{AddIcon}} />
-            <div class='say-snippet-button-text'>
-              {{t 'snippet-plugin.snippet-node.add-fragment'}}
-            </div>
-          </button>
-        </div>
-      {{/if}}
+      <div class='say-snippet-icons'>
+        <SnippetButton
+          @icon={{SynchronizeIcon}}
+          @helpText='snippet-plugin.snippet-node.change-fragment'
+          @onClick={{this.editFragment}}
+          @isActive={{this.isActive}}
+        />
+        <SnippetButton
+          @icon={{BinIcon}}
+          @helpText='snippet-plugin.snippet-node.remove-fragment'
+          @onClick={{this.deleteFragment}}
+          @isActive={{this.isActive}}
+          class='say-snippet-remove-button'
+        />
+        <SnippetButton
+          @icon={{AddIcon}}
+          @helpText='snippet-plugin.snippet-node.add-fragment'
+          @onClick={{this.addFragment}}
+          @isActive={{this.isActive}}
+        />
+      </div>
 
     </div>
     <SearchModal

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -140,6 +140,11 @@ div[typeof='besluitpublicatie:Documentonderdeel']
       border-radius: 4px;
       color: var(--au-blue-700);
       cursor: pointer;
+      &.say-snippet-hidden {
+        color: transparent;
+        border: none;
+        cursor: auto;
+      }
       &.say-snippet-remove-button {
         color: var(--au-red-600);
         border-color: var(--au-red-600);

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -299,7 +299,7 @@ export default class RegulatoryStatementSampleController extends Controller {
         rdfaAware: true,
       },
       snippet: {
-        endpoint: 'https://dev.reglementairebijlagen.lblod.info/sparql',
+        endpoint: 'https://dev.reglementairebijlagen.lblod.info/raw-sparql',
       },
       worship: {
         endpoint: 'https://data.lblod.info/sparql',


### PR DESCRIPTION
### Overview
On Chrome, clicking the icon de-selected the snippet, which caused the button to disappear and the onClick to never get called. This makes the button transparent instead, which means the onClick still gets called.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5019
GN PR: https://github.com/lblod/frontend-gelinkt-notuleren/pull/716

### Setup
N/A

### How to test/reproduce
Seems to only be easily reproducible in GN/RB and on Chrome. After inserting a snippet, the buttons that appear when the snippet is selected are now functional wherever you click on them. Before clicking on the icon would not work. Moving the selection away from the snippet should hide the buttons.

### Challenges/uncertainties
Seems like weird timing issues and is very hard to debug.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
