### PR TITLE
Move back to removing snippet buttons instead of making them invisible

### DIFF
--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { TemplateOnlyComponent } from '@ember/component/template-only';
 import t from 'ember-intl/helpers/t';
-import { not } from 'ember-truth-helpers';
 import AuIcon, {
   type AuIconSignature,
 } from '@appuniversum/ember-appuniversum/components/au-icon';
@@ -41,20 +40,19 @@ interface ButtonSig {
 }
 
 const SnippetButton: TemplateOnlyComponent<ButtonSig> = <template>
-  <button
-    class='say-snippet-button {{if @isActive "" "say-snippet-hidden"}}'
-    disabled={{(not @isActive)}}
-    type='button'
-    {{on 'click' @onClick}}
-    ...attributes
-  >
-    {{#if @isActive}}
+  {{#if @isActive}}
+    <button
+      class='say-snippet-button'
+      type='button'
+      {{on 'click' @onClick}}
+      ...attributes
+    >
       <AuIcon @icon={{@icon}} @size='large' {{on 'click' @onClick}} />
       <div class='say-snippet-button-text'>
         {{t @helpText}}
       </div>
-    {{/if}}
-  </button>
+    </button>
+  {{/if}}
 </template>;
 
 interface Signature {

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -140,11 +140,6 @@ div[typeof='besluitpublicatie:Documentonderdeel']
       border-radius: 4px;
       color: var(--au-blue-700);
       cursor: pointer;
-      &.say-snippet-hidden {
-        color: transparent;
-        border: none;
-        cursor: auto;
-      }
       &.say-snippet-remove-button {
         color: var(--au-red-600);
         border-color: var(--au-red-600);


### PR DESCRIPTION
### Overview
It seems that we don't actually need to make the buttons invisible if we have `contenteditable="true"`. It looks like the issue is that prosemirror was trying to put the selection into the help text for the buttons. This removes a weird hacky almost-fix that is best not to leave in the codebase to surprise us in the future.

No changeset as it's a purely internal change.

##### connected issues and PRs:
Undoes a hacky part of https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/479

### Setup
N/A

### How to test/reproduce
Needs to be tested in Chrome, with snippets which fill the width of the editor multiple times, e.g. a big block of text.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
