### PR TITLE
GN-5153: only trigger event handlers of snippet actions once

### DIFF
--- a/.changeset/fuzzy-pillows-relax.md
+++ b/.changeset/fuzzy-pillows-relax.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Ensure that the event handlers of snippet actions are only triggered once

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -32,7 +32,6 @@ import { recalculateNumbers } from '@lblod/ember-rdfa-editor-lblod-plugins/plugi
 interface ButtonSig {
   Args: {
     isActive: boolean;
-    onClick: () => void;
     icon: AuIconSignature['Args']['icon'];
     helpText: string;
   };
@@ -41,13 +40,8 @@ interface ButtonSig {
 
 const SnippetButton: TemplateOnlyComponent<ButtonSig> = <template>
   {{#if @isActive}}
-    <button
-      class='say-snippet-button'
-      type='button'
-      {{on 'click' @onClick}}
-      ...attributes
-    >
-      <AuIcon @icon={{@icon}} @size='large' {{on 'click' @onClick}} />
+    <button class='say-snippet-button' type='button' ...attributes>
+      <AuIcon @icon={{@icon}} @size='large' />
       <div class='say-snippet-button-text'>
         {{t @helpText}}
       </div>
@@ -169,13 +163,13 @@ export default class SnippetNode extends Component<Signature> {
         <SnippetButton
           @icon={{SynchronizeIcon}}
           @helpText='snippet-plugin.snippet-node.change-fragment'
-          @onClick={{this.editFragment}}
+          {{on 'click' this.editFragment}}
           @isActive={{this.isActive}}
         />
         <SnippetButton
           @icon={{BinIcon}}
           @helpText='snippet-plugin.snippet-node.remove-fragment'
-          @onClick={{this.deleteFragment}}
+          {{on 'click' this.deleteFragment}}
           @isActive={{this.isActive}}
           class='say-snippet-remove-button'
         />
@@ -183,7 +177,7 @@ export default class SnippetNode extends Component<Signature> {
           <SnippetButton
             @icon={{AddIcon}}
             @helpText='snippet-plugin.snippet-node.add-fragment'
-            @onClick={{this.addFragment}}
+            {{on 'click' this.addFragment}}
             @isActive={{this.isActive}}
           />
         {{/if}}


### PR DESCRIPTION
### Overview
This PR solves the issue of the snippet buttons' event handlers being fired twice (thus why two snippets were removed at once).
It seems that there were some leftovers of the attempt to resolve the chromium button bug: the button event handlers were tied to both the button and the icon inside it, which results in the handler being fired twice.

##### connected issues and PRs:
[GN-5153](https://binnenland.atlassian.net/browse/GN-5153)

### Setup
None

### How to test/reproduce
**Before**
- Start the dummy app
- Insert two snippets after eachother
- Click on the icon inside the remove button on the first snippet
- Notice that both snippets are removed (due to the event handler being fired twice)

**After**
- Insert two snippets after eachother
- Click on the icon inside the remove button on the first snippet
- Only the relevant snippet should be removed (and the event handler is only fired once)


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
