### PR TITLE
Pass decision URI to plugins for if there's no decision node

### DIFF
--- a/.changeset/cold-bananas-greet.md
+++ b/.changeset/cold-bananas-greet.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add config to specify an external decision URI when creating decision article structures

--- a/.changeset/stale-peaches-jam.md
+++ b/.changeset/stale-peaches-jam.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add config to specify an external decision URI in lpdc plugin

--- a/.changeset/violet-cups-dream.md
+++ b/.changeset/violet-cups-dream.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add config to specify an external decision URI and type in roadsign-regulation-plugin

--- a/addon/components/besluit-topic-plugin/besluit-topic-toolbar-dropdown.ts
+++ b/addon/components/besluit-topic-plugin/besluit-topic-toolbar-dropdown.ts
@@ -74,22 +74,16 @@ export default class BesluitTopicToolbarDropdownComponent extends Component<Args
 
   @action
   updateBesluitTopic() {
-    const currentBesluitURI = getCurrentBesluitURI(this.controller);
-
-    if (!currentBesluitURI || !this.topics.value) {
+    if (!this.topics.isFinished || !this.decisionRange) {
       return;
     }
-
-    const besluit = this.decisionRange;
-    if (!besluit) {
-      console.warn(
-        `We have a besluit URI (${currentBesluitURI}), but can't find a besluit ancestor`,
-      );
+    if (!this.topics.value) {
+      console.warn('Request for besluit topics failed');
       return;
     }
 
     const outgoingBesluitTopics = getOutgoingTripleList(
-      besluit.node.attrs,
+      this.decisionRange.node.attrs,
       ELI(ELI_SUBJECT),
     );
 
@@ -120,13 +114,7 @@ export default class BesluitTopicToolbarDropdownComponent extends Component<Args
   upsertBesluitTopic(selected: BesluitTopic[]) {
     this.besluitTopicsSelected = selected;
 
-    const currentBesluitRange = getCurrentBesluitRange(this.controller);
-
-    const resource =
-      (currentBesluitRange &&
-        'node' in currentBesluitRange &&
-        (currentBesluitRange.node.attrs.subject as string)) ||
-      undefined;
+    const resource = getCurrentBesluitURI(this.controller);
 
     if (this.besluitTopicsSelected && resource) {
       this.controller.doCommand(

--- a/addon/components/decision-plugin/decision-plugin-card.gts
+++ b/addon/components/decision-plugin/decision-plugin-card.gts
@@ -6,20 +6,15 @@ import {
   insertDescription,
   insertTitle,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/decision-plugin/commands';
-import type { PNode, SayController, Selection } from '@lblod/ember-rdfa-editor';
+import type { SayController, Selection } from '@lblod/ember-rdfa-editor';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 import { AlertTriangleIcon } from '@appuniversum/ember-appuniversum/components/icons/alert-triangle';
-import { findAncestors } from '@lblod/ember-rdfa-editor/utils/position-utils';
-import {
-  getOutgoingTriple,
-  hasOutgoingNamedNodeTriple,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import { getOutgoingTriple } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 import {
   BESLUIT,
   ELI,
   PROV,
-  RDF,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { NodeWithPos } from '@curvenote/prosemirror-utils';
 import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
@@ -28,6 +23,7 @@ import { on } from '@ember/modifier';
 import { not } from 'ember-truth-helpers';
 import t from 'ember-intl/helpers/t';
 import { TemplateOnlyComponent } from '@ember/component/template-only';
+import { getCurrentBesluitRange } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-topic-plugin/utils/helpers';
 
 interface DecisionCardOptions {
   articleUriGenerator?: () => string;
@@ -50,15 +46,13 @@ export default class DecisionPluginCard extends Component<Sig> {
   }
 
   get decisionNodeLocation(): NodeWithPos | null {
-    return (
-      findAncestors(this.selection.$from, (node: PNode) => {
-        return hasOutgoingNamedNodeTriple(
-          node.attrs,
-          RDF('type'),
-          BESLUIT('Besluit'),
-        );
-      })[0] ?? null
-    );
+    const besluitRange = getCurrentBesluitRange(this.controller);
+    return besluitRange
+      ? {
+          pos: besluitRange.from,
+          node: besluitRange.node,
+        }
+      : null;
   }
 
   @action

--- a/addon/components/decision-plugin/insert-article.gts
+++ b/addon/components/decision-plugin/insert-article.gts
@@ -10,8 +10,6 @@ import { buildArticleStructure } from '@lblod/ember-rdfa-editor-lblod-plugins/pl
 import { not } from 'ember-truth-helpers';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
-import { recalculateNumbers } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/structure-plugin/recalculate-structure-numbers';
-import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
 
 export interface InsertArticleOptions {
   uriGenerator?: () => string;
@@ -96,12 +94,12 @@ export default class InsertArticleComponent extends Component<Sig> {
 
   @action
   insertFreely(node: PNode) {
-    this.controller.withTransaction((tr) => {
-      return transactionCombinator(
-        this.controller.activeEditorState,
-        tr.replaceSelectionWith(node),
-      )([recalculateNumbers]).transaction;
-    });
+    this.controller.doCommand(
+      insertArticle({
+        node,
+        insertFreely: true,
+      }),
+    );
     this.controller.focus();
   }
 

--- a/addon/components/decision-plugin/insert-article.gts
+++ b/addon/components/decision-plugin/insert-article.gts
@@ -16,6 +16,8 @@ import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transactio
 export interface InsertArticleOptions {
   uriGenerator?: () => string;
   insertFreely?: boolean;
+  /** Pass a decision URI instead of finding one in the document. Implies `insertFreely`. */
+  decisionUri?: string;
 }
 interface Sig {
   Args: {
@@ -53,16 +55,16 @@ export default class InsertArticleComponent extends Component<Sig> {
       : null;
   }
 
+  get canInsertFreely() {
+    return this.options?.insertFreely || this.options?.decisionUri;
+  }
+
   get canInsert() {
-    if (this.options?.insertFreely) {
-      return this.canInsertFreely;
+    if (this.canInsertFreely) {
+      return true;
     } else {
       return this.canInsertInDecision;
     }
-  }
-
-  get canInsertFreely() {
-    return true;
   }
 
   get canInsertInDecision() {
@@ -83,8 +85,9 @@ export default class InsertArticleComponent extends Component<Sig> {
     const structureNode = buildArticleStructure(
       this.schema,
       this.args.options?.uriGenerator,
+      this.args.options?.decisionUri,
     );
-    if (this.args.options?.insertFreely) {
+    if (this.canInsertFreely) {
       this.insertFreely(structureNode);
     } else {
       this.insertInDecision(structureNode);

--- a/addon/components/lpdc-plugin/lpdc-insert.ts
+++ b/addon/components/lpdc-plugin/lpdc-insert.ts
@@ -11,7 +11,7 @@ import {
   type LpdcPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/lpdc-plugin';
 import { v4 as uuidv4 } from 'uuid';
-import { getCurrentBesluitRange } from '../../plugins/besluit-topic-plugin/utils/helpers';
+import { getCurrentBesluitURI } from '../../plugins/besluit-topic-plugin/utils/helpers';
 import { SRO } from '../../utils/constants';
 
 interface Args {
@@ -39,21 +39,19 @@ export default class LpdcPluginsInsertComponent extends Component<Args> {
     this.showModal = false;
   }
 
+  get decisionUri() {
+    return (
+      this.args.config?.decisionUri ?? getCurrentBesluitURI(this.controller)
+    );
+  }
+
   get isButtonDisabled() {
-    return !getCurrentBesluitRange(this.controller);
+    return !getCurrentBesluitURI(this.controller);
   }
 
   @action
   onLpdcInsert(lpdc: LPDC) {
-    const currentBesluitRange = getCurrentBesluitRange(this.controller);
-
-    const resource =
-      (currentBesluitRange &&
-        'node' in currentBesluitRange &&
-        (currentBesluitRange.node.attrs.subject as string)) ||
-      undefined;
-
-    if (!resource) {
+    if (!this.decisionUri) {
       throw new Error('No besluit found in selection');
     }
 
@@ -80,7 +78,7 @@ export default class LpdcPluginsInsertComponent extends Component<Args> {
 
     this.controller.doCommand(
       addProperty({
-        resource,
+        resource: this.decisionUri,
         property: {
           predicate: SRO('bekrachtigt').full,
           object: sayDataFactory.resourceNode(uri),

--- a/addon/components/lpdc-plugin/lpdc-insert.ts
+++ b/addon/components/lpdc-plugin/lpdc-insert.ts
@@ -46,7 +46,7 @@ export default class LpdcPluginsInsertComponent extends Component<Args> {
   }
 
   get isButtonDisabled() {
-    return !getCurrentBesluitURI(this.controller);
+    return !this.decisionUri;
   }
 
   @action

--- a/addon/components/roadsign-regulation-plugin/roadsigns-modal.ts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-modal.ts
@@ -47,7 +47,7 @@ type Args = {
   options: RoadsignRegulationPluginOptions;
 };
 
-export default class RoadsignRegulationCard extends Component<Args> {
+export default class RoadsignsModal extends Component<Args> {
   endpoint: string;
   imageBaseUrl: string;
 
@@ -99,12 +99,10 @@ export default class RoadsignRegulationCard extends Component<Args> {
   get controller() {
     return this.args.controller;
   }
-  get decisionRange() {
-    return getCurrentBesluitRange(this.controller);
-  }
   get decisionLocation() {
-    return this.decisionRange
-      ? { node: this.decisionRange.node, pos: this.decisionRange.from }
+    const decisionRange = getCurrentBesluitRange(this.controller);
+    return decisionRange
+      ? { node: decisionRange.node, pos: decisionRange.from }
       : null;
   }
 
@@ -320,9 +318,11 @@ export default class RoadsignRegulationCard extends Component<Args> {
                           `;
     const domParser = new DOMParser();
     const htmlNode = domParser.parseFromString(regulationHTML, 'text/html');
+    const passedDecisionUri = this.args.options.decisionContext?.decisionUri;
     const article = buildArticleStructure(
       this.controller.activeEditorState.schema,
       this.args.options.articleUriGenrator,
+      this.args.options.decisionContext?.decisionUri,
     );
     const contentFragment = ProseParser.fromSchema(
       this.args.controller.schema,
@@ -331,13 +331,12 @@ export default class RoadsignRegulationCard extends Component<Args> {
     }).content;
     const nodeToInsert = article.copy(contentFragment);
 
-    this.args.controller.doCommand(
-      insertArticle({
-        node: nodeToInsert,
-        decisionLocation: unwrap(this.decisionLocation),
-      }),
-      { view: this.args.controller.mainEditorView },
-    );
+    const insertArgs: Parameters<typeof insertArticle>[0] = passedDecisionUri
+      ? { node: nodeToInsert, insertFreely: true }
+      : { node: nodeToInsert, decisionLocation: unwrap(this.decisionLocation) };
+    this.args.controller.doCommand(insertArticle(insertArgs), {
+      view: this.args.controller.mainEditorView,
+    });
     this.args.closeModal();
   }
 

--- a/addon/plugins/besluit-topic-plugin/utils/helpers.ts
+++ b/addon/plugins/besluit-topic-plugin/utils/helpers.ts
@@ -4,7 +4,6 @@ import {
   RDF,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { hasOutgoingNamedNodeTriple } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
-import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { ElementPNode } from '@lblod/ember-rdfa-editor/plugins/datastore';
 import { findAncestors } from '@lblod/ember-rdfa-editor/utils/position-utils';
 
@@ -36,13 +35,13 @@ export const getCurrentBesluitRange = (
   };
 };
 
-export const getCurrentBesluitURI = (controller: SayController) => {
-  const currentBesluitRange = getCurrentBesluitRange(controller);
-  const doc = controller.mainEditorState.doc;
+export const getCurrentBesluitURI = (
+  controllerOrState: SayController | EditorState,
+) => {
+  const currentBesluitRange = getCurrentBesluitRange(controllerOrState);
 
   if (currentBesluitRange) {
-    const node = unwrap(doc.nodeAt(currentBesluitRange.from));
-    return node.attrs['subject'] as string | undefined;
+    return currentBesluitRange.node.attrs['subject'] as string | undefined;
   }
 
   return;

--- a/addon/plugins/decision-plugin/utils/build-article-structure.ts
+++ b/addon/plugins/decision-plugin/utils/build-article-structure.ts
@@ -1,6 +1,7 @@
 import { Schema } from '@lblod/ember-rdfa-editor';
 import {
   BESLUIT,
+  ELI,
   PROV,
   RDF,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
@@ -11,6 +12,13 @@ import { v4 as uuid } from 'uuid';
 export function buildArticleStructure(
   schema: Schema,
   uriGenerator?: () => string,
+  /**
+   * Adds a backlink to this resource instead of relying on being linked to the decision after
+   * creation.
+   * Adding backlinks like this does not play nice with the RDFa tools, but if combined with a
+   * document with this URI imported it works as expected. It creates valid RDFa in either case.
+   */
+  decisionUri?: string,
 ) {
   let articleResource: string;
   if (uriGenerator) {
@@ -34,6 +42,14 @@ export function buildArticleStructure(
           object: factory.contentLiteral(),
         },
       ] satisfies OutgoingTriple[],
+      backlinks: !decisionUri
+        ? undefined
+        : [
+            {
+              subject: factory.resourceNode(decisionUri),
+              predicate: ELI('has_part'),
+            },
+          ],
       hasTitle: false,
       structureType: 'article',
       displayStructureName: true,

--- a/addon/plugins/lpdc-plugin/api.ts
+++ b/addon/plugins/lpdc-plugin/api.ts
@@ -81,6 +81,12 @@ export const fetchLpdcs = async ({
     },
   });
 
+  if (!results.ok) {
+    throw new Error(
+      `Received '${results.status}: ${results.statusText}' when fetching from LPDC`,
+    );
+  }
+
   const resultJson = (await results.json()) as FetchResults;
 
   return {

--- a/addon/plugins/lpdc-plugin/types.ts
+++ b/addon/plugins/lpdc-plugin/types.ts
@@ -1,5 +1,7 @@
 export type LpdcPluginConfig = {
   endpoint: string;
+  /** Decision URI to use for RDFa links to avoid needing to look for one in the document */
+  decisionUri?: string;
 };
 
 export type LPDC = { uri: string; name: string };

--- a/addon/plugins/roadsign-regulation-plugin/index.ts
+++ b/addon/plugins/roadsign-regulation-plugin/index.ts
@@ -2,4 +2,9 @@ export type RoadsignRegulationPluginOptions = {
   endpoint: string;
   imageBaseUrl: string;
   articleUriGenrator?: () => string;
+  /** Instead of finding a decision node in the document, pass the relevant URI and type */
+  decisionContext?: {
+    decisionUri: string;
+    decisionType?: string;
+  };
 };

--- a/addon/utils/translation.ts
+++ b/addon/utils/translation.ts
@@ -33,7 +33,6 @@ export const getIntlService = (state: EditorState) => {
   const intl = emberApplicationPluginKey
     .getState(state)
     ?.application.lookup('service:intl');
-  console.log(emberApplicationPluginKey.getState(state));
   return intl;
 };
 /**

--- a/tests/dummy/app/config/mandatee-table-sample-config.ts
+++ b/tests/dummy/app/config/mandatee-table-sample-config.ts
@@ -1,4 +1,3 @@
-import { findParentNodeClosestToPos } from '@curvenote/prosemirror-utils';
 import {
   Fragment,
   PNode,
@@ -6,13 +5,9 @@ import {
   Schema,
   Transaction,
 } from '@lblod/ember-rdfa-editor';
+import { getCurrentBesluitURI } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-topic-plugin/utils/helpers';
 import { MandateeTableConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/mandatee-table-plugin';
-import {
-  BESLUIT,
-  EXT,
-  RDF,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
-import { hasOutgoingNamedNodeTriple } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import {
   QueryResult,
@@ -106,15 +101,7 @@ export const MANDATEE_TABLE_SAMPLE_CONFIG: MandateeTableConfig<QueryResult> = {
       return (state) => {
         const { schema, doc } = state;
         const $pos = doc.resolve(pos);
-        const decisionUri = unwrap(
-          findParentNodeClosestToPos($pos, (node) => {
-            return hasOutgoingNamedNodeTriple(
-              node.attrs,
-              RDF('type'),
-              BESLUIT('Besluit'),
-            );
-          }),
-        ).node.attrs.subject;
+        const decisionUri = getCurrentBesluitURI(state);
         if (!decisionUri) {
           return { result: false, initialState: state, transaction: state.tr };
         }
@@ -185,15 +172,7 @@ export const MANDATEE_TABLE_SAMPLE_CONFIG: MandateeTableConfig<QueryResult> = {
       return (state) => {
         const { doc, schema } = state;
         const $pos = doc.resolve(pos);
-        const decisionUri = unwrap(
-          findParentNodeClosestToPos($pos, (node) => {
-            return hasOutgoingNamedNodeTriple(
-              node.attrs,
-              RDF('type'),
-              BESLUIT('Besluit'),
-            );
-          }),
-        ).node.attrs.subject;
+        const decisionUri = getCurrentBesluitURI(state);
         if (!decisionUri) {
           return { initialState: state, result: false, transaction: state.tr };
         }


### PR DESCRIPTION
### Overview
Modified the `decision-plugin`, `lpdc-plugin` and `roadsign-regulation-plugin` to accept the decision uri as config (as well as decision type for roadsigns), to allow for them to be used by vendors without a decision node within the editor. Also refactors any lookups for the decision node so that they use the same util functions.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5104
Embeddable PR: https://github.com/lblod/frontend-embeddable-notule-editor/pull/264

### Setup
To test you'll need to tweak the sample app to pass the necessary config to the plugins.

### How to test/reproduce
- decision-plugin:
	- The 'insert freely' functionality works as before (inserts article at the selection)
	- Passing a decision uri as config enables the insert button in any context and uses the same behaviour to insert an article with a dangling backlink to the specified uri.
- roadsign-regulation-plugin:
	- Passing a decision uri and allowed type enables the insert button in any context and inserts the new article in place of the selection
- lpdc-plugin:
	- Passing a uri as config enables the button anywhere and inserts a variable with a dangling backlink to that uri.

### Challenges/uncertainties
Messes a bit with RDFa tools but not as much as I'd feared.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
