### PR TITLE
Do not add `" ."` after only article title

### DIFF
--- a/.changeset/eleven-months-know.md
+++ b/.changeset/eleven-months-know.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Do not add `" ."` at the end of 'only article' for single articles

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -162,7 +162,7 @@ export const emberNodeConfig: () => EmberNodeConfig = () => {
             },
             number.toString(),
           ],
-          '.',
+          isOnlyArticle ? '' : '.',
         ];
       }
       return renderRdfaAware({


### PR DESCRIPTION
### Overview
Slight correction to how punctuation is handled for single articles.

##### connected issues and PRs:
Makes the output of https://github.com/lblod/frontend-gelinkt-notuleren/pull/749 more sensible.

### Setup
N/A

### How to test/reproduce
Insert a single article and note that there is no longer a ` .` after the title.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
