### PR TITLE
internal: disable rdfa-aware setting for heading nodes in dummy app

### DIFF
--- a/.changeset/neat-queens-study.md
+++ b/.changeset/neat-queens-study.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Disable `rdfaAware` setting for heading nodes in dummy app

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -169,7 +169,7 @@ export default class BesluitSampleController extends Controller {
         oslo_location: osloLocation(this.config.location),
         roadsign_regulation,
         mandatee_table,
-        heading: headingWithConfig({ rdfaAware: true }),
+        heading: headingWithConfig({ rdfaAware: false }),
         blockquote,
 
         horizontal_rule,

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -180,7 +180,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       location,
       codelist,
       ...STRUCTURE_NODES,
-      heading: headingWithConfig({ rdfaAware: true }),
+      heading: headingWithConfig({ rdfaAware: false }),
       blockquote,
 
       horizontal_rule,

--- a/tests/dummy/app/controllers/snippet-edit-sample.ts
+++ b/tests/dummy/app/controllers/snippet-edit-sample.ts
@@ -171,7 +171,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       number,
       codelist,
       ...STRUCTURE_NODES,
-      heading: headingWithConfig({ rdfaAware: true }),
+      heading: headingWithConfig({ rdfaAware: false }),
       blockquote,
 
       horizontal_rule,

--- a/tests/utils/editor.ts
+++ b/tests/utils/editor.ts
@@ -105,7 +105,7 @@ export const SAMPLE_SCHEMA = new Schema({
     codelist,
     address,
     ...STRUCTURE_NODES,
-    heading: headingWithConfig({ rdfaAware: true }),
+    heading: headingWithConfig({ rdfaAware: false }),
     blockquote,
     horizontal_rule,
     code_block,


### PR DESCRIPTION
### Overview
This PR disables the `rdfaAware` setting on `heading` nodes in the dummy app to ensure consistency with the frontends.

##### connected issues and PRs:
https://github.com/lblod/frontend-gelinkt-notuleren/pull/748
https://github.com/lblod/frontend-reglementaire-bijlage/pull/291

### How to test/reproduce
- Start the dummy app
- Open the 'Editable Nodes' page
- Ensure that headings are no longer 'rdfa-aware': there is no border shown around them, you can enter inside them etc.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
