### PR TITLE
GN-5005: adjust snippet queries to work with new snippet data-model

### DIFF
--- a/.changeset/yellow-lamps-fly.md
+++ b/.changeset/yellow-lamps-fly.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': major
+---
+
+Adjust snippet queries to work with new snippet data-model

--- a/addon/plugins/citation-plugin/utils/public-decisions.ts
+++ b/addon/plugins/citation-plugin/utils/public-decisions.ts
@@ -1,6 +1,7 @@
 import {
   executeCountQuery,
   executeQuery,
+  sparqlEscapeString,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/sparql-helpers';
 import {
   dateValue,
@@ -43,18 +44,18 @@ const getFilters = ({
   }
 
   const governmentNameFilter = filter.governmentName?.trim()
-    ? `FILTER (CONTAINS(LCASE(?administrativeUnitName), "${replaceDiacriticsInWord(
-        filter.governmentName?.trim(),
-      ).toLowerCase()}"))`
+    ? `FILTER (CONTAINS(LCASE(?administrativeUnitName), ${sparqlEscapeString(
+        replaceDiacriticsInWord(filter.governmentName?.trim()).toLowerCase(),
+      )}))`
     : '';
 
   return `
     ${words
       .map(
         (word) =>
-          `FILTER (CONTAINS(LCASE(?decisionTitle), "${replaceDiacriticsInWord(
-            word,
-          ).toLowerCase()}"))`,
+          `FILTER (CONTAINS(LCASE(?decisionTitle), ${sparqlEscapeString(
+            replaceDiacriticsInWord(word).toLowerCase(),
+          )}))`,
       )
       .join('\n')}
     ${documentDateFilter.join('\n')}

--- a/addon/plugins/citation-plugin/utils/vlaamse-codex.ts
+++ b/addon/plugins/citation-plugin/utils/vlaamse-codex.ts
@@ -5,6 +5,7 @@ import {
 import {
   executeCountQuery,
   executeQuery,
+  sparqlEscapeString,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/sparql-helpers';
 import {
   LegalDocument,
@@ -91,9 +92,9 @@ export async function fetchVlaamseCodexLegalDocuments({
         ${words
           .map(
             (word) =>
-              `FILTER (CONTAINS(LCASE(?title), "${replaceDiacriticsInWord(
-                word,
-              ).toLowerCase()}"))`,
+              `FILTER (CONTAINS(LCASE(?title), ${sparqlEscapeString(
+                replaceDiacriticsInWord(word).toLowerCase(),
+              )}))`,
           )
           .join('\n')}
         ${excludeAdaptationFilters.join('\n')}
@@ -116,9 +117,9 @@ export async function fetchVlaamseCodexLegalDocuments({
           ${words
             .map(
               (word) =>
-                `FILTER (CONTAINS(LCASE(?title), "${replaceDiacriticsInWord(
-                  word,
-                ).toLowerCase()}"))`,
+                `FILTER (CONTAINS(LCASE(?title), ${sparqlEscapeString(
+                  replaceDiacriticsInWord(word).toLowerCase(),
+                )}))`,
             )
             .join('\n')}
           OPTIONAL { ?expressionUri eli:date_publication ?publicationDate . }

--- a/addon/plugins/snippet-plugin/utils/fetch-data.ts
+++ b/addon/plugins/snippet-plugin/utils/fetch-data.ts
@@ -17,7 +17,7 @@ export type OrderBy =
 type Pagination = { pageNumber: number; pageSize: number };
 
 const buildSnippetCountQuery = ({ name, assignedSnippetListIds }: Filter) => {
-  return `
+  return /* sparql */ `
       PREFIX schema: <http://schema.org/>
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX pav: <http://purl.org/pav/>
@@ -25,13 +25,13 @@ const buildSnippetCountQuery = ({ name, assignedSnippetListIds }: Filter) => {
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX prov: <http://www.w3.org/ns/prov#>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX gn: <http://data.lblod.info/vocabularies/gelinktnotuleren/>
+      PREFIX say: <https://say.data.gift/ns/>
 
       SELECT (COUNT(?snippet) AS ?count)
       WHERE {
-          ?snippet a gn:Snippet;
+          ?snippet a say:Snippet;
                    pav:hasCurrentVersion ?snippetVersion;
-                   ^gn:hasSnippet ?snippetList.
+                   ^say:hasSnippet ?snippetList.
           ?snippetList mu:uuid ?snippetListId.
           ?snippetVersion dct:title ?title.
           OPTIONAL { ?snippetVersion schema:validThrough ?validThrough. }
@@ -75,7 +75,7 @@ const buildSnippetFetchQuery = ({
   filter: Filter;
   pagination: Pagination;
 }) => {
-  return `
+  return /* sparql */ `
       PREFIX schema: <http://schema.org/>
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX pav: <http://purl.org/pav/>
@@ -83,14 +83,14 @@ const buildSnippetFetchQuery = ({
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX prov: <http://www.w3.org/ns/prov#>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX gn: <http://data.lblod.info/vocabularies/gelinktnotuleren/>
+      PREFIX say: <https://say.data.gift/ns/>
 
       SELECT DISTINCT ?title ?content ?createdOn
       WHERE {
-          ?snippet a gn:Snippet;
+          ?snippet a say:Snippet;
                    pav:hasCurrentVersion ?snippetVersion;
                    pav:createdOn ?createdOn;
-                   ^gn:hasSnippet ?snippetList.
+                   ^say:hasSnippet ?snippetList.
           OPTIONAL {
             ?snippet schema:position ?position.
           }
@@ -142,14 +142,13 @@ const buildSnippetListFetchQuery = ({
   filter: Filter;
   orderBy: OrderBy;
 }) => {
-  return `
+  return /* sparql */ `
         PREFIX pav: <http://purl.org/pav/>
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-        PREFIX gn: <http://data.lblod.info/vocabularies/gelinktnotuleren/>
         PREFIX say: <https://say.data.gift/ns/>
 
         SELECT (?snippetLists as ?id) ?label ?createdOn ?importedResources WHERE {
-          ?snippetLists a gn:SnippetList;
+          ?snippetLists a say:SnippetList;
             skos:prefLabel ?label;
             pav:createdOn ?createdOn.
           OPTIONAL { ?snippetLists say:snippetImportedResource ?importedResources . }

--- a/addon/plugins/snippet-plugin/utils/fetch-data.ts
+++ b/addon/plugins/snippet-plugin/utils/fetch-data.ts
@@ -38,7 +38,7 @@ const buildSnippetCountQuery = ({ name, assignedSnippetListIds }: Filter) => {
           FILTER(!BOUND(?validThrough) || xsd:dateTime(?validThrough) > now())
           ${
             name
-              ? `FILTER (CONTAINS(LCASE(?title), "${name.toLowerCase()}"))`
+              ? `FILTER (CONTAINS(LCASE(?title), ${sparqlEscapeString(name.toLowerCase())}))`
               : ''
           }
           ${
@@ -102,7 +102,7 @@ const buildSnippetFetchQuery = ({
           FILTER(!BOUND(?validThrough) || xsd:dateTime(?validThrough) > now())
           ${
             name
-              ? `FILTER (CONTAINS(LCASE(?title), "${name.toLowerCase()}"))`
+              ? `FILTER (CONTAINS(LCASE(?title), ${sparqlEscapeString(name.toLowerCase())}))`
               : ''
           }
           ${
@@ -155,7 +155,7 @@ const buildSnippetListFetchQuery = ({
           OPTIONAL { ?snippetLists say:snippetImportedResource ?importedResources . }
           ${
             name
-              ? `FILTER (CONTAINS(LCASE(?label), "${name.toLowerCase()}"))`
+              ? `FILTER (CONTAINS(LCASE(?label), ${sparqlEscapeString(name.toLowerCase())}))`
               : ''
           }
         }

--- a/addon/services/roadsign-registry.ts
+++ b/addon/services/roadsign-registry.ts
@@ -8,6 +8,7 @@ import Sign from '../models/sign';
 import { IBindings } from 'fetch-sparql-endpoint';
 import dataFactory from '@rdfjs/data-model';
 import { optionMapOr, unwrap } from '../utils/option';
+import { sparqlEscapeString } from '../utils/sparql-helpers';
 
 const PREFIXES = `
 PREFIX ex: <http://example.org#>
@@ -112,7 +113,7 @@ export default class RoadsignRegistryService extends Service {
         ${signFilter}
         ${
           codeString
-            ? `FILTER(CONTAINS(LCASE(?signCode), "${codeString.toLowerCase()}"))`
+            ? `FILTER(CONTAINS(LCASE(?signCode), ${sparqlEscapeString(codeString.toLowerCase())}))`
             : ''
         }
       }


### PR DESCRIPTION
### Overview
This (draft) PR adjusts the snippet queries to work with the new snippet/snippet-list data-model.
Additionally, it sorts the snippets based on their (custom) position (in ascending order). If such a position is missing (as will be with many older snippets), the snippets are sorted based on their creation-date (in descending order).
If snippets of multiple snippet lists are shown, the sorting works as follows:
- Sort on creation date of the snippet lists (in descending order)
- Then sort on position of the snippets (in ascending order)
- Fallback (if position is missing): sort on creation date of the snippets (in descending order)

##### connected issues and PRs:
[GN-5005](https://binnenland.atlassian.net/browse/GN-5005)
https://github.com/lblod/frontend-reglementaire-bijlage/pull/279
https://github.com/lblod/app-reglementaire-bijlage/pull/84
https://github.com/lblod/frontend-gelinkt-notuleren/pull/720


### Setup
Check-out https://github.com/lblod/frontend-reglementaire-bijlage/pull/279

### How to test/reproduce
Check-out https://github.com/lblod/frontend-reglementaire-bijlage/pull/279

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
