### PR TITLE
GN-5187: add clearer warning to mandatee table on losing changes

### DIFF
--- a/.changeset/chilled-cooks-juggle.md
+++ b/.changeset/chilled-cooks-juggle.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Mandatee table plugin: ensure synchronisation warning shown in mandatee tables is clearer/more explicit

--- a/addon/components/mandatee-table-plugin/node.gts
+++ b/addon/components/mandatee-table-plugin/node.gts
@@ -1,4 +1,6 @@
+import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
 import AuIcon from '@appuniversum/ember-appuniversum/components/au-icon';
+import { AlertTriangleIcon } from '@appuniversum/ember-appuniversum/components/icons/alert-triangle';
 
 import { UserIcon } from '@appuniversum/ember-appuniversum/components/icons/user';
 import { service } from '@ember/service';
@@ -45,12 +47,19 @@ export default class MandateeTableNode extends Component<Sig> {
         />
         <div>
           <h6 class='say-mandatee-table__title'>{{this.title}}</h6>
-          <p class='say-mandatee-table__warning'>
-            {{this.warning}}
-          </p>
         </div>
       </div>
-      <div class='say-mandatee-table-content'>{{yield}}</div>
+      <div class='say-mandatee-table-content'>
+        <AuAlert
+          class='say-mandatee-table__warning'
+          @icon={{AlertTriangleIcon}}
+          @skin='warning'
+          @size='small'
+        >
+          {{this.warning}}
+        </AuAlert>
+        {{yield}}
+      </div>
     </div>
   </template>
 }

--- a/app/styles/mandatee-table-plugin.scss
+++ b/app/styles/mandatee-table-plugin.scss
@@ -9,12 +9,15 @@
     cursor: default;
   }
 
-  p.say-mandatee-table__warning {
-    margin-top: 0;
+  .say-mandatee-table__warning {
+    .au-c-alert__content {
+      margin-top: 0;
+    }
   }
 
   .say-mandatee-table-content {
     padding: 1.2rem;
+    margin-top: 0;
   }
 
   .say-mandatee-table__title {

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -548,5 +548,5 @@ mandatee-table-plugin:
       label: Title
       placeholder: Title
   node:
-    warning: Information which you enter below may be removed upon
+    warning: Information which you enter below will be removed upon
       synchronisation of the inauguration meeting.

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -545,5 +545,4 @@ mandatee-table-plugin:
       label: Titel
       placeholder: Titel
   node:
-    warning: Informatie die u hieronder manueel ingeeft, wordt mogelijks
-      verwijderd bij synchronisatie van de installatievergadering.
+    warning: Informatie die u hieronder manueel ingeeft, wordt verwijderd bij synchronisatie van de installatievergadering.


### PR DESCRIPTION
### Overview
This PR includes two adjustments to the synchronisation warning shown in mandatee table nodes:
- The message is now clearer/more correct
- The message is now shown in a yellow `AuAlert` component

##### connected issues and PRs:
[GN-5187](https://binnenland.atlassian.net/browse/GN-5187)

### Setup
None

### How to test/reproduce
- Start the dummy app
- Open the 'Besluit sample' page
- Insert a mandatee table
- The sync warning should be clearer in terms of message as well as visibility

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
