### PR TITLE
Instantiate template URIs in snippets when inserting

### DIFF
--- a/.changeset/giant-ladybugs-agree.md
+++ b/.changeset/giant-ladybugs-agree.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Correctly instantiate placeholder URIs in snippets when inserting

--- a/addon/plugins/snippet-plugin/nodes/snippet.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import templateUuidInstantiator from '@lblod/template-uuid-instantiator';
 import {
   type Attrs,
   getRdfaAttrs,
@@ -88,6 +89,8 @@ export function createSnippet({
       replacedContent = replacedContent.replaceAll(imported, linked);
     }
   }
+  // Instantiate URIs of the form --ref-algo-123
+  replacedContent = templateUuidInstantiator(replacedContent);
   // Create the new node
   const parser = ProseParser.fromSchema(schema);
   const contentAsNode = htmlToDoc(replacedContent, {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@curvenote/prosemirror-utils": "^1.0.5",
     "@embroider/macros": "^1.16.5",
     "@lblod/marawa": "0.8.0-beta.6",
+    "@lblod/template-uuid-instantiator": "^1.0.2",
     "@rdfjs/data-model": "^2.0.2",
     "@rdfjs/dataset": "^2.0.2",
     "@rdfjs/parser-n3": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@lblod/marawa':
         specifier: 0.8.0-beta.6
         version: 0.8.0-beta.6
+      '@lblod/template-uuid-instantiator':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@rdfjs/data-model':
         specifier: ^2.0.2
         version: 2.0.2
@@ -1617,6 +1620,9 @@ packages:
 
   '@lblod/marawa@0.8.0-beta.6':
     resolution: {integrity: sha512-BW3yCpeQlk9EPnQAEQnM9uViA8RC5DkuoiaPJzbuhMcLvKHfI4cjc6dTg9i8qAijbL/xObmQ/Aexko2Xcj9ktw==}
+
+  '@lblod/template-uuid-instantiator@1.0.2':
+    resolution: {integrity: sha512-gw6nJnWCcHZYOG/Z/5Br8Txjqi5qV4S95ApoBpxeJKFzFyXMpl1Gh6LOKeOtuJerLp4NtZ71uVTJ3LzrrS2bdQ==}
 
   '@lezer/common@1.2.1':
     resolution: {integrity: sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==}
@@ -4968,7 +4974,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -10803,6 +10809,10 @@ snapshots:
     dependencies:
       '@rdfjs/data-model': 1.3.4
       '@rdfjs/dataset': 1.1.1
+
+  '@lblod/template-uuid-instantiator@1.0.2':
+    dependencies:
+      uuid: 9.0.1
 
   '@lezer/common@1.2.1': {}
 

--- a/types/lblod/template-uuid-instantiator.d.ts
+++ b/types/lblod/template-uuid-instantiator.d.ts
@@ -1,0 +1,3 @@
+declare module '@lblod/template-uuid-instantiator' {
+  export default function (content: string): string;
+}


### PR DESCRIPTION
### Overview
I found that there were article URIs in GN documents of the form `--ref-uuid4-123-456`. These are from 2 sources, this one is articles within snippets that were not being instantiated correctly. This leads to all snippet users having the same URI for each article within a snippet. There will be another part in GN to insert more normal URIs for new articles, but this is less problematic.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5206

### Setup
N/A

### How to test/reproduce
Insert a snippet including an article and look at the URI for the `besluit:Artikel`.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
