### PR TITLE
Parse only article also from templates

### DIFF
--- a/.changeset/mighty-mice-itch.md
+++ b/.changeset/mighty-mice-itch.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+parse articles also from templates

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -252,6 +252,9 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
               `span[property~='${ELI('number').prefixed}'],
                span[property~='${ELI('number').full}']`,
             );
+            const isOnlyArticle =
+              node.dataset.sayIsOnlyArticle &&
+              node.dataset.sayIsOnlyArticle !== 'false';
             const number = numberNode?.textContent
               ? parseInt(numberNode.textContent, 10)
               : 1;
@@ -274,7 +277,7 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
               structureType: 'article',
               displayStructureName: true,
               hasTitle: false,
-              isOnlyArticle: false,
+              isOnlyArticle,
               number,
             };
           }

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -466,7 +466,7 @@ export default class BesluitSampleController extends Controller {
             <h5>Beslissing</h5>
 
             <div property="prov:value" datatype="xsd:string">
-              <div property="eli:has_part" resource="http://data.lblod.info/artikels/\${generateUuid()}" typeof="besluit:Artikel">
+              <div property="eli:has_part" resource="http://data.lblod.info/artikels/\${generateUuid()}" typeof="besluit:Artikel" data-say-is-only-article="true">
                 <div>Artikel <span property="eli:number" datatype="xsd:string">1</span></div>
                 <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
                 <div property="prov:value" datatype="xsd:string">
@@ -518,7 +518,7 @@ export default class BesluitSampleController extends Controller {
 
             <p class="u-spacer--small">Beslist,</p>
             <div property="prov:value" datatype="xsd:string">
-              <div property="eli:has_part" resource="http://data.lblod.info/artikels/\${generateUuid()}" typeof="besluit:Artikel">
+              <div property="eli:has_part" resource="http://data.lblod.info/artikels/\${generateUuid()}" typeof="besluit:Artikel" data-say-is-only-article="true">
                 <div>Artikel <span property="eli:number" datatype="xsd:string">1</span></div>
                 <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
                 <div property="prov:value" datatype="xsd:string"><span class="mark-highlight-manual">Voer inhoud in</span></div>
@@ -563,7 +563,7 @@ export default class BesluitSampleController extends Controller {
           <br />
           <h5>Beslissing</h5>
           <div property="prov:value" datatype="xsd:string">
-            <div property="eli:has_part" resource="http://data.lblod.info/artikels/\${generateUuid()}" typeof="besluit:Artikel">
+            <div property="eli:has_part" resource="http://data.lblod.info/artikels/\${generateUuid()}" typeof="besluit:Artikel" data-say-is-only-article="true">
               <div>Artikel <span property="eli:number" datatype="xsd:string">1</span></div>
               <span style="display: none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
               <div property="prov:value" datatype="xsd:string"><span class="mark-highlight-manual">Voer inhoud in</span></div>


### PR DESCRIPTION
### Overview
Now the only article attr is also parsed from templates and added it to the templates stored in the test app

##### connected issues and PRs:
GN-5113



### Setup
None

### How to test/reproduce
Insert a template with an article like besluit template and check that it correctly shows enig article 

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
