### PR TITLE
GN-5209: extend/generalize 'nodes' config option to citation plugin

### DIFF
--- a/.changeset/purple-bobcats-lick.md
+++ b/.changeset/purple-bobcats-lick.md
@@ -1,0 +1,16 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Extension of configuration options of `citation-plugin`.
+The `CitationPluginNodeConfig` is extended to allow for a `activeInNode` condition.
+This allows you to specify a condition which an active/context node needs to satisfy.
+```ts
+interface CitationPluginNodeConditionConfig {
+  type: 'nodes';
+  regex?: RegExp;
+
+  activeInNode(node: PNode, state?: EditorState): boolean;
+}
+```
+The previously expected `activeInNodeTypes` option is marked as deprecated and will be removed in a future release.

--- a/README.md
+++ b/README.md
@@ -335,9 +335,10 @@ Make `this.citationPlugin` a tracked reference to the plugin created with the fu
 
 Configuration:
 
-- type: it can be 'nodes' or 'ranges' if nodes is selected you are expected to pass the `activeInNodeTypes` function, otherwise you should pass the `activeInRanges` function
-- activeInNodeTypes: it's a function that gets the prosemirror schema and the state of the actual instance of the editor and returns a `Set` of nodetypes where the plugin should be active
-- activeInRanges: it's a function that gets the state of the actual instance of the editor and returns an array of ranges for the plugin to be active in, for example `[[0,50], [70,100]]`
+- type: it can either be 'nodes', or 'ranges'
+  * if 'nodes' is selected, you are expected to pass the `activeInNode` function. It's a function which expects an instance of a prosemirror node and returns whether it should be active in that node. The previously expected `activeInNodeTypes` is marked as deprecated and will be removed in a future release.
+  * if 'ranges' is selected, you are expected to pass the `activeInRanges` function. It's a function that gets the state of the actual instance of the editor and returns an array of ranges for the plugin to be active in, for example `[[0,50], [70,100]]`
+
 - regex: you can provide your custom regex to detect citations, if not the default one will be used
 
 A common usecase is to have the plugin active in the entire document. Here's how to do that using each configuration type:
