### PR TITLE
Replace snippet placeholder when deleting last snippet

### DIFF
--- a/.changeset/gentle-berries-exist.md
+++ b/.changeset/gentle-berries-exist.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+When removing last snippet of a 'group', replace the placeholder instead of completely deleting

--- a/.changeset/hungry-trees-perform.md
+++ b/.changeset/hungry-trees-perform.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Fix bug with snippet list names containing a `,` displaying as multiple lists

--- a/addon/components/snippet-plugin/nodes/placeholder.gts
+++ b/addon/components/snippet-plugin/nodes/placeholder.gts
@@ -8,13 +8,13 @@ import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 
 interface Signature {
-  Args: EmberNodeArgs;
+  Args: Pick<EmberNodeArgs, 'node' | 'selectNode'>;
 }
 
 export default class SnippetPluginPlaceholder extends Component<Signature> {
   @service declare intl: IntlService;
   get listNames() {
-    return this.args.node.attrs.listNames;
+    return this.args.node.attrs.snippetListNames;
   }
   get isSingleList() {
     return this.listNames.length === 1;

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -28,6 +28,8 @@ import insertSnippet from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippe
 import { isNone } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
 import { recalculateNumbers } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/structure-plugin/recalculate-structure-numbers';
+import { createSnippetPlaceholder } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet-placeholder';
+import { hasDecendant } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/has-descendant';
 
 interface ButtonSig {
   Args: {
@@ -62,6 +64,15 @@ export default class SnippetNode extends Component<Signature> {
   get controller() {
     return this.args.controller;
   }
+  get schema() {
+    return this.controller.schema;
+  }
+  get snippetOrPlaceholder() {
+    return [
+      this.schema.nodes.snippet,
+      this.schema.nodes.snippet_placeholder,
+    ].filter(Boolean);
+  }
   get node() {
     return this.args.node;
   }
@@ -94,17 +105,46 @@ export default class SnippetNode extends Component<Signature> {
   deleteFragment() {
     const position = this.args.getPos();
     if (position !== undefined) {
-      this.controller.withTransaction((tr) => {
-        return transactionCombinator(
-          this.controller.mainEditorState,
-          tr.deleteRange(position, position + this.node.nodeSize),
-        )([recalculateNumbers]).transaction;
-      });
+      const matchingSnippetExists = hasDecendant(
+        this.controller.mainEditorState.doc,
+        (node) =>
+          node !== this.node &&
+          this.snippetOrPlaceholder.includes(node.type) &&
+          node.attrs.placeholderId === this.node.attrs.placeholderId,
+      );
+      if (matchingSnippetExists) {
+        this.controller.withTransaction((tr) => {
+          return transactionCombinator(
+            this.controller.mainEditorState,
+            tr.deleteRange(position, position + this.node.nodeSize),
+          )([recalculateNumbers]).transaction;
+        });
+      } else {
+        const node = createSnippetPlaceholder({
+          listProperties: {
+            placeholderId: this.node.attrs.placeholderId,
+            listIds: this.node.attrs.snippetListIds,
+            names: this.node.attrs.snippetListNames,
+            importedResources: this.node.attrs.importedResources,
+          },
+          schema: this.schema,
+          allowMultipleSnippets: this.allowMultipleSnippets,
+        });
+
+        this.args.controller.withTransaction(
+          (tr) =>
+            transactionCombinator(
+              this.controller.mainEditorState,
+              tr.replaceWith(position, position + this.node.nodeSize, node),
+            )([recalculateNumbers]).transaction,
+          { view: this.args.controller.mainEditorView },
+        );
+      }
     }
   }
   createSliceFromElement(element: Element) {
     return new Slice(
-      ProseParser.fromSchema(this.controller.schema).parse(element, {
+      ProseParser.fromSchema(this.schema).parse(element, {
         preserveWhitespace: true,
       }).content,
       0,

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -127,7 +127,8 @@ export default class SnippetNode extends Component<Signature> {
   @action
   onInsert(content: string, title: string) {
     this.closeModal();
-    const assignedSnippetListsIds = this.node.attrs.assignedSnippetListsIds;
+    const snippetListIds = this.node.attrs.snippetListIds;
+    const snippetListNames = this.node.attrs.snippetListNames;
     let start = 0;
     let end = 0;
     const pos = this.args.getPos();
@@ -147,7 +148,8 @@ export default class SnippetNode extends Component<Signature> {
       insertSnippet({
         content,
         title,
-        assignedSnippetListsIds,
+        snippetListIds,
+        snippetListNames,
         importedResources: this.node.attrs.importedResources,
         range: { start, end },
         allowMultipleSnippets: this.allowMultipleSnippets,
@@ -189,7 +191,7 @@ export default class SnippetNode extends Component<Signature> {
       @closeModal={{this.closeModal}}
       @config={{this.node.attrs.config}}
       @onInsert={{this.onInsert}}
-      @assignedSnippetListsIds={{this.node.attrs.assignedSnippetListsIds}}
+      @snippetListIds={{this.node.attrs.snippetListIds}}
     />
   </template>
 }

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -127,8 +127,6 @@ export default class SnippetNode extends Component<Signature> {
   @action
   onInsert(content: string, title: string) {
     this.closeModal();
-    const snippetListIds = this.node.attrs.snippetListIds;
-    const snippetListNames = this.node.attrs.snippetListNames;
     let start = 0;
     let end = 0;
     const pos = this.args.getPos();
@@ -148,9 +146,12 @@ export default class SnippetNode extends Component<Signature> {
       insertSnippet({
         content,
         title,
-        snippetListIds,
-        snippetListNames,
-        importedResources: this.node.attrs.importedResources,
+        listProperties: {
+          placeholderId: this.node.attrs.placeholderId,
+          listIds: this.node.attrs.snippetListIds,
+          names: this.node.attrs.snippetListNames,
+          importedResources: this.node.attrs.importedResources,
+        },
         range: { start, end },
         allowMultipleSnippets: this.allowMultipleSnippets,
       }),

--- a/addon/components/snippet-plugin/search-modal.ts
+++ b/addon/components/snippet-plugin/search-modal.ts
@@ -11,7 +11,7 @@ import { SnippetPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plug
 
 interface Args {
   config: SnippetPluginConfig;
-  assignedSnippetListsIds: string[] | undefined;
+  snippetListIds: string[] | undefined;
   closeModal: () => void;
   open: boolean;
   onInsert: (content: string, title: string) => void;
@@ -64,8 +64,7 @@ export default class SnippetPluginSearchModalComponent extends Component<Args> {
         abortSignal: abortController.signal,
         filter: {
           name: this.inputSearchText ?? undefined,
-          assignedSnippetListIds:
-            this.args.assignedSnippetListsIds ?? undefined,
+          snippetListIds: this.args.snippetListIds ?? undefined,
         },
         pagination: {
           pageNumber: this.pageNumber,
@@ -88,7 +87,7 @@ export default class SnippetPluginSearchModalComponent extends Component<Args> {
     this.inputSearchText,
     this.pageNumber,
     this.pageSize,
-    this.args.assignedSnippetListsIds,
+    this.args.snippetListIds,
   ]);
 
   @action

--- a/addon/components/snippet-plugin/snippet-insert-placeholder.gts
+++ b/addon/components/snippet-plugin/snippet-insert-placeholder.gts
@@ -72,7 +72,7 @@ export default class SnippetPluginSnippetInsertPlaceholder extends Component<Sig
     </li>
     <SnippetListModal
       @config={{@config}}
-      @assignedSnippetListsIds={{empty}}
+      @snippetListIds={{empty}}
       @allowMultipleSnippets={{false}}
       @onSaveSnippetLists={{this.insertPlaceholder}}
       @open={{this.isModalOpen}}

--- a/addon/components/snippet-plugin/snippet-insert-placeholder.gts
+++ b/addon/components/snippet-plugin/snippet-insert-placeholder.gts
@@ -43,11 +43,11 @@ export default class SnippetPluginSnippetInsertPlaceholder extends Component<Sig
     allowMultipleSnippets: boolean,
   ) {
     if (lists) {
-      const node = createSnippetPlaceholder(
+      const node = createSnippetPlaceholder({
         lists,
-        this.args.controller.schema,
+        schema: this.args.controller.schema,
         allowMultipleSnippets,
-      );
+      });
 
       this.args.controller.withTransaction(
         (tr) => {

--- a/addon/components/snippet-plugin/snippet-insert-rdfa.gts
+++ b/addon/components/snippet-plugin/snippet-insert-rdfa.gts
@@ -23,11 +23,7 @@ interface Sig {
 }
 
 export default class SnippetInsertRdfaComponent extends Component<Sig> {
-  get disableInsert() {
-    return (this.snippetListProperties?.listIds.length ?? 0) === 0;
-  }
-
-  get snippetListProperties(): SnippetListProperties | undefined {
+  get listProperties(): SnippetListProperties | undefined {
     const activeNode = this.args.node.value;
     const activeNodeSnippetListIds = getSnippetListIdsProperties(activeNode);
 
@@ -36,6 +32,7 @@ export default class SnippetInsertRdfaComponent extends Component<Sig> {
         listIds: getAssignedSnippetListsIdsFromProperties(
           activeNodeSnippetListIds,
         ),
+        placeholderId: activeNode.attrs.placeholderId,
         names: activeNode.attrs.snippetListNames,
         importedResources: activeNode.attrs.importedResources,
       };
@@ -57,6 +54,7 @@ export default class SnippetInsertRdfaComponent extends Component<Sig> {
       if (properties.length > 0) {
         return {
           listIds: getAssignedSnippetListsIdsFromProperties(properties),
+          placeholderId: parentNode.node.attrs.placeholderId,
           names: parentNode.node.attrs.snippetListNames,
           importedResources: parentNode.node.attrs.importedResources,
         };
@@ -79,8 +77,7 @@ export default class SnippetInsertRdfaComponent extends Component<Sig> {
     <SnippetInsert
       @config={{@config}}
       @controller={{@controller}}
-      @snippetListProperties={{this.snippetListProperties}}
-      @disabled={{this.disableInsert}}
+      @listProperties={{this.listProperties}}
       @allowMultipleSnippets={{this.allowMultipleSnippets}}
     />
   </template>

--- a/addon/components/snippet-plugin/snippet-insert-rdfa.gts
+++ b/addon/components/snippet-plugin/snippet-insert-rdfa.gts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 import { SayController } from '@lblod/ember-rdfa-editor';
 import {
-  type ImportedResourceMap,
+  type SnippetListProperties,
   type SnippetPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import { findParentNodeClosestToPos } from '@curvenote/prosemirror-utils';
@@ -27,9 +27,7 @@ export default class SnippetInsertRdfaComponent extends Component<Sig> {
     return (this.snippetListProperties?.listIds.length ?? 0) === 0;
   }
 
-  get snippetListProperties():
-    | { listIds: string[]; importedResources: ImportedResourceMap }
-    | undefined {
+  get snippetListProperties(): SnippetListProperties | undefined {
     const activeNode = this.args.node.value;
     const activeNodeSnippetListIds = getSnippetListIdsProperties(activeNode);
 
@@ -38,6 +36,7 @@ export default class SnippetInsertRdfaComponent extends Component<Sig> {
         listIds: getAssignedSnippetListsIdsFromProperties(
           activeNodeSnippetListIds,
         ),
+        names: activeNode.attrs.snippetListNames,
         importedResources: activeNode.attrs.importedResources,
       };
     }
@@ -58,6 +57,7 @@ export default class SnippetInsertRdfaComponent extends Component<Sig> {
       if (properties.length > 0) {
         return {
           listIds: getAssignedSnippetListsIdsFromProperties(properties),
+          names: parentNode.node.attrs.snippetListNames,
           importedResources: parentNode.node.attrs.importedResources,
         };
       }

--- a/addon/components/snippet-plugin/snippet-insert.gts
+++ b/addon/components/snippet-plugin/snippet-insert.gts
@@ -11,7 +11,7 @@ import {
   Slice,
 } from '@lblod/ember-rdfa-editor';
 import { SnippetPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
-import { type ImportedResourceMap } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
+import { type SnippetListProperties } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import insertSnippet from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/commands/insert-snippet';
 import SearchModal from './search-modal';
 
@@ -19,9 +19,7 @@ interface Sig {
   Args: {
     controller: SayController;
     config: SnippetPluginConfig;
-    snippetListProperties:
-      | { listIds: string[]; importedResources: ImportedResourceMap }
-      | undefined;
+    snippetListProperties: SnippetListProperties | undefined;
     disabled?: boolean;
     allowMultipleSnippets?: boolean;
   };
@@ -62,7 +60,8 @@ export default class SnippetInsertComponent extends Component<Sig> {
       insertSnippet({
         content,
         title,
-        assignedSnippetListsIds: this.args.snippetListProperties?.listIds || [],
+        snippetListIds: this.args.snippetListProperties?.listIds || [],
+        snippetListNames: this.args.snippetListProperties?.names || [],
         importedResources: this.args.snippetListProperties?.importedResources,
         allowMultipleSnippets: this.args.allowMultipleSnippets,
       }),
@@ -91,7 +90,7 @@ export default class SnippetInsertComponent extends Component<Sig> {
       @closeModal={{this.closeModal}}
       @config={{@config}}
       @onInsert={{this.onInsert}}
-      @assignedSnippetListsIds={{@snippetListProperties.listIds}}
+      @snippetListIds={{@snippetListProperties.listIds}}
     />
   </template>
 }

--- a/addon/components/snippet-plugin/snippet-insert.gts
+++ b/addon/components/snippet-plugin/snippet-insert.gts
@@ -19,8 +19,7 @@ interface Sig {
   Args: {
     controller: SayController;
     config: SnippetPluginConfig;
-    snippetListProperties: SnippetListProperties | undefined;
-    disabled?: boolean;
+    listProperties: SnippetListProperties | undefined;
     allowMultipleSnippets?: boolean;
   };
 }
@@ -30,6 +29,9 @@ export default class SnippetInsertComponent extends Component<Sig> {
 
   get controller() {
     return this.args.controller;
+  }
+  get disabled() {
+    return (this.args.listProperties?.listIds.length ?? 0) === 0;
   }
 
   @action
@@ -56,20 +58,16 @@ export default class SnippetInsertComponent extends Component<Sig> {
   @action
   onInsert(content: string, title: string) {
     this.closeModal();
-    this.controller.doCommand(
-      insertSnippet({
-        content,
-        title,
-        snippetListIds: this.args.snippetListProperties?.listIds || [],
-        snippetListNames: this.args.snippetListProperties?.names || [],
-        importedResources: this.args.snippetListProperties?.importedResources,
-        allowMultipleSnippets: this.args.allowMultipleSnippets,
-      }),
-    );
-  }
-
-  get disabled() {
-    return this.args.disabled ?? false;
+    if (this.args.listProperties) {
+      this.controller.doCommand(
+        insertSnippet({
+          content,
+          title,
+          listProperties: this.args.listProperties,
+          allowMultipleSnippets: this.args.allowMultipleSnippets,
+        }),
+      );
+    }
   }
 
   <template>
@@ -90,7 +88,7 @@ export default class SnippetInsertComponent extends Component<Sig> {
       @closeModal={{this.closeModal}}
       @config={{@config}}
       @onInsert={{this.onInsert}}
-      @snippetListIds={{@snippetListProperties.listIds}}
+      @snippetListIds={{@listProperties.listIds}}
     />
   </template>
 }

--- a/addon/components/snippet-plugin/snippet-list-select.gts
+++ b/addon/components/snippet-plugin/snippet-list-select.gts
@@ -53,7 +53,7 @@ export default class SnippetListSelect extends Component<Signature> {
     return getSnippetListIdsProperties(this.args.node.value);
   }
 
-  get assignedSnippetListsIds(): string[] {
+  get snippetListIds(): string[] {
     return getAssignedSnippetListsIdsFromProperties(
       this.snippetListIdsProperties,
     );
@@ -99,7 +99,7 @@ export default class SnippetListSelect extends Component<Signature> {
 
       <SnippetListModal
         @config={{@config}}
-        @assignedSnippetListsIds={{this.assignedSnippetListsIds}}
+        @snippetListIds={{this.snippetListIds}}
         @onSaveSnippetLists={{this.onSaveSnippetLists}}
         @allowMultipleSnippets={{this.allowMultipleSnippets}}
         @open={{this.showModal}}

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.hbs
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.hbs
@@ -19,7 +19,7 @@
           {{else}}
             <SnippetPlugin::SnippetList::SnippetListView
               @snippetLists={{this.snippetListResource.value}}
-              @assignedSnippetListsIds={{this.assignedSnippetListsIds}}
+              @snippetListIds={{this.snippetListIds}}
               @listNameFilter={{this.nameFilterText}}
               @sort={{this.sort}}
               @onChange={{this.onChange}}

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
@@ -23,7 +23,7 @@ interface Signature {
       lists: SnippetList[],
       allowMultipleSnippets: boolean,
     ) => void;
-    assignedSnippetListsIds: string[] | undefined;
+    snippetListIds: string[] | undefined;
     closeModal: () => void;
     open: boolean;
     allowMultipleSnippets?: boolean;
@@ -40,10 +40,8 @@ export default class SnippetListModalComponent extends Component<Signature> {
   // Display
   @tracked error: unknown;
 
-  @trackedReset('args.assignedSnippetListsIds')
-  assignedSnippetListsIds: string[] = [
-    ...(this.args.assignedSnippetListsIds ?? []),
-  ];
+  @trackedReset('args.snippetListIds')
+  snippetListIds: string[] = [...(this.args.snippetListIds ?? [])];
 
   @localCopy('args.allowMultipleSnippets') allowMultipleSnippets = false;
 
@@ -65,7 +63,7 @@ export default class SnippetListModalComponent extends Component<Signature> {
   @action
   saveAndClose() {
     const snippetLists = this.snippetListResource.value?.filter((snippetList) =>
-      this.assignedSnippetListsIds.includes(snippetList.id),
+      this.snippetListIds.includes(snippetList.id),
     );
     this.args.onSaveSnippetLists(
       snippetLists || [],
@@ -73,7 +71,7 @@ export default class SnippetListModalComponent extends Component<Signature> {
     );
     this.args.closeModal();
     // Clear selection for next time
-    this.assignedSnippetListsIds = [];
+    this.snippetListIds = [];
   }
 
   snippetListSearch = restartableTask(async () => {
@@ -107,7 +105,7 @@ export default class SnippetListModalComponent extends Component<Signature> {
   );
 
   @action
-  onChange(assignedSnippetListsIds: string[]) {
-    this.assignedSnippetListsIds = assignedSnippetListsIds;
+  onChange(snippetListIds: string[]) {
+    this.snippetListIds = snippetListIds;
   }
 }

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
@@ -53,7 +53,7 @@
             <AuCheckbox
               id={{row.label}}
               @onChange={{fn this.onChange row.id}}
-              @checked={{in-array @assignedSnippetListsIds row.id}}
+              @checked={{in-array @snippetListIds row.id}}
             />
           </td>
           <td>{{row.label}}</td>

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-view.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-view.ts
@@ -4,25 +4,22 @@ import { SnippetList } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snip
 
 interface Args {
   snippetLists: SnippetList[];
-  assignedSnippetListsIds: string[];
+  snippetListIds: string[];
   listNameFilter: string | null;
   isLoading: boolean;
-  onChange: (assignedSnippetListsIds: string[]) => void;
+  onChange: (snippetListIds: string[]) => void;
 }
 
 export default class SnippetListViewComponent extends Component<Args> {
   @action
   onChange(snippetId: string, isSelected: boolean) {
     if (isSelected) {
-      const newSnippetListIds = [
-        ...this.args.assignedSnippetListsIds,
-        snippetId,
-      ];
+      const newSnippetListIds = [...this.args.snippetListIds, snippetId];
 
       return this.args.onChange(newSnippetListIds);
     }
 
-    const newSnippetListIds = this.args.assignedSnippetListsIds.filter(
+    const newSnippetListIds = this.args.snippetListIds.filter(
       (id) => id !== snippetId,
     );
 
@@ -49,8 +46,7 @@ export default class SnippetListViewComponent extends Component<Args> {
       return;
     }
 
-    const isSelected =
-      this.args.assignedSnippetListsIds.includes(snippetListId);
+    const isSelected = this.args.snippetListIds.includes(snippetListId);
 
     this.onChange(snippetListId, !isSelected);
   }

--- a/addon/plugins/snippet-plugin/commands/insert-snippet.ts
+++ b/addon/plugins/snippet-plugin/commands/insert-snippet.ts
@@ -12,7 +12,8 @@ import {
 export interface InsertSnippetCommandArgs {
   content: string;
   title: string;
-  assignedSnippetListsIds: string[];
+  snippetListIds: string[];
+  snippetListNames: string[];
   importedResources?: ImportedResourceMap;
   range?: { start: number; end: number };
   allowMultipleSnippets?: boolean;
@@ -21,7 +22,8 @@ export interface InsertSnippetCommandArgs {
 const insertSnippet = ({
   content,
   title,
-  assignedSnippetListsIds,
+  snippetListIds,
+  snippetListNames,
   importedResources,
   range,
   allowMultipleSnippets,
@@ -44,7 +46,8 @@ const insertSnippet = ({
         schema: state.schema,
         content,
         title,
-        snippetListIds: assignedSnippetListsIds,
+        snippetListIds,
+        snippetListNames,
         importedResources,
         allowMultipleSnippets,
       });

--- a/addon/plugins/snippet-plugin/commands/insert-snippet.ts
+++ b/addon/plugins/snippet-plugin/commands/insert-snippet.ts
@@ -3,7 +3,7 @@ import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transactio
 import { addPropertyToNode } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 import { recalculateNumbers } from '../../structure-plugin/recalculate-structure-numbers';
 import { createSnippet } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet';
-import { type ImportedResourceMap } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
+import { type SnippetListProperties } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import {
   isSome,
   unwrap,
@@ -12,9 +12,7 @@ import {
 export interface InsertSnippetCommandArgs {
   content: string;
   title: string;
-  snippetListIds: string[];
-  snippetListNames: string[];
-  importedResources?: ImportedResourceMap;
+  listProperties: SnippetListProperties;
   range?: { start: number; end: number };
   allowMultipleSnippets?: boolean;
 }
@@ -22,9 +20,7 @@ export interface InsertSnippetCommandArgs {
 const insertSnippet = ({
   content,
   title,
-  snippetListIds,
-  snippetListNames,
-  importedResources,
+  listProperties,
   range,
   allowMultipleSnippets,
 }: InsertSnippetCommandArgs): Command => {
@@ -46,14 +42,12 @@ const insertSnippet = ({
         schema: state.schema,
         content,
         title,
-        snippetListIds,
-        snippetListNames,
-        importedResources,
+        listProperties,
         allowMultipleSnippets,
       });
 
       const addImportedResourceProperties = Object.values(
-        importedResources ?? {},
+        listProperties.importedResources ?? {},
       )
         .map((linked) => {
           const newProperties =

--- a/addon/plugins/snippet-plugin/commands/update-snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/commands/update-snippet-placeholder.ts
@@ -2,7 +2,7 @@ import { Command } from '@lblod/ember-rdfa-editor';
 import { addProperty, removeProperty } from '@lblod/ember-rdfa-editor/commands';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { SNIPPET_LIST_RDFA_PREDICATE } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
-import { getSnippetUriFromId } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
+import { getSnippetUriFromId } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { type OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import { type ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
 import {

--- a/addon/plugins/snippet-plugin/commands/update-snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/commands/update-snippet-placeholder.ts
@@ -59,7 +59,7 @@ export const updateSnippetPlaceholder = ({
       });
       transaction = transaction.setNodeAttribute(
         node.pos,
-        'listNames',
+        'snippetListNames',
         newSnippetLists.map((list) => list.label),
       );
       transaction = transaction.setNodeAttribute(

--- a/addon/plugins/snippet-plugin/index.ts
+++ b/addon/plugins/snippet-plugin/index.ts
@@ -34,6 +34,12 @@ export class Snippet {
 
 export type ImportedResourceMap = Record<string, Option<string>>;
 
+export type SnippetListProperties = {
+  listIds: string[];
+  names: string[];
+  importedResources: ImportedResourceMap;
+};
+
 export type SnippetListArgs = {
   id: string;
   label: string;

--- a/addon/plugins/snippet-plugin/index.ts
+++ b/addon/plugins/snippet-plugin/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { dateValue } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/strings';
 import { SafeString } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/types';
+import { getSnippetIdFromUri } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 
 export const DEFAULT_CONTENT_STRING = 'block+';
 
@@ -47,13 +48,6 @@ export type SnippetListArgs = {
   createdOn: string;
   importedResources: string[];
 };
-
-const snippetListBase = 'http://lblod.data.gift/snippet-lists/';
-
-export const getSnippetUriFromId = (id: string) => `${snippetListBase}${id}`;
-
-export const getSnippetIdFromUri = (uri: string) =>
-  uri.replace(snippetListBase, '');
 
 export class SnippetList {
   id: string;

--- a/addon/plugins/snippet-plugin/index.ts
+++ b/addon/plugins/snippet-plugin/index.ts
@@ -35,6 +35,7 @@ export class Snippet {
 export type ImportedResourceMap = Record<string, Option<string>>;
 
 export type SnippetListProperties = {
+  placeholderId: string;
   listIds: string[];
   names: string[];
   importedResources: ImportedResourceMap;

--- a/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
@@ -46,7 +46,7 @@ export function createSnippetPlaceholder(
   const mappingResource = `http://example.net/lblod-snippet-placeholder/${uuidv4()}`;
   return schema.nodes.snippet_placeholder.create({
     rdfaNodeType: 'resource',
-    listNames: lists.map((list) => list.label),
+    snippetListNames: lists.map((list) => list.label),
     subject: mappingResource,
     properties: [
       {
@@ -73,7 +73,7 @@ const emberNodeConfig: EmberNodeConfig = {
   attrs: {
     ...rdfaAttrSpec({ rdfaAware: true }),
     typeof: { default: EXT('SnippetPlaceholder') },
-    listNames: { default: [] },
+    snippetListNames: { default: [] },
     importedResources: { default: {} },
     allowMultipleSnippets: { default: false },
   },
@@ -86,7 +86,7 @@ const emberNodeConfig: EmberNodeConfig = {
       attrs: {
         ...node.attrs,
         class: 'say-snippet-placeholder-node',
-        'data-list-names': (node.attrs.listNames as string[]).join(','),
+        'data-list-names': (node.attrs.snippetListNames as string[])?.join(','),
         'data-imported-resources': JSON.stringify(node.attrs.importedResources),
         'data-allow-multiple-snippets': node.attrs.allowMultipleSnippets,
       },
@@ -114,7 +114,7 @@ const emberNodeConfig: EmberNodeConfig = {
         ) {
           return {
             ...rdfaAttrs,
-            listNames: node.getAttribute('data-list-names')?.split(','),
+            snippetListNames: node.getAttribute('data-list-names')?.split(','),
             importedResources: jsonParse(
               node.getAttribute('data-imported-resources'),
             ),

--- a/addon/plugins/snippet-plugin/nodes/snippet.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet.ts
@@ -166,6 +166,7 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
   component: SnippetComponent,
   content: options.allowedContent || DEFAULT_CONTENT_STRING,
   serialize(node) {
+    const listNames = node.attrs.snippetListNames as string[];
     return renderRdfaAware({
       renderable: node,
       tag: 'div',
@@ -175,7 +176,7 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
         'data-assigned-snippet-ids': (
           node.attrs.snippetListIds as string[]
         )?.join(','),
-        'data-list-names': (node.attrs.snippetListNames as string[])?.join(','),
+        'data-list-names': listNames && JSON.stringify(listNames),
         'data-imported-resources': JSON.stringify(node.attrs.importedResources),
         'data-snippet-title': node.attrs.title,
         'data-allow-multiple-snippets': node.attrs.allowMultipleSnippets,
@@ -201,11 +202,10 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
           return {
             ...rdfaAttrs,
             placeholderId,
-            // TODO need to handle `,` inside list names correctly
             snippetListIds: node
               .getAttribute('data-assigned-snippet-ids')
               ?.split(','),
-            snippetListNames: node.getAttribute('data-list-names')?.split(','),
+            snippetListNames: jsonParse(node.getAttribute('data-list-names')),
             importedResources: jsonParse(
               node.getAttribute('data-imported-resources'),
             ),

--- a/addon/plugins/snippet-plugin/nodes/snippet.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet.ts
@@ -62,6 +62,7 @@ interface CreateSnippetArgs {
   content: string;
   title: string;
   snippetListIds: string[];
+  snippetListNames: string[];
   importedResources?: ImportedResourceMap;
   allowMultipleSnippets?: boolean;
 }
@@ -77,6 +78,7 @@ export function createSnippet({
   content,
   title,
   snippetListIds,
+  snippetListNames,
   importedResources,
   allowMultipleSnippets,
 }: CreateSnippetArgs): [PNode, Map<string, OutgoingTriple[]>] {
@@ -97,7 +99,8 @@ export function createSnippet({
   const node = schema.node(
     'snippet',
     {
-      assignedSnippetListsIds: snippetListIds,
+      snippetListIds,
+      snippetListNames,
       title,
       subject: `http://data.lblod.info/snippets/${uuidv4()}`,
       importedResources,
@@ -150,7 +153,8 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
       ],
     },
     rdfaNodeType: { default: 'resource' },
-    assignedSnippetListsIds: { default: [] },
+    snippetListNames: { default: [] },
+    snippetListIds: { default: [] },
     importedResources: { default: {} },
     title: { default: '' },
     config: { default: options },
@@ -165,8 +169,9 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
       attrs: {
         ...node.attrs,
         'data-assigned-snippet-ids': (
-          node.attrs.assignedSnippetListsIds as string[]
-        ).join(','),
+          node.attrs.snippetListIds as string[]
+        )?.join(','),
+        'data-list-names': (node.attrs.snippetListNames as string[])?.join(','),
         'data-imported-resources': JSON.stringify(node.attrs.importedResources),
         'data-snippet-title': node.attrs.title,
         'data-allow-multiple-snippets': node.attrs.allowMultipleSnippets,
@@ -185,9 +190,11 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
         ) {
           return {
             ...rdfaAttrs,
-            assignedSnippetListsIds: node
+            // TODO need to handle `,` inside list names correctly
+            snippetListIds: node
               .getAttribute('data-assigned-snippet-ids')
               ?.split(','),
+            snippetListNames: node.getAttribute('data-list-names')?.split(','),
             importedResources: jsonParse(
               node.getAttribute('data-imported-resources'),
             ),

--- a/addon/plugins/snippet-plugin/utils/fetch-data.ts
+++ b/addon/plugins/snippet-plugin/utils/fetch-data.ts
@@ -6,7 +6,7 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/sparql-helpers';
 import { Snippet, SnippetList, SnippetListArgs } from '../index';
 
-type Filter = { name?: string; assignedSnippetListIds?: string[] };
+type Filter = { name?: string; snippetListIds?: string[] };
 export type OrderBy =
   | 'label'
   | 'created-on'
@@ -16,7 +16,7 @@ export type OrderBy =
   | null;
 type Pagination = { pageNumber: number; pageSize: number };
 
-const buildSnippetCountQuery = ({ name, assignedSnippetListIds }: Filter) => {
+const buildSnippetCountQuery = ({ name, snippetListIds }: Filter) => {
   return /* sparql */ `
       PREFIX schema: <http://schema.org/>
       PREFIX dct: <http://purl.org/dc/terms/>
@@ -42,8 +42,8 @@ const buildSnippetCountQuery = ({ name, assignedSnippetListIds }: Filter) => {
               : ''
           }
           ${
-            assignedSnippetListIds && assignedSnippetListIds.length
-              ? `FILTER (?snippetListId IN (${assignedSnippetListIds
+            snippetListIds && snippetListIds.length
+              ? `FILTER (?snippetListId IN (${snippetListIds
                   .map((from) => sparqlEscapeString(from))
                   .join(', ')}))`
               : ''
@@ -69,7 +69,7 @@ const buildSnippetCountQuery = ({ name, assignedSnippetListIds }: Filter) => {
 // };
 
 const buildSnippetFetchQuery = ({
-  filter: { name, assignedSnippetListIds },
+  filter: { name, snippetListIds },
   pagination: { pageSize, pageNumber },
 }: {
   filter: Filter;
@@ -106,8 +106,8 @@ const buildSnippetFetchQuery = ({
               : ''
           }
           ${
-            assignedSnippetListIds && assignedSnippetListIds.length
-              ? `FILTER (?snippetListId IN (${assignedSnippetListIds
+            snippetListIds && snippetListIds.length
+              ? `FILTER (?snippetListId IN (${snippetListIds
                   .map((from) => sparqlEscapeString(from))
                   .join(', ')}))`
               : ''
@@ -173,7 +173,7 @@ export const fetchSnippets = async ({
   filter: Filter;
   pagination: Pagination;
 }) => {
-  if (!filter.assignedSnippetListIds?.length) {
+  if (!filter.snippetListIds?.length) {
     return { totalCount: 0, results: [] };
   }
 

--- a/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
+++ b/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
@@ -1,10 +1,24 @@
-import { PNode } from '@lblod/ember-rdfa-editor';
-import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
-import { getSnippetIdFromUri } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
+import { type PNode } from '@lblod/ember-rdfa-editor';
+import { type OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { getOutgoingTripleList } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 
 export const SNIPPET_LIST_RDFA_PREDICATE = SAY('allowedSnippetList');
+
+const snippetListBase = 'http://lblod.data.gift/snippet-lists/';
+
+export const getSnippetUriFromId = (id: string) => `${snippetListBase}${id}`;
+
+export const getSnippetIdFromUri = (uri: string) =>
+  uri.replace(snippetListBase, '');
+
+export function tripleForSnippetListId(id: string) {
+  return {
+    predicate: SNIPPET_LIST_RDFA_PREDICATE.full,
+    object: sayDataFactory.namedNode(getSnippetUriFromId(id)),
+  };
+}
 
 export const getSnippetListIdsProperties = (node: PNode) => {
   return getOutgoingTripleList(node.attrs, SNIPPET_LIST_RDFA_PREDICATE);

--- a/addon/utils/has-descendant.ts
+++ b/addon/utils/has-descendant.ts
@@ -1,0 +1,19 @@
+import { type PNode } from '@lblod/ember-rdfa-editor';
+
+export function hasDecendant(
+  nodeToDescendInto: PNode,
+  matchFunc: (node: PNode) => boolean,
+) {
+  let foundMatch = false;
+  nodeToDescendInto.descendants((node) => {
+    // Already found a match, stop descending or checking
+    if (foundMatch) return false;
+    if (matchFunc(node)) {
+      foundMatch = true;
+      return false;
+    }
+    return true;
+  });
+
+  return foundMatch;
+}


### PR DESCRIPTION
### Overview
Tried to reduce some of the differences in naming and arguments between snippet nodes and snippet placeholders while doing this, so it's easier to do other work that pulls them together in the future but without re-writing everything. Also fixes commas in snippet list names.

Should be backwards compatible but does (can) not fix some historical issues that will remain in old documents. Namely:
- Snippets inserted in old documents don't know which placeholder they 'came from', so will be handled as separate 'groups'. For example, if you created a document from a template including a placeholder, inserted two snippets, then saved; the new code will now, when deleting either of those snippets, replace it with a placeholder. This can easily be deleted, by pressing backspace, so this shouldn't be too much of a problem.
- Snippet placeholders which include a snippet with a `,` in the name will remain broken. There's no reasonable way for us to figure out that this has happened, so we just handle it as before.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5003

### Setup
N/A

### How to test/reproduce
Create a document with placeholders, multi-snippet placeholders and placeholders with commas in the list names and play around inserting and deleting snippets and refreshing. 

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
