### PR TITLE
fix(decision-article): remove unnecessary css placeholder

### DIFF
--- a/.changeset/smart-pigs-fly.md
+++ b/.changeset/smart-pigs-fly.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Decision article structures: remove unnecessary css placeholder from content section

--- a/addon/components/structure-plugin/_private/structure.gts
+++ b/addon/components/structure-plugin/_private/structure.gts
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import { SayView, Schema } from '@lblod/ember-rdfa-editor';
 import { redacted } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/confidentiality-plugin';
 import NestedProsemirror from '@lblod/ember-rdfa-editor-lblod-plugins/utils/nested-prosemirror';
-import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 import {
@@ -73,20 +72,6 @@ export default class Structure extends Component<Sig> {
 
   get node() {
     return this.args.node;
-  }
-
-  get isEmpty() {
-    if (this.node.childCount > 1) {
-      return false;
-    }
-    const firstChild = unwrap(this.node.firstChild);
-    if (!firstChild.isTextblock) {
-      return false;
-    }
-    if (firstChild.childCount > 0) {
-      return false;
-    }
-    return true;
   }
 
   get tag() {
@@ -188,7 +173,7 @@ export default class Structure extends Component<Sig> {
           </Tag>
         {{/let}}
       </div>
-      <div class='say-structure__content {{if this.isEmpty "say-empty" ""}}'>
+      <div class='say-structure__content'>
         {{yield}}
       </div>
     </div>

--- a/app/styles/structure-plugin.scss
+++ b/app/styles/structure-plugin.scss
@@ -46,18 +46,6 @@
   }
 }
 
-.say-structure__content.say-empty {
-  [data-ember-node-content] {
-    p::before {
-      color: var(--au-gray-400);
-      content: 'Fill in content...';
-      float: left;
-      height: 0;
-      pointer-events: none;
-    }
-  }
-}
-
 .ember-node.say-active:has(> .say-structure) {
   outline: none;
 }


### PR DESCRIPTION
### Overview
This PR removes an unnecessary css rule which showed an alternative type of placeholder in decision articles.

**Before**

https://github.com/user-attachments/assets/49f753eb-7f5f-4c0d-b91d-4bd1d73b2899

**After**
![image](https://github.com/user-attachments/assets/839fa38f-b23a-4e0e-8e98-a6dc20a4d3bf)


##### connected issues and PRs:
None

### How to test/reproduce
- Start the dummy app
- Insert a decision with an article
- Remove the placeholder within the article
- Ensure that no css-placeholder is shown


### Challenges/uncertainties
This was probably a remnant of the article-structures POC where I tried out css placeholders.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