@@ -347,9 +348,8 @@ import { citationPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/c
 
 const configA = {
   type: 'nodes',
-  activeInNodeTypes(schema) {
-    // the root node of the document should always have the doc type
-    return new Set([schema.nodes.doc]);
+  activeInNode(node, state) {
+    return node.type === state.schema.nodes.doc;
   },
 };
 

--- a/README.md
+++ b/README.md
@@ -335,9 +335,10 @@ Make `this.citationPlugin` a tracked reference to the plugin created with the fu
 
 Configuration:
 
-- type: it can either be 'nodes', or 'ranges'
+- type (optional): it can either be 'nodes', or 'ranges'
   * if 'nodes' is selected, you are expected to pass the `activeInNode` function. It's a function which expects an instance of a prosemirror node and returns whether it should be active in that node. The previously expected `activeInNodeTypes` is marked as deprecated and will be removed in a future release.
   * if 'ranges' is selected, you are expected to pass the `activeInRanges` function. It's a function that gets the state of the actual instance of the editor and returns an array of ranges for the plugin to be active in, for example `[[0,50], [70,100]]`
+  * if no type is provided, the citation plugin will be activated document-wide
 
 - regex: you can provide your custom regex to detect citations, if not the default one will be used
 

--- a/addon/components/citation-plugin/citation-insert.ts
+++ b/addon/components/citation-plugin/citation-insert.ts
@@ -64,6 +64,10 @@ export default class EditorPluginsCitationInsertComponent extends Component<Args
     }
     const { selection } = this.controller.mainEditorState;
     const config = this.config;
+    if (!('type' in config)) {
+      // Enable plugin document wide
+      return false;
+    }
     if (config.type === 'ranges') {
       const ranges = config.activeInRanges(this.controller.mainEditorState);
       for (const range of ranges) {

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -4,12 +4,7 @@ import { tracked } from 'tracked-built-ins';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 
-import {
-  NodeType,
-  Plugin,
-  SayController,
-  Schema,
-} from '@lblod/ember-rdfa-editor';
+import { Plugin, PNode, SayController, Schema } from '@lblod/ember-rdfa-editor';
 import {
   em,
   strikethrough,
@@ -114,6 +109,8 @@ import {
 import { MANDATEE_TABLE_SAMPLE_CONFIG } from '../config/mandatee-table-sample-config';
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
 import { BlockRDFaView } from '@lblod/ember-rdfa-editor/nodes/block-rdfa';
+import { isRdfaAttrs } from '@lblod/ember-rdfa-editor/core/schema';
+import { BESLUIT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 
 export default class BesluitSampleController extends Controller {
   DebugInfo = DebugInfo;
@@ -234,8 +231,15 @@ export default class BesluitSampleController extends Controller {
     return {
       citation: {
         type: 'nodes',
-        activeInNodeTypes(schema: Schema): Set<NodeType> {
-          return new Set<NodeType>([schema.nodes.motivering]);
+        activeInNode(node: PNode): boolean {
+          const { attrs } = node;
+          if (!isRdfaAttrs(attrs)) {
+            return false;
+          }
+          const match = attrs.backlinks.find((bl) =>
+            BESLUIT('motivering').matches(bl.predicate),
+          );
+          return Boolean(match);
         },
         endpoint: 'https://codex.opendata.api.vlaanderen.be:8888/sparql',
         decisionsEndpoint:

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import applyDevTools from 'prosemirror-dev-tools';
 import { action } from '@ember/object';
 import { tracked } from 'tracked-built-ins';
-import { SayController } from '@lblod/ember-rdfa-editor';
+import { EditorState, PNode, SayController } from '@lblod/ember-rdfa-editor';
 import { Schema, Plugin } from '@lblod/ember-rdfa-editor';
 import {
   em,
@@ -321,10 +321,10 @@ export default class RegulatoryStatementSampleController extends Controller {
       },
       citation: {
         type: 'nodes',
-        activeInNodeTypes(schema: Schema) {
-          return new Set([schema.nodes.doc]);
+        activeInNode(node: PNode, state: EditorState) {
+          return node.type === state.schema.nodes.doc;
         },
-        endpoint: '/codex/sparql',
+        endpoint: 'https://codex.opendata.api.vlaanderen.be:8888/sparql',
       } as CitationPluginConfig,
       autofilledVariable: {
         autofilledValues: {},

--- a/tests/dummy/app/controllers/snippet-edit-sample.ts
+++ b/tests/dummy/app/controllers/snippet-edit-sample.ts
@@ -3,7 +3,7 @@ import applyDevTools from 'prosemirror-dev-tools';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from 'tracked-built-ins';
-import { SayController } from '@lblod/ember-rdfa-editor';
+import { EditorState, PNode, SayController } from '@lblod/ember-rdfa-editor';
 import { Schema, Plugin } from '@lblod/ember-rdfa-editor';
 import {
   em,
@@ -301,10 +301,10 @@ export default class RegulatoryStatementSampleController extends Controller {
       },
       citation: {
         type: 'nodes',
-        activeInNodeTypes(schema: Schema) {
-          return new Set([schema.nodes.doc]);
+        activeInNode(node: PNode, state: EditorState) {
+          return node.type === state.schema.nodes.doc;
         },
-        endpoint: '/codex/sparql',
+        endpoint: 'https://codex.opendata.api.vlaanderen.be:8888/sparql',
       } as CitationPluginConfig,
     };
   }


### PR DESCRIPTION
### Overview
This PR extends/generalizes the 'nodes' config option of the citation plugin.
It now allows you to specify a condition which an active/context node needs to satisfy.
```ts
interface CitationPluginNodeConditionConfig {
  type: 'nodes';
  regex?: RegExp;

  activeInNode(node: PNode, state?: EditorState): boolean;
}
```
The previously expected `activeInNodeTypes` option is marked as deprecated and will be removed in a future release.
Currently, we were still using the  `activeInNodeTypes` option in the dummy app and GN. This failed however, as we do not use the 'motivering' node-spec/type anymore.

##### connected issues and PRs:
[GN-5209](https://binnenland.atlassian.net/browse/GN-5209)
https://github.com/lblod/frontend-gelinkt-notuleren/pull/763

### Setup
None

### How to test/reproduce
- Start the dummy app
- Open the decision sample page
- Insert a decision
- Ensure that you can insert a citation in the 'motivering' block.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
