### PR TITLE
Feat/add snippet list names to modal title

### DIFF
--- a/.changeset/tough-pugs-shave.md
+++ b/.changeset/tough-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add snippet list names to the modal title

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -253,6 +253,7 @@ export default class SnippetNode extends Component<Signature> {
       @config={{this.node.attrs.config}}
       @onInsert={{this.onInsert}}
       @snippetListIds={{getSnippetListIdsFromNode this.node}}
+      @snippetListNames={{this.node.attrs.snippetListNames}}
     />
   </template>
 }

--- a/addon/components/snippet-plugin/search-modal.hbs
+++ b/addon/components/snippet-plugin/search-modal.hbs
@@ -3,7 +3,10 @@
   class='snippet-modal'
   @modalOpen={{@open}}
   @closeModal={{this.closeModal}}
-  @title={{t 'snippet-plugin.modal.title' snippetListNames=this.snippetListNames}}
+  @title={{t
+    'snippet-plugin.modal.title'
+    snippetListNames=this.snippetListNames
+  }}
   @size='large'
   @padding='none'
   as |modal|

--- a/addon/components/snippet-plugin/search-modal.hbs
+++ b/addon/components/snippet-plugin/search-modal.hbs
@@ -3,7 +3,7 @@
   class='snippet-modal'
   @modalOpen={{@open}}
   @closeModal={{this.closeModal}}
-  @title={{t 'snippet-plugin.modal.title'}}
+  @title={{t 'snippet-plugin.modal.title' snippetListNames=this.snippetListNames}}
   @size='large'
   @padding='none'
   as |modal|

--- a/addon/components/snippet-plugin/search-modal.ts
+++ b/addon/components/snippet-plugin/search-modal.ts
@@ -12,6 +12,7 @@ import { SnippetPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plug
 interface Args {
   config: SnippetPluginConfig;
   snippetListIds: string[] | undefined;
+  snippetListNames: string[] | undefined;
   closeModal: () => void;
   open: boolean;
   onInsert: (content: string, title: string) => void;
@@ -35,6 +36,10 @@ export default class SnippetPluginSearchModalComponent extends Component<Args> {
 
   get searchText() {
     return this.inputSearchText;
+  }
+
+  get snippetListNames() {
+    return this.args.snippetListNames?.join(', ');
   }
 
   @action

--- a/addon/components/snippet-plugin/search-modal.ts
+++ b/addon/components/snippet-plugin/search-modal.ts
@@ -39,7 +39,7 @@ export default class SnippetPluginSearchModalComponent extends Component<Args> {
   }
 
   get snippetListNames() {
-    return this.args.snippetListNames?.join(', ');
+    return this.args.snippetListNames?.map((name) => `"${name}"`).join(', ');
   }
 
   @action

--- a/addon/components/snippet-plugin/snippet-insert.gts
+++ b/addon/components/snippet-plugin/snippet-insert.gts
@@ -89,6 +89,7 @@ export default class SnippetInsertComponent extends Component<Sig> {
       @config={{@config}}
       @onInsert={{this.onInsert}}
       @snippetListIds={{@listProperties.listIds}}
+      @snippetListNames={{@listProperties.names}}
     />
   </template>
 }

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -304,7 +304,7 @@ snippet-plugin:
     button: Select the desired snippet
     active-lists: 'Active lists:'
   modal:
-    title: Choose a snippet
+    title: Choose a snippet from {snippetListNames}
     preview-button:
       title: Show snippet preview
     select-button:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -303,7 +303,7 @@ snippet-plugin:
     button: Selecteer het gewenste fragment
     active-lists: 'Actieve lijsten:'
   modal:
-    title: Kies een fragment
+    title: Kies een fragment uit {snippetListNames}
     preview-button:
       title: Preview van fragment tonen
     select-button:


### PR DESCRIPTION
### Overview
Add snippet names to the modal title

##### connected issues and PRs:
GN-5190


### Setup
None

### How to test/reproduce
Insert a snippet placeholder with one list and other with several lists, open the modal to insert a snippet and check that the list names appear on the modal title

### Challenges/uncertainties
Need to merge the snippet redesign first



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
