### PR TITLE
Use a special name if you only have one article in the document

### DIFF
--- a/.changeset/six-ants-appear.md
+++ b/.changeset/six-ants-appear.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Use a special name if you only have one article in the document

--- a/.changeset/six-ants-appear.md
+++ b/.changeset/six-ants-appear.md
@@ -3,3 +3,4 @@
 ---
 
 Use a special name if you only have one article in the document
+The title from the second article is shortened to Art.

--- a/addon/components/structure-plugin/_private/structure.gts
+++ b/addon/components/structure-plugin/_private/structure.gts
@@ -122,6 +122,17 @@ export default class Structure extends Component<Sig> {
     return this.node.attrs.hasTitle;
   }
 
+  get title() {
+    if (this.node.attrs.isOnlyArticle) {
+      const docLang = this.controller.mainEditorState.doc.attrs.lang;
+      return this.intl.t('structure-plugin.only-article-title', {
+        locale: docLang,
+      });
+    } else {
+      return `${this.structureName} ${this.number}.`;
+    }
+  }
+
   @action
   onAttrsUpdate() {
     if (this.titleAttr !== this.innerEditor?.htmlContent) {
@@ -161,8 +172,7 @@ export default class Structure extends Component<Sig> {
       <div class='say-structure__header' contenteditable='false'>
 
         {{#let (element this.headerTag) as |Tag|}}
-          <Tag>{{this.structureName}}
-            {{this.number}}.
+          <Tag>{{this.title}}
 
             {{#if this.hasTitle}}
               <span

--- a/addon/components/structure-plugin/_private/structure.gts
+++ b/addon/components/structure-plugin/_private/structure.gts
@@ -113,7 +113,12 @@ export default class Structure extends Component<Sig> {
   get structureName() {
     const docLang = this.controller.mainEditorState.doc.attrs.lang;
     if (this.displayStructureName) {
-      return getNameForStructureType(this.structureType, this.intl, docLang);
+      return getNameForStructureType(
+        this.structureType,
+        this.number,
+        this.intl,
+        docLang,
+      );
     } else {
       return '';
     }

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -29,11 +29,16 @@ const rdfaAware = true;
 
 export function getNameForStructureType(
   structureType: StructureType,
+  number: number,
   intl?: IntlService,
   locale?: string,
 ) {
   if (intl?.exists(`structure-plugin.types.${structureType}`, locale)) {
-    return intl?.t(`structure-plugin.types.${structureType}`, { locale });
+    if (structureType === 'article' && number !== 1) {
+      return intl?.t(`structure-plugin.shortened-article`, { locale });
+    } else {
+      return intl?.t(`structure-plugin.types.${structureType}`, { locale });
+    }
   } else {
     return structureType;
   }
@@ -100,6 +105,7 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
       const structureName = displayStructureName
         ? getNameForStructureType(
             structureType,
+            number,
             intlService,
             state.doc.attrs.lang,
           )
@@ -216,7 +222,7 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
               structureType: node.dataset.sayStructureType,
               displayStructureName: node.dataset.sayDisplayStructureName,
               headerTag: node.dataset.sayHeaderTag,
-              number: node.dataset.sayNumber,
+              number: Number(node.dataset.sayNumber),
               isOnlyArticle,
               title,
             };

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -71,6 +71,9 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
       number: {
         default: 1,
       },
+      isOnlyArticle: {
+        default: false,
+      },
       structureType: {},
       displayStructureName: {
         default: false,
@@ -86,21 +89,28 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
       const tag = node.attrs.headerTag;
       const structureType = node.attrs.structureType as StructureType;
       const number = node.attrs.number as number;
+      const isOnlyArticle = node.attrs.isOnlyArticle as boolean;
       const hasTitle = node.attrs.hasTitle as boolean;
       const titleHTML = hasTitle
         ? parser.parseFromString(node.attrs.title, 'text/html').body
             .firstElementChild
         : null;
       const displayStructureName = node.attrs.displayStructureName as boolean;
+      const intlService = getIntlService(state);
       const structureName = displayStructureName
         ? getNameForStructureType(
             structureType,
-            getIntlService(state),
+            intlService,
             state.doc.attrs.lang,
           )
         : null;
       let headerSpec;
 
+      const onlyArticleTitle = intlService
+        ? intlService.t('structure-plugin.only-article-title', {
+            locale: state.doc.attrs.lang,
+          })
+        : structureName;
       if (titleHTML) {
         headerSpec = [
           tag,
@@ -133,13 +143,14 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
                 [
                   'span',
                   { 'data-say-structure-header-name': true },
-                  `${structureName} `,
+                  `${isOnlyArticle ? onlyArticleTitle : structureName} `,
                 ],
               ]
             : []),
           [
             'span',
             {
+              style: isOnlyArticle ? 'display: none;' : '',
               'data-say-structure-header-number': true,
               property: ELI('number').full,
             },
@@ -158,6 +169,7 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
           'data-say-display-structure-name': displayStructureName,
           'data-say-header-tag': tag,
           'data-say-number': number,
+          'data-say-is-only-article': isOnlyArticle,
         },
         content: [
           'div',
@@ -181,6 +193,9 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
           ) {
             const hasTitle =
               node.dataset.sayHasTitle && node.dataset.sayHasTitle !== 'false';
+            const isOnlyArticle =
+              node.dataset.sayIsOnlyArticle &&
+              node.dataset.sayIsOnlyArticle !== 'false';
             // strict selector here to avoid false positives when structures are nested
             // :scope refers to the element on which we call querySelector
             const titleElement = node.querySelector(
@@ -202,6 +217,7 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
               displayStructureName: node.dataset.sayDisplayStructureName,
               headerTag: node.dataset.sayHeaderTag,
               number: node.dataset.sayNumber,
+              isOnlyArticle,
               title,
             };
           }
@@ -252,6 +268,7 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
               structureType: 'article',
               displayStructureName: true,
               hasTitle: false,
+              isOnlyArticle: false,
               number,
             };
           }

--- a/addon/plugins/structure-plugin/recalculate-structure-numbers.ts
+++ b/addon/plugins/structure-plugin/recalculate-structure-numbers.ts
@@ -12,17 +12,25 @@ export function recalculateNumbers(
   const tr = state.tr;
   const doc = tr.doc;
   let counter = 0;
+  let lastNodePos;
   doc.descendants((node, pos) => {
     if (
       node.type.name === 'structure' &&
       hasOutgoingNamedNodeTriple(node.attrs, RDF('type'), BESLUIT('Artikel'))
     ) {
       counter += 1;
+      lastNodePos = pos;
+      if (node.attrs.isOnlyArticle === true) {
+        tr.setNodeAttribute(pos, 'isOnlyArticle', false);
+      }
       if (counter !== Number(node.attrs.number)) {
         tr.setNodeAttribute(pos, 'number', counter);
       }
     }
     return true;
   });
+  if (lastNodePos !== undefined && counter === 1) {
+    tr.setNodeAttribute(lastNodePos, 'isOnlyArticle', true);
+  }
   return { transaction: tr, result: true, initialState: state };
 }

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -15,6 +15,7 @@ structure-plugin:
   move-up: 'Move {structureName} up'
   move-down: 'Move {structureName} down'
   only-article-title: Only article
+  shortened-article: Art.
   types:
     article: Article
     title: Title

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -14,6 +14,7 @@ common:
 structure-plugin:
   move-up: 'Move {structureName} up'
   move-down: 'Move {structureName} down'
+  only-article-title: Only article
   types:
     article: Article
     title: Title

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -14,6 +14,7 @@ common:
 structure-plugin:
   move-up: '{structureName} naar boven verplaatsen'
   move-down: '{structureName} naar beneden verplaatsen'
+  only-article-title: Enig artikel
   types:
     article: Artikel
     title: Titel

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -15,6 +15,7 @@ structure-plugin:
   move-up: '{structureName} naar boven verplaatsen'
   move-down: '{structureName} naar beneden verplaatsen'
   only-article-title: Enig artikel
+  shortened-article: Art.
   types:
     article: Artikel
     title: Titel


### PR DESCRIPTION
### Overview
If there's only one article change the title of it and shorten articles from the second one

##### connected issues and PRs:
GN-5002


### Setup
None

### How to test/reproduce
Create a few articles in the besluit part, notice that the numbering still works correctly and when there's only one article left the title changes to "Only article". Also check that the articles from the number 2 are shortened and only shown art. in the title

### Challenges/uncertainties
In the export I hide the number but is still present in the rdfa, this makes sense for me, as any harvesting would like to know that's the article number 1 and also doesn't break any logic based on this, but we would want something else



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
