### PR TITLE
Fix bug when setting 31/12/.. date

### DIFF
--- a/.changeset/swift-fireants-dress.md
+++ b/.changeset/swift-fireants-dress.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Fix bug when setting a date with a day bigger than the number of days in the current month

--- a/addon/components/variable-plugin/date/date-time-picker.ts
+++ b/addon/components/variable-plugin/date/date-time-picker.ts
@@ -51,9 +51,9 @@ export default class DateTimePickerComponent extends Component<Args> {
         this.date = new Date();
         this.date.setHours(0, 0, 0, 0);
       }
-      this.date.setDate(date.getDate());
-      this.date.setMonth(date.getMonth());
       this.date.setFullYear(date.getFullYear());
+      this.date.setMonth(date.getMonth());
+      this.date.setDate(date.getDate());
       this.args.onChange(this.date);
     }
   }


### PR DESCRIPTION
### Overview
The date was constructed from the date of today, and then set the day, month and year in that order, if you set the day to a bigger number than the days of the month the day set was wrong, I changed it to do first the year then the month and last the day so this error is no longer possible

##### connected issues and PRs:
GN-5182


### Setup
None

### How to test/reproduce
Insert a date variable then change the date to the 31 of december and notice it correctly works

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
