### PR TITLE
Reset person edit modal on close

### DIFF
--- a/addon/components/lmb-plugin/search-modal.ts
+++ b/addon/components/lmb-plugin/search-modal.ts
@@ -34,6 +34,8 @@ export default class LmbPluginSearchModalComponent extends Component<Args> {
 
   @action
   async closeModal() {
+    this.inputSearchText = null;
+    this.sort = false;
     await this.servicesResource.cancel();
     this.args.closeModal();
   }
@@ -45,6 +47,13 @@ export default class LmbPluginSearchModalComponent extends Component<Args> {
   // TODO Either make this a trackedFunction or do filtering on the query and correctly pass an
   // AbortController
   search = restartableTask(async () => {
+    if (!this.args.open) {
+      return {
+        results: [],
+        totalCount: 0,
+      };
+    }
+
     // Can't do what I want, so if the user modifies the filter before resolving the query will run again
     if (!this.fetchData.lastComplete) {
       try {
@@ -108,6 +117,7 @@ export default class LmbPluginSearchModalComponent extends Component<Args> {
     this.sort,
     this.pageNumber,
     this.pageSize,
+    this.args.open,
   ]);
 
   @action


### PR DESCRIPTION
### Overview
Reset the person edit modal so it doesn't show old filtered data when it's open again

##### connected issues and PRs:
GN-5096


### Setup
You must have a working vendor proxy service in the backend, or you can test linking the plugins to GN-frontend and proxying that to dev, let me know if you need any help

### How to test/reproduce
Insert 2 person variable nodes in the RB part, then swich to the GN part and try to edit them, you should be able to filter on one, close the modal and open the same one or the other and the filter will be cleared and the data refreshed

### Challenges/uncertainties
None



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
