### PR TITLE
GN-5004: add option to enable/disable multi-snippet insertion

### DIFF
--- a/.changeset/olive-zebras-check.md
+++ b/.changeset/olive-zebras-check.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add option for enabling/disabling multi-snippet insertion

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -81,10 +81,17 @@ export default class SnippetNode extends Component<Signature> {
     this.controller.focus();
     this.showModal = true;
   }
+
+  get allowMultipleSnippets() {
+    return this.node.attrs.allowMultipleSnippets as boolean;
+  }
+
   @action
   addFragment() {
-    this.mode = 'add';
-    this.openModal();
+    if (this.allowMultipleSnippets) {
+      this.mode = 'add';
+      this.openModal();
+    }
   }
   @action
   editFragment() {
@@ -151,6 +158,7 @@ export default class SnippetNode extends Component<Signature> {
         assignedSnippetListsIds,
         importedResources: this.node.attrs.importedResources,
         range: { start, end },
+        allowMultipleSnippets: this.allowMultipleSnippets,
       }),
     );
   }
@@ -173,12 +181,14 @@ export default class SnippetNode extends Component<Signature> {
           @isActive={{this.isActive}}
           class='say-snippet-remove-button'
         />
-        <SnippetButton
-          @icon={{AddIcon}}
-          @helpText='snippet-plugin.snippet-node.add-fragment'
-          @onClick={{this.addFragment}}
-          @isActive={{this.isActive}}
-        />
+        {{#if this.allowMultipleSnippets}}
+          <SnippetButton
+            @icon={{AddIcon}}
+            @helpText='snippet-plugin.snippet-node.add-fragment'
+            @onClick={{this.addFragment}}
+            @isActive={{this.isActive}}
+          />
+        {{/if}}
       </div>
 
     </div>

--- a/addon/components/snippet-plugin/snippet-insert-placeholder.gts
+++ b/addon/components/snippet-plugin/snippet-insert-placeholder.gts
@@ -38,9 +38,16 @@ export default class SnippetPluginSnippetInsertPlaceholder extends Component<Sig
   }
 
   @action
-  insertPlaceholder(lists: SnippetList[] | undefined) {
+  insertPlaceholder(
+    lists: SnippetList[] | undefined,
+    allowMultipleSnippets: boolean,
+  ) {
     if (lists) {
-      const node = createSnippetPlaceholder(lists, this.args.controller.schema);
+      const node = createSnippetPlaceholder(
+        lists,
+        this.args.controller.schema,
+        allowMultipleSnippets,
+      );
 
       this.args.controller.withTransaction(
         (tr) => {
@@ -66,6 +73,7 @@ export default class SnippetPluginSnippetInsertPlaceholder extends Component<Sig
     <SnippetListModal
       @config={{@config}}
       @assignedSnippetListsIds={{empty}}
+      @allowMultipleSnippets={{false}}
       @onSaveSnippetLists={{this.insertPlaceholder}}
       @open={{this.isModalOpen}}
       @closeModal={{this.closeModal}}

--- a/addon/components/snippet-plugin/snippet-insert-rdfa.gts
+++ b/addon/components/snippet-plugin/snippet-insert-rdfa.gts
@@ -71,12 +71,17 @@ export default class SnippetInsertRdfaComponent extends Component<Sig> {
     return undefined;
   }
 
+  get allowMultipleSnippets() {
+    return this.args.node.value.attrs.allowMultipleSnippets as boolean;
+  }
+
   <template>
     <SnippetInsert
       @config={{@config}}
       @controller={{@controller}}
       @snippetListProperties={{this.snippetListProperties}}
       @disabled={{this.disableInsert}}
+      @allowMultipleSnippets={{this.allowMultipleSnippets}}
     />
   </template>
 }

--- a/addon/components/snippet-plugin/snippet-insert.gts
+++ b/addon/components/snippet-plugin/snippet-insert.gts
@@ -23,6 +23,7 @@ interface Sig {
       | { listIds: string[]; importedResources: ImportedResourceMap }
       | undefined;
     disabled?: boolean;
+    allowMultipleSnippets?: boolean;
   };
 }
 
@@ -63,6 +64,7 @@ export default class SnippetInsertComponent extends Component<Sig> {
         title,
         assignedSnippetListsIds: this.args.snippetListProperties?.listIds || [],
         importedResources: this.args.snippetListProperties?.importedResources,
+        allowMultipleSnippets: this.args.allowMultipleSnippets,
       }),
     );
   }

--- a/addon/components/snippet-plugin/snippet-list-select.gts
+++ b/addon/components/snippet-plugin/snippet-list-select.gts
@@ -59,12 +59,16 @@ export default class SnippetListSelect extends Component<Signature> {
     );
   }
 
+  get allowMultipleSnippets(): boolean {
+    return this.args.node.value.attrs.allowMultipleSnippets as boolean;
+  }
+
   get imported(): ImportedResourceMap {
     return this.args.node.value.attrs['importedResources'];
   }
 
   @action
-  onSaveSnippetLists(lists: SnippetList[]) {
+  onSaveSnippetLists(lists: SnippetList[], allowMultipleSnippets: boolean) {
     if (this.currentResource) {
       this.args.controller?.doCommand(
         updateSnippetPlaceholder({
@@ -73,6 +77,7 @@ export default class SnippetListSelect extends Component<Signature> {
           newSnippetLists: lists,
           oldImportedResources: this.imported,
           node: this.args.node,
+          allowMultipleSnippets,
         }),
         {
           view: this.args.controller.mainEditorView,
@@ -96,6 +101,7 @@ export default class SnippetListSelect extends Component<Signature> {
         @config={{@config}}
         @assignedSnippetListsIds={{this.assignedSnippetListsIds}}
         @onSaveSnippetLists={{this.onSaveSnippetLists}}
+        @allowMultipleSnippets={{this.allowMultipleSnippets}}
         @open={{this.showModal}}
         @closeModal={{this.closeModal}}
       />

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.hbs
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.hbs
@@ -31,20 +31,31 @@
           @border='top'
           @size='large'
           @nowrap={{true}}
-          @reverse={{true}}
+          class='au-u-flex--vertical-center'
+          as |Group|
         >
-          <AuButtonGroup>
-            <AuButton @skin='secondary' {{on 'click' this.closeModal}}>
-              {{t 'snippet-plugin.snippet-list.modal.button.cancel'}}
-            </AuButton>
-            <AuButton
-              @skin='primary'
-              {{on 'click' this.saveAndClose}}
-              @disabled={{@onSaveSnippetLists.isRunning}}
+          <Group>
+            <AuCheckbox
+              @checked={{this.allowMultipleSnippets}}
+              @onChange={{this.handleMultipleSnippetsCheckbox}}
             >
-              {{t 'snippet-plugin.snippet-list.modal.button.update'}}
-            </AuButton>
-          </AuButtonGroup>
+              {{t 'snippet-plugin.snippet-list.modal.multi-snippet-toggle'}}
+            </AuCheckbox>
+          </Group>
+          <Group>
+            <AuButtonGroup>
+              <AuButton @skin='secondary' {{on 'click' this.closeModal}}>
+                {{t 'snippet-plugin.snippet-list.modal.button.cancel'}}
+              </AuButton>
+              <AuButton
+                @skin='primary'
+                {{on 'click' this.saveAndClose}}
+                @disabled={{@onSaveSnippetLists.isRunning}}
+              >
+                {{t 'snippet-plugin.snippet-list.modal.button.update'}}
+              </AuButton>
+            </AuButtonGroup>
+          </Group>
         </AuToolbar>
       </mc.content>
     </AuMainContainer>

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
@@ -14,15 +14,19 @@ import {
   SnippetPluginConfig,
   SnippetList,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
-import { trackedReset } from 'tracked-toolbox';
+import { localCopy, trackedReset } from 'tracked-toolbox';
 
 interface Signature {
   Args: {
     config: SnippetPluginConfig;
-    onSaveSnippetLists: (lists: SnippetList[]) => void;
+    onSaveSnippetLists: (
+      lists: SnippetList[],
+      allowMultipleSnippets: boolean,
+    ) => void;
     assignedSnippetListsIds: string[] | undefined;
     closeModal: () => void;
     open: boolean;
+    allowMultipleSnippets?: boolean;
   };
 }
 
@@ -41,12 +45,20 @@ export default class SnippetListModalComponent extends Component<Signature> {
     ...(this.args.assignedSnippetListsIds ?? []),
   ];
 
+  @localCopy('args.allowMultipleSnippets') allowMultipleSnippets = false;
+
+  @action
+  handleMultipleSnippetsCheckbox(checked: boolean) {
+    this.allowMultipleSnippets = checked;
+  }
+
   get config() {
     return this.args.config;
   }
 
   @action
   closeModal() {
+    this.allowMultipleSnippets = this.args.allowMultipleSnippets ?? false;
     this.args.closeModal();
   }
 
@@ -55,7 +67,10 @@ export default class SnippetListModalComponent extends Component<Signature> {
     const snippetLists = this.snippetListResource.value?.filter((snippetList) =>
       this.assignedSnippetListsIds.includes(snippetList.id),
     );
-    this.args.onSaveSnippetLists(snippetLists || []);
+    this.args.onSaveSnippetLists(
+      snippetLists || [],
+      this.allowMultipleSnippets,
+    );
     this.args.closeModal();
     // Clear selection for next time
     this.assignedSnippetListsIds = [];

--- a/addon/plugins/snippet-plugin/commands/insert-snippet.ts
+++ b/addon/plugins/snippet-plugin/commands/insert-snippet.ts
@@ -15,6 +15,7 @@ export interface InsertSnippetCommandArgs {
   assignedSnippetListsIds: string[];
   importedResources?: ImportedResourceMap;
   range?: { start: number; end: number };
+  allowMultipleSnippets?: boolean;
 }
 
 const insertSnippet = ({
@@ -23,6 +24,7 @@ const insertSnippet = ({
   assignedSnippetListsIds,
   importedResources,
   range,
+  allowMultipleSnippets,
 }: InsertSnippetCommandArgs): Command => {
   return (state, dispatch) => {
     const domParser = new DOMParser();
@@ -44,6 +46,7 @@ const insertSnippet = ({
         title,
         snippetListIds: assignedSnippetListsIds,
         importedResources,
+        allowMultipleSnippets,
       });
 
       const addImportedResourceProperties = Object.values(

--- a/addon/plugins/snippet-plugin/commands/update-snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/commands/update-snippet-placeholder.ts
@@ -17,12 +17,14 @@ export const updateSnippetPlaceholder = ({
   newSnippetLists,
   oldImportedResources,
   node,
+  allowMultipleSnippets = false,
 }: {
   resource: string;
   oldSnippetProperties: OutgoingTriple[];
   newSnippetLists: SnippetList[];
   oldImportedResources: ImportedResourceMap;
   node: ResolvedPNode;
+  allowMultipleSnippets?: boolean;
 }): Command => {
   return (state, dispatch) => {
     if (dispatch) {
@@ -67,6 +69,11 @@ export const updateSnippetPlaceholder = ({
           newSnippetLists,
           oldImportedResources,
         ),
+      );
+      transaction = transaction.setNodeAttribute(
+        node.pos,
+        'allowMultipleSnippets',
+        allowMultipleSnippets,
       );
 
       dispatch(transaction);

--- a/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
@@ -38,7 +38,11 @@ export function importedResourcesFromSnippetLists(
   );
 }
 
-export function createSnippetPlaceholder(lists: SnippetList[], schema: Schema) {
+export function createSnippetPlaceholder(
+  lists: SnippetList[],
+  schema: Schema,
+  allowMultipleSnippets?: boolean,
+) {
   const mappingResource = `http://example.net/lblod-snippet-placeholder/${uuidv4()}`;
   return schema.nodes.snippet_placeholder.create({
     rdfaNodeType: 'resource',
@@ -55,6 +59,7 @@ export function createSnippetPlaceholder(lists: SnippetList[], schema: Schema) {
       })),
     ],
     importedResources: importedResourcesFromSnippetLists(lists),
+    allowMultipleSnippets,
   });
 }
 
@@ -70,6 +75,7 @@ const emberNodeConfig: EmberNodeConfig = {
     typeof: { default: EXT('SnippetPlaceholder') },
     listNames: { default: [] },
     importedResources: { default: {} },
+    allowMultipleSnippets: { default: false },
   },
   component: SnippetPlaceholderComponent,
   serialize(node, editorState) {
@@ -82,6 +88,7 @@ const emberNodeConfig: EmberNodeConfig = {
         class: 'say-snippet-placeholder-node',
         'data-list-names': (node.attrs.listNames as string[]).join(','),
         'data-imported-resources': JSON.stringify(node.attrs.importedResources),
+        'data-allow-multiple-snippets': node.attrs.allowMultipleSnippets,
       },
       content: [
         'text',
@@ -111,6 +118,8 @@ const emberNodeConfig: EmberNodeConfig = {
             importedResources: jsonParse(
               node.getAttribute('data-imported-resources'),
             ),
+            allowMultipleSnippets:
+              node.dataset.allowMultipleSnippets === 'true',
           };
         }
         return false;

--- a/addon/plugins/snippet-plugin/nodes/snippet.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet.ts
@@ -63,6 +63,7 @@ interface CreateSnippetArgs {
   title: string;
   snippetListIds: string[];
   importedResources?: ImportedResourceMap;
+  allowMultipleSnippets?: boolean;
 }
 
 /**
@@ -77,6 +78,7 @@ export function createSnippet({
   title,
   snippetListIds,
   importedResources,
+  allowMultipleSnippets,
 }: CreateSnippetArgs): [PNode, Map<string, OutgoingTriple[]>] {
   // Replace instances of linked to uris with the resources that exist in the outer document.
   let replacedContent = content;
@@ -99,6 +101,7 @@ export function createSnippet({
       title,
       subject: `http://data.lblod.info/snippets/${uuidv4()}`,
       importedResources,
+      allowMultipleSnippets,
     },
     contentAsNode.content,
   );
@@ -151,6 +154,7 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
     importedResources: { default: {} },
     title: { default: '' },
     config: { default: options },
+    allowMultipleSnippets: { default: false },
   },
   component: SnippetComponent,
   content: options.allowedContent || DEFAULT_CONTENT_STRING,
@@ -165,6 +169,7 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
         ).join(','),
         'data-imported-resources': JSON.stringify(node.attrs.importedResources),
         'data-snippet-title': node.attrs.title,
+        'data-allow-multiple-snippets': node.attrs.allowMultipleSnippets,
       },
       content: 0,
     });
@@ -187,6 +192,8 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
               node.getAttribute('data-imported-resources'),
             ),
             title: node.getAttribute('data-snippet-title'),
+            allowMultipleSnippets:
+              node.dataset.allowMultipleSnippets === 'true',
           };
         }
         return false;

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -330,6 +330,7 @@ snippet-plugin:
         list: List
         created: Created
         imported-resources: Imported Resources
+      multi-snippet-toggle: Allow multi-snippet selection
   snippet-node:
     change-fragment: Change Fragment
     remove-fragment: Remove Fragment

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -329,6 +329,7 @@ snippet-plugin:
         list: Lijst
         created: Aangemaakt op
         imported-resources: Ingevoerde Middelen
+      multi-snippet-toggle: Meerkeuze-fragmentselectie
   snippet-node:
     change-fragment: Fragment vervangen
     remove-fragment: Fragment verwijderen


### PR DESCRIPTION
### Overview
This PR implements support for configuring a snippet placeholder/snippets to support single/multiple snippets.

##### connected issues and PRs:
[GN-5004](https://binnenland.atlassian.net/browse/GN-5004?atlOrigin=eyJpIjoiZmNlM2YxNjEwMjVjNGViNmEyNzIyMzJmZWFlNDFkOTQiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the dummy app
- Open the RB sample page
- Insert a snippet placeholder
**First option**
- Do not enable the checkbox
- Ensure that snippets which are inserted do not have a 'plus' button
- Ensure this persists across reloads
- Ensure this persists when you replace the snippet
**Second option**
- Enable the checkbox
- Inserted snippets should have a 'plus' button

### Challenges/uncertainties
We should/could probably clean-up the components of the snippets a bit. I tried to maintain backwards compatibility.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
