### PR TITLE
adapt irgn plugin with new model

### DIFF
--- a/addon/models/sign.ts
+++ b/addon/models/sign.ts
@@ -17,20 +17,15 @@ export default class Sign {
       unwrap(binding['imageBaseUrl']?.value),
     );
 
-    const uri = unwrap(binding['uri']?.value);
-    const order = unwrap(binding['order']?.value);
+    const uri = unwrap(binding['relatedTrafficSignConcepts']?.value);
+    // const order = unwrap(binding['order']?.value);
 
     const classifications = binding['classifications']?.value.split('|') ?? [];
     const zonality = binding['zonality']?.value;
-    return new Sign(code, image, classifications, uri, order, zonality);
+    return new Sign(code, image, classifications, uri, '', zonality);
   }
 
-  static processImage(url: string, imageBaseUrl: string) {
-    const isAbsoluteRegex = new RegExp('^(?:[a-z]+:)?//', 'i');
-    if (isAbsoluteRegex.test(url)) {
-      return url;
-    } else {
-      return `${imageBaseUrl}${url}`;
-    }
+  static processImage(imageId: string, imageBaseUrl: string) {
+    return `${imageBaseUrl}/files/${imageId}/download`;
   }
 }

--- a/addon/plugins/roadsign-regulation-plugin/utils/fetchData.ts
+++ b/addon/plugins/roadsign-regulation-plugin/utils/fetchData.ts
@@ -23,12 +23,12 @@ function buildFilters({
   if (codes) {
     filters.push(`
         ${codes
-          .map(
-            (uri) => `
+        .map(
+          (uri) => `
               <${uri}> mobiliteit:heeftMaatregelconcept ?uri.
             `,
-          )
-          .join(' ')}
+        )
+        .join(' ')}
     `);
   }
   if (category) {
@@ -58,11 +58,10 @@ export function generateMeasuresQuery({
     pagination = `LIMIT 10 OFFSET ${pageStart}`;
   }
   const query = `
-SELECT ${
-    count
+SELECT ${count
       ? '(COUNT(DISTINCT(?template)) AS ?count)'
       : '?uri ?label ?basicTemplate ?annotatedTemplate ?zonality ?temporal'
-  }
+    }
 WHERE {
     ?uri a mobiliteit:Mobiliteitmaatregelconcept;
          skos:prefLabel ?label;
@@ -77,17 +76,16 @@ WHERE {
 
     ${filters.join('\n')}
   OPTIONAL {
-    ?uri ext:temporal ?temporal.
+    ?uri mobiliteit:variabeleSignalisatie ?temporal.
   }
   OPTIONAL {
-    ?signUri org:classification ?signClassification.
+    ?signUri dct:type ?signClassification.
   }
 }
-${
-  count
-    ? ''
-    : `GROUP BY ?uri ?label ?template ?zonality\n ORDER BY ASC(strlen(str(?label))) ASC(?label)`
-}
+${count
+      ? ''
+      : `GROUP BY ?uri ?label ?template ?zonality\n ORDER BY ASC(strlen(str(?label))) ASC(?label)`
+    }
 ${pagination}
 `;
   return query;

--- a/addon/plugins/roadsign-regulation-plugin/utils/fetchData.ts
+++ b/addon/plugins/roadsign-regulation-plugin/utils/fetchData.ts
@@ -64,18 +64,16 @@ SELECT ${
       : '?uri ?label ?basicTemplate ?annotatedTemplate ?zonality ?temporal'
   }
 WHERE {
-    ?uri a lblodMobiliteit:TrafficMeasureConcept;
+    ?uri a mobiliteit:Mobiliteitmaatregelconcept;
          skos:prefLabel ?label;
          ext:zonality ?zonality;
-         ext:relation ?relationUri;
-         ext:template ?template.
+         mobiliteit:template ?template.
          ?template ext:annotated ?annotatedTemplate;
-                   ext:value ?basicTemplate.
-    ?relationUri a ext:MustUseRelation ;
-                 ext:concept ?signUri.
-    ?signUri a ?signType;
-             skos:prefLabel ?signCode.
-            
+                   prov:value ?basicTemplate.
+    ?signUri a mobiliteit:Verkeerstekenconcept;
+                mobiliteit:heeftMaatregelconcept ?uri;
+                skos:prefLabel ?signCode.
+
     ${filters.join('\n')}
   OPTIONAL {
     ?uri ext:temporal ?temporal.

--- a/addon/plugins/roadsign-regulation-plugin/utils/fetchData.ts
+++ b/addon/plugins/roadsign-regulation-plugin/utils/fetchData.ts
@@ -25,7 +25,7 @@ function buildFilters({
         ${codes
           .map(
             (uri) => `
-              ?uri ext:relation/ext:concept <${uri}>.
+              <${uri}> mobiliteit:heeftMaatregelconcept ?uri.
             `,
           )
           .join(' ')}

--- a/addon/plugins/roadsign-regulation-plugin/utils/fetchData.ts
+++ b/addon/plugins/roadsign-regulation-plugin/utils/fetchData.ts
@@ -70,7 +70,6 @@ WHERE {
          ?template ext:annotated ?annotatedTemplate;
                    prov:value ?basicTemplate.
     ?signUri a  ?signType;
-                dct:type ?signClassification;
                 mobiliteit:heeftMaatregelconcept ?uri;
                 skos:prefLabel ?signCode.
 
@@ -79,7 +78,7 @@ WHERE {
     ?uri mobiliteit:variabeleSignalisatie ?temporal.
   }
   OPTIONAL {
-    ?signUri dct:type ?signClassification.
+              ?signUri  dct:type ?signClassification.
   }
 }
 ${count

--- a/addon/plugins/roadsign-regulation-plugin/utils/fetchData.ts
+++ b/addon/plugins/roadsign-regulation-plugin/utils/fetchData.ts
@@ -70,7 +70,8 @@ WHERE {
          mobiliteit:template ?template.
          ?template ext:annotated ?annotatedTemplate;
                    prov:value ?basicTemplate.
-    ?signUri a mobiliteit:Verkeerstekenconcept;
+    ?signUri a  ?signType;
+                dct:type ?signClassification;
                 mobiliteit:heeftMaatregelconcept ?uri;
                 skos:prefLabel ?signCode.
 

--- a/addon/services/roadsign-registry.ts
+++ b/addon/services/roadsign-registry.ts
@@ -84,7 +84,7 @@ export default class RoadsignRegistryService extends Service {
       let signFilter = '';
       if (combinedSigns.length > 0) {
         signFilter = combinedSigns
-          .map((sign) => `?measure ext:relation/ext:concept <${sign}>.`)
+          .map((sign) => `<${sign}>  mobiliteit:heeftMaatregelconcept ?measure.`)
           .join('\n');
         signFilter += '\n';
         const commaSeperatedSigns = combinedSigns
@@ -95,7 +95,7 @@ export default class RoadsignRegistryService extends Service {
 
       const query = `
       SELECT DISTINCT ?signUri ?signCode WHERE {
-        ?measure ext:relation/ext:concept ?signUri.
+        ?signUri mobiliteit:heeftMaatregelconcept ?measure.
         ?signUri a ${type ? `<${type}>` : '?signType'};
           skos:prefLabel ?signCode;
           ext:valid "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.

--- a/addon/services/roadsign-registry.ts
+++ b/addon/services/roadsign-registry.ts
@@ -38,10 +38,9 @@ export default class RoadsignRegistryService extends Service {
     const result = await this.executeQuery.perform(
       `
     SELECT DISTINCT ?classificationUri ?classificationLabel  WHERE {
-      ?measure ext:relation/ext:concept ?signUri.
-      ?signUri org:classification ?classificationUri.
-      ?classificationUri a mobiliteit:Verkeersbordcategorie;
-        skos:prefLabel ?classificationLabel.
+      ?signUri mobiliteit:heeftMaatregelconcept ?measure.
+      ?signUri dct:type ?classificationUri.
+      ?classificationUri skos:prefLabel ?classificationLabel.
     }
 `,
       endpoint,
@@ -56,7 +55,6 @@ export default class RoadsignRegistryService extends Service {
   getInstructionsForMeasure = task(
     async (uri: string, endpoint: string): Promise<Instruction[]> => {
       if (this.instructions.has(uri)) {
-        console.log("instructions", this.instructions);
         return unwrap(this.instructions.get(uri));
       } else {
         const instructions = await this.fetchInstructionsForMeasure.perform(
@@ -260,7 +258,6 @@ export default class RoadsignRegistryService extends Service {
 `;
       const result = await this.executeQuery.perform(query, endpoint);
       const signs = [];
-      console.log(result.results);
       for (const binding of result.results.bindings) {
         const sign = Sign.fromBinding({
           ...binding,

--- a/addon/services/roadsign-registry.ts
+++ b/addon/services/roadsign-registry.ts
@@ -101,11 +101,10 @@ export default class RoadsignRegistryService extends Service {
         ?signUri a ${type ? `<${type}>` : '?signType'};
           skos:prefLabel ?signCode;
           ext:valid "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
-        ${category ? `?signUri org:classification <${category}>` : ''}
-        ${
-          type
-            ? ''
-            : `
+        ${category ? `?signUri dct:type <${category}>` : ''}
+        ${type
+          ? ''
+          : `
           VALUES ?signType {
             <https://data.vlaanderen.be/ns/mobiliteit#Verkeersbordconcept>
             <https://data.vlaanderen.be/ns/mobiliteit#Wegmarkeringconcept>
@@ -114,10 +113,9 @@ export default class RoadsignRegistryService extends Service {
         `
         }
         ${signFilter}
-        ${
-          codeString
-            ? `FILTER(CONTAINS(LCASE(?signCode), ${sparqlEscapeString(codeString.toLowerCase())}))`
-            : ''
+        ${codeString
+          ? `FILTER(CONTAINS(LCASE(?signCode), ${sparqlEscapeString(codeString.toLowerCase())}))`
+          : ''
         }
       }
       ORDER BY ASC(?signCode)

--- a/addon/services/roadsign-registry.ts
+++ b/addon/services/roadsign-registry.ts
@@ -100,7 +100,7 @@ export default class RoadsignRegistryService extends Service {
         ?signUri mobiliteit:heeftMaatregelconcept ?measure.
         ?signUri a ${type ? `<${type}>` : '?signType'};
           skos:prefLabel ?signCode;
-          ext:valid "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
+            ext:valid "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
         ${category ? `?signUri dct:type <${category}>` : ''}
         ${type
           ? ''

--- a/addon/services/roadsign-registry.ts
+++ b/addon/services/roadsign-registry.ts
@@ -84,7 +84,9 @@ export default class RoadsignRegistryService extends Service {
       let signFilter = '';
       if (combinedSigns.length > 0) {
         signFilter = combinedSigns
-          .map((sign) => `<${sign}>  mobiliteit:heeftMaatregelconcept ?measure.`)
+          .map(
+            (sign) => `<${sign}>  mobiliteit:heeftMaatregelconcept ?measure.`,
+          )
           .join('\n');
         signFilter += '\n';
         const commaSeperatedSigns = combinedSigns
@@ -166,12 +168,10 @@ export default class RoadsignRegistryService extends Service {
     async (uri: string, endpoint: string): Promise<Instruction[]> => {
       const query = `SELECT ?name ?template ?annotatedTemplate
            WHERE {
-            <${uri}> ext:template/ext:mapping ?mapping.
-          ?mapping ext:variableType 'instruction';
-            ext:variable ?name;
-            ext:instructionVariable ?instructionVariable.
-          ?instructionVariable ext:annotated ?annotatedTemplate;
-            ext:value ?template.
+            <${uri}> mobiliteit:template ?template.
+             ?template mobiliteit:variabele ?variable; ext:annotated ?annotatedTemplate.
+             ?variable rdfs:value ?name;
+             dct:type "instruction".
           }
           `;
       const result = await this.executeQuery.perform(query, endpoint);

--- a/addon/services/roadsign-registry.ts
+++ b/addon/services/roadsign-registry.ts
@@ -168,7 +168,7 @@ export default class RoadsignRegistryService extends Service {
            WHERE {
             <${uri}> mobiliteit:template ?template.
              ?template mobiliteit:variabele ?variable; ext:annotated ?annotatedTemplate.
-             ?variable rdfs:value ?name;
+             ?variable rdf:value ?name;
              dct:type "instruction".
           }
           `;

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -257,8 +257,8 @@ export default class BesluitSampleController extends Controller {
         defaultDecisionsGovernmentName: 'Edegem',
       },
       roadsignRegulation: {
-        endpoint: 'https://dev.roadsigns.lblod.info/sparql',
-        imageBaseUrl: 'https://register.mobiliteit.vlaanderen.be/',
+        endpoint: 'https://dev-vlag.roadsigns.lblod.info/sparql',
+        imageBaseUrl: 'https://dev-vlag.roadsigns.lblod.info',
       },
       besluitType: {
         endpoint: 'https://centrale-vindplaats.lblod.info/sparql',


### PR DESCRIPTION
GN-4997

Still a work in progress, the filters and table seem working, I think template is the next thing to implement once GN-5108 is ready (cf @aliokan )

If you see something I missed, please let me know

uses https://dev-vlag.roadsigns.lblod.info/ for the backend, as it uses the new model.

cf @andreo141 

I've removed `order` as it doesn't seem to be in the new model (I think it will have to be added at some point)



https://github.com/user-attachments/assets/26478e74-31c2-4a39-bac8-4e49ffcd5b8b


