### PR TITLE
Snippet placeholder redesign

### DIFF
--- a/.changeset/four-eagles-live.md
+++ b/.changeset/four-eagles-live.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Redesign snippet placeholder to have more intuitive UX

--- a/.changeset/tough-pugs-shave.md
+++ b/.changeset/tough-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add snippet list names to the modal title

--- a/addon/components/snippet-plugin/nodes/placeholder.gts
+++ b/addon/components/snippet-plugin/nodes/placeholder.gts
@@ -1,11 +1,21 @@
 import Component from '@glimmer/component';
-import { on } from '@ember/modifier';
-import t from 'ember-intl/helpers/t';
-import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
 import { PlusTextIcon } from '@appuniversum/ember-appuniversum/components/icons/plus-text';
 import { type EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/_private/ember-node';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
+import AuIcon from '@appuniversum/ember-appuniversum/components/au-icon';
+import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
+import { on } from '@ember/modifier';
+import SearchModal from '../search-modal';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { ProseParser, Slice } from '@lblod/ember-rdfa-editor';
+import insertSnippet from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/commands/insert-snippet';
+import {
+  getAssignedSnippetListsIdsFromProperties,
+  getSnippetListIdsProperties,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
+import t from 'ember-intl/helpers/t';
 
 interface Signature {
   Args: Pick<EmberNodeArgs, 'node' | 'selectNode'>;
@@ -13,6 +23,57 @@ interface Signature {
 
 export default class SnippetPluginPlaceholder extends Component<Signature> {
   @service declare intl: IntlService;
+
+  @tracked showModal = false;
+
+  get controller() {
+    return this.args.controller;
+  }
+
+  get node() {
+    return this.args.node;
+  }
+
+  get snippetListIds() {
+    const activeNodeSnippetListIds = getSnippetListIdsProperties(this.node);
+    return getAssignedSnippetListsIdsFromProperties(activeNodeSnippetListIds);
+  }
+
+  @action
+  openModal() {
+    this.controller.focus();
+    this.showModal = true;
+  }
+
+  @action
+  closeModal() {
+    this.showModal = false;
+  }
+
+  createSliceFromElement(element: Element) {
+    return new Slice(
+      ProseParser.fromSchema(this.controller.schema).parse(element, {
+        preserveWhitespace: true,
+      }).content,
+      0,
+      0,
+    );
+  }
+
+  @action
+  onInsert(content: string, title: string) {
+    this.closeModal();
+    this.controller.doCommand(
+      insertSnippet({
+        content,
+        title,
+        assignedSnippetListsIds: this.snippetListIds,
+        importedResources: this.node.attrs.importedResources,
+        allowMultipleSnippets: this.node.attrs.allowMultipleSnippets,
+      }),
+    );
+  }
+
   get listNames() {
     return this.args.node.attrs.snippetListNames;
   }
@@ -29,23 +90,36 @@ export default class SnippetPluginPlaceholder extends Component<Signature> {
     }
   }
   <template>
-    <AuAlert
-      @title={{this.alertTitle}}
-      @skin='warning'
-      @icon={{PlusTextIcon}}
-      @size='small'
-      class='say-snippet-placeholder'
-      {{on 'click' @selectNode}}
-    >
-      {{#unless this.isSingleList}}
-        {{t 'snippet-plugin.placeholder.active-lists'}}
-        <ul>
-          {{#each this.listNames as |listName|}}
-            <li>{{listName}}</li>
-          {{/each}}
-        </ul>
-      {{/unless}}
-      {{t 'snippet-plugin.placeholder.text'}}
-    </AuAlert>
+    <div class='say-snippet-placeholder' {{on 'click' @selectNode}}>
+      <div class='say-snippet-placeholder__icon'>
+        <AuIcon @icon={{PlusTextIcon}} />
+      </div>
+      <div class='say-snippet-placeholder__content'>
+        <p class='say-snippet-placeholder__title'>{{this.alertTitle}}</p>
+        {{#unless this.isSingleList}}
+          <ul class='say-snippet-placeholder__list'>
+            {{#each this.listNames as |listName|}}
+              <li>{{listName}}</li>
+            {{/each}}
+          </ul>
+        {{/unless}}
+        {{#if this.node.attrs.config.showInsertButton}}
+          <AuButton
+            @skin='link'
+            class='say-snippet-placeholder__button'
+            {{on 'click' this.openModal}}
+          >
+            {{t 'snippet-plugin.placeholder.button'}}
+          </AuButton>
+        {{/if}}
+      </div>
+    </div>
+    <SearchModal
+      @open={{this.showModal}}
+      @closeModal={{this.closeModal}}
+      @config={{this.node.attrs.config}}
+      @onInsert={{this.onInsert}}
+      @assignedSnippetListsIds={{this.snippetListIds}}
+    />
   </template>
 }

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -13,6 +13,7 @@ import { BinIcon } from '@appuniversum/ember-appuniversum/components/icons/bin';
 import { AddIcon } from '@appuniversum/ember-appuniversum/components/icons/add';
 import { type EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/_private/ember-node';
 import {
+  NodeSelection,
   type PNode,
   ProseParser,
   type Selection,
@@ -30,6 +31,8 @@ import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transactio
 import { recalculateNumbers } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/structure-plugin/recalculate-structure-numbers';
 import { createSnippetPlaceholder } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet-placeholder';
 import { hasDecendant } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/has-descendant';
+import SnippetPlaceholder from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/nodes/placeholder';
+import { getSnippetListIdsFromNode } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 
 interface ButtonSig {
   Args: {
@@ -76,6 +79,13 @@ export default class SnippetNode extends Component<Signature> {
   get node() {
     return this.args.node;
   }
+  get isPlaceholder() {
+    return this.node.content.size === 0;
+  }
+  get allowMultipleSnippets() {
+    return this.node.attrs.allowMultipleSnippets as boolean;
+  }
+
   @action
   closeModal() {
     this.showModal = false;
@@ -83,10 +93,6 @@ export default class SnippetNode extends Component<Signature> {
   openModal() {
     this.controller.focus();
     this.showModal = true;
-  }
-
-  get allowMultipleSnippets() {
-    return this.node.attrs.allowMultipleSnippets as boolean;
   }
 
   @action
@@ -123,7 +129,7 @@ export default class SnippetNode extends Component<Signature> {
         const node = createSnippetPlaceholder({
           listProperties: {
             placeholderId: this.node.attrs.placeholderId,
-            listIds: this.node.attrs.snippetListIds,
+            listIds: getSnippetListIdsFromNode(this.node),
             names: this.node.attrs.snippetListNames,
             importedResources: this.node.attrs.importedResources,
           },
@@ -155,6 +161,12 @@ export default class SnippetNode extends Component<Signature> {
     return this.controller.mainEditorState.selection;
   }
   get isActive(): boolean {
+    if (
+      this.selection instanceof NodeSelection &&
+      this.selection.node === this.node
+    ) {
+      return true;
+    }
     const ancestor = findAncestors(this.selection.$from, (node: PNode) => {
       return hasOutgoingNamedNodeTriple(
         node.attrs,
@@ -188,7 +200,7 @@ export default class SnippetNode extends Component<Signature> {
         title,
         listProperties: {
           placeholderId: this.node.attrs.placeholderId,
-          listIds: this.node.attrs.snippetListIds,
+          listIds: getSnippetListIdsFromNode(this.node),
           names: this.node.attrs.snippetListNames,
           importedResources: this.node.attrs.importedResources,
         },
@@ -199,40 +211,48 @@ export default class SnippetNode extends Component<Signature> {
   }
 
   <template>
-    <div class='say-snippet-card'>
-      <div class='say-snippet-title'>{{this.node.attrs.title}}</div>
-      <div class='say-snippet-content'>{{yield}}</div>
-      <div class='say-snippet-icons' contenteditable='false'>
-        <SnippetButton
-          @icon={{SynchronizeIcon}}
-          @helpText='snippet-plugin.snippet-node.change-fragment'
-          {{on 'click' this.editFragment}}
-          @isActive={{this.isActive}}
-        />
-        <SnippetButton
-          @icon={{BinIcon}}
-          @helpText='snippet-plugin.snippet-node.remove-fragment'
-          {{on 'click' this.deleteFragment}}
-          @isActive={{this.isActive}}
-          class='say-snippet-remove-button'
-        />
-        {{#if this.allowMultipleSnippets}}
+    {{#if this.isPlaceholder}}
+      <SnippetPlaceholder
+        @node={{@node}}
+        @selectNode={{@selectNode}}
+        @insertSnippet={{this.editFragment}}
+      />
+    {{else}}
+      <div class='say-snippet-card'>
+        <div class='say-snippet-title'>{{this.node.attrs.title}}</div>
+        <div class='say-snippet-content'>{{yield}}</div>
+        <div class='say-snippet-icons' contenteditable='false'>
           <SnippetButton
-            @icon={{AddIcon}}
-            @helpText='snippet-plugin.snippet-node.add-fragment'
-            {{on 'click' this.addFragment}}
+            @icon={{SynchronizeIcon}}
+            @helpText='snippet-plugin.snippet-node.change-fragment'
+            {{on 'click' this.editFragment}}
             @isActive={{this.isActive}}
           />
-        {{/if}}
-      </div>
+          <SnippetButton
+            @icon={{BinIcon}}
+            @helpText='snippet-plugin.snippet-node.remove-fragment'
+            {{on 'click' this.deleteFragment}}
+            @isActive={{this.isActive}}
+            class='say-snippet-remove-button'
+          />
+          {{#if this.allowMultipleSnippets}}
+            <SnippetButton
+              @icon={{AddIcon}}
+              @helpText='snippet-plugin.snippet-node.add-fragment'
+              {{on 'click' this.addFragment}}
+              @isActive={{this.isActive}}
+            />
+          {{/if}}
+        </div>
 
-    </div>
+      </div>
+    {{/if}}
     <SearchModal
       @open={{this.showModal}}
       @closeModal={{this.closeModal}}
       @config={{this.node.attrs.config}}
       @onInsert={{this.onInsert}}
-      @snippetListIds={{this.node.attrs.snippetListIds}}
+      @snippetListIds={{getSnippetListIdsFromNode this.node}}
     />
   </template>
 }

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -253,6 +253,7 @@ export default class SnippetNode extends Component<Signature> {
       @config={{this.node.attrs.config}}
       @onInsert={{this.onInsert}}
       @snippetListIds={{getSnippetListIdsFromNode this.node}}
+      @snippetListNames={{this.node.attrs.snippetListNames}}
     />
   </template>
 }

--- a/addon/components/snippet-plugin/search-modal.hbs
+++ b/addon/components/snippet-plugin/search-modal.hbs
@@ -3,7 +3,10 @@
   class='snippet-modal'
   @modalOpen={{@open}}
   @closeModal={{this.closeModal}}
-  @title={{t 'snippet-plugin.modal.title'}}
+  @title={{t
+    'snippet-plugin.modal.title'
+    snippetListNames=this.snippetListNames
+  }}
   @size='large'
   @padding='none'
   as |modal|

--- a/addon/components/snippet-plugin/search-modal.ts
+++ b/addon/components/snippet-plugin/search-modal.ts
@@ -12,6 +12,7 @@ import { SnippetPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plug
 interface Args {
   config: SnippetPluginConfig;
   snippetListIds: string[] | undefined;
+  snippetListNames: string[] | undefined;
   closeModal: () => void;
   open: boolean;
   onInsert: (content: string, title: string) => void;
@@ -35,6 +36,10 @@ export default class SnippetPluginSearchModalComponent extends Component<Args> {
 
   get searchText() {
     return this.inputSearchText;
+  }
+
+  get snippetListNames() {
+    return this.args.snippetListNames?.map((name) => `"${name}"`).join(', ');
   }
 
   @action

--- a/addon/components/snippet-plugin/snippet-insert-rdfa.gts
+++ b/addon/components/snippet-plugin/snippet-insert-rdfa.gts
@@ -7,10 +7,7 @@ import {
   type SnippetPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import { findParentNodeClosestToPos } from '@curvenote/prosemirror-utils';
-import {
-  getAssignedSnippetListsIdsFromProperties,
-  getSnippetListIdsProperties,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
+import { getSnippetListIdsFromNode } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
 import SnippetInsert from './snippet-insert';
 
@@ -25,13 +22,11 @@ interface Sig {
 export default class SnippetInsertRdfaComponent extends Component<Sig> {
   get listProperties(): SnippetListProperties | undefined {
     const activeNode = this.args.node.value;
-    const activeNodeSnippetListIds = getSnippetListIdsProperties(activeNode);
+    const listIds = getSnippetListIdsFromNode(activeNode);
 
-    if (activeNodeSnippetListIds.length > 0) {
+    if (listIds.length > 0) {
       return {
-        listIds: getAssignedSnippetListsIdsFromProperties(
-          activeNodeSnippetListIds,
-        ),
+        listIds,
         placeholderId: activeNode.attrs.placeholderId,
         names: activeNode.attrs.snippetListNames,
         importedResources: activeNode.attrs.importedResources,
@@ -49,11 +44,11 @@ export default class SnippetInsertRdfaComponent extends Component<Sig> {
       isResourceNode(node),
     );
     while (parentNode) {
-      const properties = getSnippetListIdsProperties(parentNode.node);
+      const listIds = getSnippetListIdsFromNode(parentNode.node);
 
-      if (properties.length > 0) {
+      if (listIds.length > 0) {
         return {
-          listIds: getAssignedSnippetListsIdsFromProperties(properties),
+          listIds,
           placeholderId: parentNode.node.attrs.placeholderId,
           names: parentNode.node.attrs.snippetListNames,
           importedResources: parentNode.node.attrs.importedResources,

--- a/addon/components/snippet-plugin/snippet-insert.gts
+++ b/addon/components/snippet-plugin/snippet-insert.gts
@@ -89,6 +89,7 @@ export default class SnippetInsertComponent extends Component<Sig> {
       @config={{@config}}
       @onInsert={{this.onInsert}}
       @snippetListIds={{@listProperties.listIds}}
+      @snippetListNames={{@listProperties.names}}
     />
   </template>
 }

--- a/addon/plugins/snippet-plugin/index.ts
+++ b/addon/plugins/snippet-plugin/index.ts
@@ -13,6 +13,7 @@ export const DEFAULT_CONTENT_STRING = 'block+';
 export type SnippetPluginConfig = {
   endpoint: string;
   allowedContent?: string;
+  hidePlaceholderInsertButton?: boolean;
 };
 
 interface SnippetArgs {

--- a/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
@@ -11,7 +11,7 @@ import {
   createEmberNodeView,
   type EmberNodeConfig,
 } from '@lblod/ember-rdfa-editor/utils/ember-node';
-import SnippetPlaceholderComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/nodes/placeholder';
+import SnippetComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/nodes/snippet';
 import {
   EXT,
   RDF,
@@ -23,14 +23,10 @@ import {
   type SnippetListProperties,
   type ImportedResourceMap,
   type SnippetList,
+  type SnippetPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import { tripleForSnippetListId } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
-
-type SnippetPlaceholderConfig = {
-  endpoint?: string;
-  showInsertButton?: boolean;
-};
 
 export function importedResourcesFromSnippetLists(
   lists: SnippetList[],
@@ -98,9 +94,7 @@ export function createSnippetPlaceholder({
   });
 }
 
-const emberNodeConfig = (
-  config: SnippetPlaceholderConfig,
-): EmberNodeConfig => ({
+const emberNodeConfig = (config: SnippetPluginConfig): EmberNodeConfig => ({
   name: 'snippet_placeholder',
   inline: false,
   group: 'block',
@@ -118,7 +112,7 @@ const emberNodeConfig = (
       default: config,
     },
   },
-  component: SnippetPlaceholderComponent,
+  component: SnippetComponent,
   serialize(node, editorState) {
     const t = getTranslationFunction(editorState);
     const listNames = node.attrs.snippetListNames as string[];
@@ -180,7 +174,7 @@ const emberNodeConfig = (
   ],
 });
 
-export const snippetPlaceholder = (config: SnippetPlaceholderConfig) =>
+export const snippetPlaceholder = (config: SnippetPluginConfig) =>
   createEmberNodeSpec(emberNodeConfig(config));
-export const snippetPlaceholderView = (config: SnippetPlaceholderConfig) =>
+export const snippetPlaceholderView = (config: SnippetPluginConfig) =>
   createEmberNodeView(emberNodeConfig(config));

--- a/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
@@ -27,6 +27,11 @@ import {
 import { tripleForSnippetListId } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 
+type SnippetPlaceholderConfig = {
+  endpoint?: string;
+  showInsertButton?: boolean;
+};
+
 export function importedResourcesFromSnippetLists(
   lists: SnippetList[],
   existing: ImportedResourceMap = {},
@@ -93,7 +98,9 @@ export function createSnippetPlaceholder({
   });
 }
 
-const emberNodeConfig: EmberNodeConfig = {
+const emberNodeConfig = (
+  config: SnippetPlaceholderConfig,
+): EmberNodeConfig => ({
   name: 'snippet_placeholder',
   inline: false,
   group: 'block',
@@ -107,6 +114,9 @@ const emberNodeConfig: EmberNodeConfig = {
     snippetListNames: { default: [] },
     importedResources: { default: {} },
     allowMultipleSnippets: { default: false },
+    config: {
+      default: config,
+    },
   },
   component: SnippetPlaceholderComponent,
   serialize(node, editorState) {
@@ -116,7 +126,6 @@ const emberNodeConfig: EmberNodeConfig = {
       renderable: node,
       tag: 'div',
       attrs: {
-        ...node.attrs,
         class: 'say-snippet-placeholder-node',
         'data-list-names': listNames && JSON.stringify(listNames),
         'data-imported-resources': JSON.stringify(node.attrs.importedResources),
@@ -169,7 +178,9 @@ const emberNodeConfig: EmberNodeConfig = {
       },
     },
   ],
-};
+});
 
-export const snippetPlaceholder = createEmberNodeSpec(emberNodeConfig);
-export const snippetPlaceholderView = createEmberNodeView(emberNodeConfig);
+export const snippetPlaceholder = (config: SnippetPlaceholderConfig) =>
+  createEmberNodeSpec(emberNodeConfig(config));
+export const snippetPlaceholderView = (config: SnippetPlaceholderConfig) =>
+  createEmberNodeView(emberNodeConfig(config));

--- a/addon/plugins/snippet-plugin/nodes/snippet.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet.ts
@@ -34,6 +34,7 @@ import {
   SnippetListProperties,
   type SnippetPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
+import { tripleForSnippetListId } from '../utils/rdfa-predicate';
 
 function outgoingFromBacklink(
   backlink: IncomingTriple,
@@ -57,6 +58,13 @@ function outgoingFromBacklink(
   }
 }
 
+const defaultProperties = [
+  {
+    predicate: RDF('type').full,
+    object: sayDataFactory.namedNode(EXT('Snippet').full),
+  },
+];
+
 interface CreateSnippetArgs {
   schema: Schema;
   allowMultipleSnippets?: boolean;
@@ -77,7 +85,7 @@ export function createSnippet({
   title,
   allowMultipleSnippets,
   listProperties: {
-    listIds: snippetListIds,
+    listIds,
     names: snippetListNames,
     importedResources,
     placeholderId,
@@ -97,11 +105,15 @@ export function createSnippet({
     schema,
     parser,
   });
+  const properties = [
+    ...defaultProperties,
+    ...listIds.map(tripleForSnippetListId),
+  ];
   const node = schema.node(
     'snippet',
     {
       placeholderId,
-      snippetListIds,
+      properties,
       snippetListNames,
       title,
       subject: `http://data.lblod.info/snippets/${uuidv4()}`,
@@ -147,17 +159,11 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
   attrs: {
     ...rdfaAttrSpec({ rdfaAware: true }),
     properties: {
-      default: [
-        {
-          predicate: RDF('type').full,
-          object: sayDataFactory.namedNode(EXT('Snippet').full),
-        },
-      ],
+      default: defaultProperties,
     },
     rdfaNodeType: { default: 'resource' },
     placeholderId: { default: '' },
     snippetListNames: { default: [] },
-    snippetListIds: { default: [] },
     importedResources: { default: {} },
     title: { default: '' },
     config: { default: options },
@@ -173,9 +179,6 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
       attrs: {
         ...node.attrs,
         'data-snippet-placeholder-id': node.attrs.placeholderId,
-        'data-assigned-snippet-ids': (
-          node.attrs.snippetListIds as string[]
-        )?.join(','),
         'data-list-names': listNames && JSON.stringify(listNames),
         'data-imported-resources': JSON.stringify(node.attrs.importedResources),
         'data-snippet-title': node.attrs.title,
@@ -191,6 +194,8 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
         if (typeof node === 'string') return false;
         const rdfaAttrs = getRdfaAttrs(node, { rdfaAware: true });
         if (
+          rdfaAttrs &&
+          rdfaAttrs.rdfaNodeType !== 'literal' &&
           hasOutgoingNamedNodeTriple(rdfaAttrs, RDF('type'), EXT('Snippet'))
         ) {
           // For older documents without placeholder ids, treat each inserted snippet separately.
@@ -199,12 +204,19 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
           // risking having no ability to insert another snippet.
           const placeholderId =
             node.getAttribute('data-snippet-placeholder-id') || uuidv4();
+          const legacySnippetListIds = node
+            .getAttribute('data-assigned-snippet-ids')
+            ?.split(',');
+          const properties = !legacySnippetListIds
+            ? rdfaAttrs.properties
+            : [
+                ...rdfaAttrs.properties,
+                ...legacySnippetListIds.map(tripleForSnippetListId),
+              ];
           return {
             ...rdfaAttrs,
+            properties,
             placeholderId,
-            snippetListIds: node
-              .getAttribute('data-assigned-snippet-ids')
-              ?.split(','),
             snippetListNames: jsonParse(node.getAttribute('data-list-names')),
             importedResources: jsonParse(
               node.getAttribute('data-imported-resources'),

--- a/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
+++ b/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
@@ -33,3 +33,6 @@ export const getAssignedSnippetListsIdsFromProperties = (
     .map(getSnippetIdFromUri)
     .filter((id) => id !== undefined);
 };
+
+export const getSnippetListIdsFromNode = (node: PNode) =>
+  getAssignedSnippetListsIdsFromProperties(getSnippetListIdsProperties(node));

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -145,14 +145,14 @@
 .say-snippet-placeholder {
   display: flex;
   flex-direction: row;
-  padding: $au-unit-small $au-unit-small*1.5;
+  padding: $au-unit-small $au-unit-small * 1.5;
   background-color: #fff7bb;
   border-radius: var(--au-radius);
   border: 0.1rem solid #e5d34f;
 }
 
 .say-snippet-placeholder__icon {
-  background-color: #FFA10A;
+  background-color: #ffa10a;
   color: black;
   height: $au-unit - 0.1rem; // compensate for visual distortion of perfect circle
   width: $au-unit;
@@ -169,7 +169,7 @@
 }
 
 .say-snippet-placeholder__title {
-  color: #9E5805;
+  color: #9e5805;
   font-weight: 500;
 }
 

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -146,9 +146,9 @@
   display: flex;
   flex-direction: row;
   padding: $au-unit-small $au-unit-small * 1.5;
-  background-color: #fff7bb;
+  background-color: var(--au-orange-300);
   border-radius: var(--au-radius);
-  border: 0.1rem solid #e5d34f;
+  border: 0.1rem solid var(--au-orange-500);
 }
 
 .say-snippet-placeholder__icon {
@@ -169,7 +169,7 @@
 }
 
 .say-snippet-placeholder__title {
-  color: #9e5805;
+  color: var(--au-orange-700);
   font-weight: var(--au-medium);
 }
 

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -152,7 +152,7 @@
 }
 
 .say-snippet-placeholder__icon {
-  background-color: #ffa10a;
+  background-color: var(--au-orange-500);
   color: black;
   height: $au-unit - 0.1rem; // compensate for visual distortion of perfect circle
   width: $au-unit;
@@ -170,7 +170,7 @@
 
 .say-snippet-placeholder__title {
   color: #9e5805;
-  font-weight: 500;
+  font-weight: var(--au-medium);
 }
 
 .say-snippet-placeholder__button {

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -86,29 +86,6 @@
   }
 }
 
-.ProseMirror-selectednode > .say-snippet-placeholder {
-  background-color: var(--au-blue-200);
-}
-
-.say-snippet-placeholder-node {
-  background-color: var(--au-orange-200);
-  padding: 2rem;
-
-  div {
-    font-weight: var(--au-medium);
-  }
-}
-
-div[typeof='besluitpublicatie:Documentonderdeel']
-  .say-snippet-placeholder-node {
-  background-color: var(--au-gray-300);
-}
-
-.rdfa-annotations
-  [typeof]:not([typeof='foaf:Document']).say-snippet-placeholder-node {
-  padding-bottom: 2rem;
-}
-
 .say-snippet-card {
   border: 1px solid var(--au-blue-300);
   .say-snippet-title {
@@ -163,4 +140,63 @@ div[typeof='besluitpublicatie:Documentonderdeel']
       }
     }
   }
+}
+
+.say-snippet-placeholder {
+  display: flex;
+  flex-direction: row;
+  padding: $au-unit-small $au-unit-small*1.5;
+  background-color: #fff7bb;
+  border-radius: var(--au-radius);
+  border: 0.1rem solid #e5d34f;
+}
+
+.say-snippet-placeholder__icon {
+  background-color: #FFA10A;
+  color: black;
+  height: $au-unit - 0.1rem; // compensate for visual distortion of perfect circle
+  width: $au-unit;
+  margin-right: $au-unit * 0.5;
+  border-radius: $au-unit-large;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.say-snippet-placeholder__content {
+  margin-top: 0 !important;
+}
+
+.say-snippet-placeholder__title {
+  color: #9E5805;
+  font-weight: 500;
+}
+
+.say-snippet-placeholder__button {
+  margin: 0;
+  padding: 0;
+}
+
+.ProseMirror-selectednode > .say-snippet-placeholder {
+  background-color: var(--au-blue-200);
+}
+
+.say-snippet-placeholder-node {
+  background-color: var(--au-orange-200);
+  padding: 2rem;
+
+  div {
+    font-weight: var(--au-medium);
+  }
+}
+
+div[typeof='besluitpublicatie:Documentonderdeel']
+  .say-snippet-placeholder-node {
+  background-color: var(--au-gray-300);
+}
+
+.rdfa-annotations
+  [typeof]:not([typeof='foaf:Document']).say-snippet-placeholder-node {
+  padding-bottom: 2rem;
 }

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -149,33 +149,33 @@
   background-color: var(--au-orange-300);
   border-radius: var(--au-radius);
   border: 0.1rem solid var(--au-orange-500);
-}
 
-.say-snippet-placeholder__icon {
-  background-color: var(--au-orange-500);
-  color: black;
-  height: $au-unit - 0.1rem; // compensate for visual distortion of perfect circle
-  width: $au-unit;
-  margin-right: $au-unit * 0.5;
-  border-radius: $au-unit-large;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
+  .say-snippet-placeholder__icon {
+    background-color: var(--au-orange-500);
+    color: black;
+    height: $au-unit - 0.1rem; // compensate for visual distortion of perfect circle
+    width: $au-unit;
+    margin-right: $au-unit * 0.5;
+    border-radius: $au-unit-large;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
 
-.say-snippet-placeholder__content {
-  margin-top: 0 !important;
-}
+  .say-snippet-placeholder__content {
+    margin-top: 0;
+  }
 
-.say-snippet-placeholder__title {
-  color: var(--au-orange-700);
-  font-weight: var(--au-medium);
-}
+  .say-snippet-placeholder__title {
+    color: var(--au-orange-700);
+    font-weight: var(--au-medium);
+  }
 
-.say-snippet-placeholder__button {
-  margin: 0;
-  padding: 0;
+  .say-snippet-placeholder__button {
+    margin: 0;
+    padding: 0;
+  }
 }
 
 .ProseMirror-selectednode > .say-snippet-placeholder {

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -304,7 +304,7 @@ export default class BesluitSampleController extends Controller {
         },
       },
       snippet: {
-        endpoint: 'https://dev.reglementairebijlagen.lblod.info/raw-sparql',
+        endpoint: 'https://dev.reglementairebijlagen.lblod.info/sparql',
       },
     };
   }

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -113,6 +113,14 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/mandatee-table-plugin/node';
 import { MANDATEE_TABLE_SAMPLE_CONFIG } from '../config/mandatee-table-sample-config';
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
+import {
+  snippetPlaceholder,
+  snippetPlaceholderView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet-placeholder';
+import {
+  snippet,
+  snippetView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet';
 
 export default class BesluitSampleController extends Controller {
   DebugInfo = DebugInfo;
@@ -184,6 +192,8 @@ export default class BesluitSampleController extends Controller {
         invisible_rdfa: invisibleRdfaWithConfig({ rdfaAware: true }),
         inline_rdfa: inlineRdfaWithConfig({ rdfaAware: true }),
         link: link(this.config.link),
+        snippet_placeholder: snippetPlaceholder(this.config.snippet),
+        snippet: snippet(this.config.snippet),
       },
       marks: {
         em,
@@ -293,6 +303,9 @@ export default class BesluitSampleController extends Controller {
           dateRightNow: new Date().toLocaleString(),
         },
       },
+      snippet: {
+        endpoint: 'https://dev.reglementairebijlagen.lblod.info/raw-sparql',
+      },
     };
   }
 
@@ -323,6 +336,10 @@ export default class BesluitSampleController extends Controller {
       structure: structureView(controller),
       mandatee_table: mandateeTableView(controller),
       autofilled_variable: autofilledVariableView(controller),
+      snippet_placeholder: snippetPlaceholderView(this.config.snippet)(
+        controller,
+      ),
+      snippet: snippetView(this.config.snippet)(controller),
     } satisfies Record<string, SayNodeViewConstructor>;
   };
   @tracked plugins: Plugin[] = [

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -104,6 +104,7 @@ import {
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
 import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
+import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
 import SnippetListSelect from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-list-select';
 import {
   CitationPluginConfig,
@@ -126,6 +127,7 @@ import recreateUuidsOnPaste from '@lblod/ember-rdfa-editor-lblod-plugins/plugins
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
 
 export default class RegulatoryStatementSampleController extends Controller {
+  SnippetInsert = SnippetInsertRdfaComponent;
   SnippetListSelect = SnippetListSelect;
   DebugInfo = DebugInfo;
   AttributeEditor = AttributeEditor;
@@ -193,7 +195,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       invisible_rdfa: invisibleRdfaWithConfig({ rdfaAware: true }),
       inline_rdfa: inlineRdfaWithConfig({ rdfaAware: true }),
       link: link(this.config.link),
-      snippet_placeholder: snippetPlaceholder(this.config.snippetPlaceholder),
+      snippet_placeholder: snippetPlaceholder(this.config.snippet),
       snippet: snippet(this.config.snippet),
     },
     marks: {
@@ -309,10 +311,7 @@ export default class RegulatoryStatementSampleController extends Controller {
         allowedContent:
           'document_title? ((block|chapter)+|(block|title)+|(block|article)+)',
         endpoint: 'https://dev.reglementairebijlagen.lblod.info/raw-sparql',
-      },
-      snippetPlaceholder: {
-        endpoint: 'https://dev.reglementairebijlagen.lblod.info/raw-sparql',
-        showInsertButton: true,
+        hidePlaceholderInsertButton: true,
       },
       worship: {
         endpoint: 'https://data.lblod.info/sparql',

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -104,7 +104,6 @@ import {
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
 import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
-import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
 import SnippetListSelect from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-list-select';
 import {
   CitationPluginConfig,
@@ -127,7 +126,6 @@ import recreateUuidsOnPaste from '@lblod/ember-rdfa-editor-lblod-plugins/plugins
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
 
 export default class RegulatoryStatementSampleController extends Controller {
-  SnippetInsert = SnippetInsertRdfaComponent;
   SnippetListSelect = SnippetListSelect;
   DebugInfo = DebugInfo;
   AttributeEditor = AttributeEditor;
@@ -195,7 +193,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       invisible_rdfa: invisibleRdfaWithConfig({ rdfaAware: true }),
       inline_rdfa: inlineRdfaWithConfig({ rdfaAware: true }),
       link: link(this.config.link),
-      snippet_placeholder: snippetPlaceholder,
+      snippet_placeholder: snippetPlaceholder(this.config.snippetPlaceholder),
       snippet: snippet(this.config.snippet),
     },
     marks: {
@@ -312,6 +310,10 @@ export default class RegulatoryStatementSampleController extends Controller {
           'document_title? ((block|chapter)+|(block|title)+|(block|article)+)',
         endpoint: 'https://dev.reglementairebijlagen.lblod.info/raw-sparql',
       },
+      snippetPlaceholder: {
+        endpoint: 'https://dev.reglementairebijlagen.lblod.info/raw-sparql',
+        showInsertButton: true,
+      },
       worship: {
         endpoint: 'https://data.lblod.info/sparql',
       },
@@ -356,7 +358,9 @@ export default class RegulatoryStatementSampleController extends Controller {
       templateComment: templateCommentView(controller),
       address: addressView(controller),
       inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
-      snippet_placeholder: snippetPlaceholderView(controller),
+      snippet_placeholder: snippetPlaceholderView(this.config.snippet)(
+        controller,
+      ),
       snippet: snippetView(this.config.snippet)(controller),
       autofilled_variable: autofilledVariableView(controller),
     };

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -310,7 +310,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       snippet: {
         allowedContent:
           'document_title? ((block|chapter)+|(block|title)+|(block|article)+)',
-        endpoint: 'https://dev.reglementairebijlagen.lblod.info/raw-sparql',
+        endpoint: 'https://dev.reglementairebijlagen.lblod.info/sparql',
         hidePlaceholderInsertButton: true,
       },
       worship: {

--- a/tests/dummy/app/controllers/snippet-edit-sample.ts
+++ b/tests/dummy/app/controllers/snippet-edit-sample.ts
@@ -92,7 +92,6 @@ import {
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
 import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
-import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
 import SnippetListSelect from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-list-select';
 import {
   CitationPluginConfig,
@@ -113,7 +112,6 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet';
 
 export default class RegulatoryStatementSampleController extends Controller {
-  SnippetInsert = SnippetInsertRdfaComponent;
   SnippetListSelect = SnippetListSelect;
   DebugInfo = DebugInfo;
   AttributeEditor = AttributeEditor;
@@ -186,7 +184,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       table_of_contents: table_of_contents(this.config.tableOfContents),
       invisible_rdfa: invisibleRdfaWithConfig({ rdfaAware: true }),
       link: link(this.config.link),
-      snippet_placeholder: snippetPlaceholder,
+      snippet_placeholder: snippetPlaceholder(this.config.snippetPlaceholder),
       snippet: snippet(this.config.snippet),
     },
     marks: {
@@ -292,6 +290,10 @@ export default class RegulatoryStatementSampleController extends Controller {
       snippet: {
         endpoint: 'https://dev.reglementairebijlagen.lblod.info/sparql',
       },
+      snippetPlaceholder: {
+        endpoint: 'https://dev.reglementairebijlagen.lblod.info/raw-sparql',
+        showInsertButton: true,
+      },
       worship: {
         endpoint: 'https://data.lblod.info/sparql',
       },
@@ -333,7 +335,9 @@ export default class RegulatoryStatementSampleController extends Controller {
       person_variable: personVariableView(controller),
       inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
       oslo_location: osloLocationView(this.config.location)(controller),
-      snippet_placeholder: snippetPlaceholderView(controller),
+      snippet_placeholder: snippetPlaceholderView(this.config.snippet)(
+        controller,
+      ),
       snippet: snippetView(this.config.snippet)(controller),
     };
   };

--- a/tests/dummy/app/controllers/snippet-edit-sample.ts
+++ b/tests/dummy/app/controllers/snippet-edit-sample.ts
@@ -184,7 +184,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       table_of_contents: table_of_contents(this.config.tableOfContents),
       invisible_rdfa: invisibleRdfaWithConfig({ rdfaAware: true }),
       link: link(this.config.link),
-      snippet_placeholder: snippetPlaceholder(this.config.snippetPlaceholder),
+      snippet_placeholder: snippetPlaceholder(this.config.snippet),
       snippet: snippet(this.config.snippet),
     },
     marks: {
@@ -288,11 +288,7 @@ export default class RegulatoryStatementSampleController extends Controller {
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
       },
       snippet: {
-        endpoint: 'https://dev.reglementairebijlagen.lblod.info/sparql',
-      },
-      snippetPlaceholder: {
         endpoint: 'https://dev.reglementairebijlagen.lblod.info/raw-sparql',
-        showInsertButton: true,
       },
       worship: {
         endpoint: 'https://data.lblod.info/sparql',

--- a/tests/dummy/app/controllers/snippet-edit-sample.ts
+++ b/tests/dummy/app/controllers/snippet-edit-sample.ts
@@ -288,7 +288,7 @@ export default class RegulatoryStatementSampleController extends Controller {
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
       },
       snippet: {
-        endpoint: 'https://dev.reglementairebijlagen.lblod.info/raw-sparql',
+        endpoint: 'https://dev.reglementairebijlagen.lblod.info/sparql',
       },
       worship: {
         endpoint: 'https://data.lblod.info/sparql',

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -93,6 +93,13 @@
                   @controller={{this.controller}}
                   @options={{this.config.structures}}
                 />
+                {{#if this.activeNode}}
+                  <this.SnippetInsert
+                    @controller={{this.controller}}
+                    @config={{this.config.snippet}}
+                    @node={{this.activeNode}}
+                  />
+                {{/if}}
                 <TemplateCommentsPlugin::Insert
                   @controller={{this.controller}}
                 />

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -93,13 +93,6 @@
                   @controller={{this.controller}}
                   @options={{this.config.structures}}
                 />
-                {{#if this.activeNode}}
-                  <this.SnippetInsert
-                    @controller={{this.controller}}
-                    @config={{this.config.snippet}}
-                    @node={{this.activeNode}}
-                  />
-                {{/if}}
                 <TemplateCommentsPlugin::Insert
                   @controller={{this.controller}}
                 />

--- a/tests/dummy/app/templates/snippet-edit-sample.hbs
+++ b/tests/dummy/app/templates/snippet-edit-sample.hbs
@@ -135,13 +135,6 @@
                 <VariablePlugin::Address::Insert
                   @controller={{this.controller}}
                 />
-                {{#if this.activeNode}}
-                  <this.SnippetInsert
-                    @controller={{this.controller}}
-                    @config={{this.config.snippet}}
-                    @node={{this.activeNode}}
-                  />
-                {{/if}}
                 <SnippetPlugin::SnippetInsertPlaceholder
                   @controller={{this.controller}}
                   @config={{this.config.snippet}}

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -304,7 +304,7 @@ snippet-plugin:
     button: Select the desired snippet
     active-lists: 'Active lists:'
   modal:
-    title: Choose a snippet
+    title: Choose a snippet from {snippetListNames}
     preview-button:
       title: Show snippet preview
     select-button:

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -301,7 +301,7 @@ snippet-plugin:
   placeholder:
     title-single: Snippet from the list "{listName}"
     title-multiple: Snippet from multiple lists
-    text: Select this then insert the desired snippet
+    button: Select the desired snippet
     active-lists: 'Active lists:'
   modal:
     title: Choose a snippet

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -303,7 +303,7 @@ snippet-plugin:
     button: Selecteer het gewenste fragment
     active-lists: 'Actieve lijsten:'
   modal:
-    title: Kies een fragment
+    title: Kies een fragment uit {snippetListNames}
     preview-button:
       title: Preview van fragment tonen
     select-button:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -300,7 +300,7 @@ snippet-plugin:
   placeholder:
     title-single: Fragment uit de lijst "{listName}"
     title-multiple: Fragment uit meerdere lijsten
-    text: Selecteer dit en voeg het gewenste fragment in
+    button: Selecteer het gewenste fragment
     active-lists: 'Actieve lijsten:'
   modal:
     title: Kies een fragment


### PR DESCRIPTION
### Overview
Continued a little of the refactoring from replacing the snippet placeholder, so that the snippet placeholder component is now used inside a snippet component. This means that I could re-use the insert logic from the snippet buttons and if we wanted in the future we could include buttons in the same style as for inserted snippets. Since I was not including buttons for now, I was able to use @elpoelma 's redesign implementation work almost untouched.

For consistency, I move the snippet list ids information to RDFa for inserted snippet nodes.

##### connected issues and PRs:
Builds on https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/495
Jira ticket: https://binnenland.atlassian.net/browse/GN-5117

### Setup
N/A

### How to test/reproduce
Insert, replace, delete snippets and snippet placeholders with different configurations and make sure everything works as expected. The expected interactivity is different depending on which sample page:
- Besluit: It's only possible to insert snippets using the in-node insert button. placeholders cannot be inserted
- Reg statement: The in-node insert snippet button is hidden, but the sidebar button remains.
- Snippet edit: The in-node snippet insert button is shown, the sidebar button is not there. Placeholders can be inserted.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
