### PR TITLE
bugfix: ensure article-decision relationship when inserting article-container

### DIFF
--- a/.changeset/short-pears-deny.md
+++ b/.changeset/short-pears-deny.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+bugfix: ensure that an http://data.europa.eu/eli/ontology#has_part relationship is created between the article and decision when inserting an article container/block

--- a/addon/plugins/decision-plugin/commands/insert-article-container.ts
+++ b/addon/plugins/decision-plugin/commands/insert-article-container.ts
@@ -24,7 +24,11 @@ export default function insertArticleContainer({
     const nodeToInsert = schema.node(
       'block_rdfa',
       { rdfaNodeType: 'literal', __rdfaId: articleContainerId },
-      buildArticleStructure(schema, articleUriGenerator),
+      buildArticleStructure(
+        schema,
+        articleUriGenerator,
+        decisionLocation.node.attrs.subject,
+      ),
     );
 
     const tr = state.tr;


### PR DESCRIPTION
### Overview
This PR fixes an issue where the necessary relationship between the default article and current decision (`eli:has_part`) was not added when inserting an article-container.

### connected issues and PRs:
None


### Setup
None

### How to test/reproduce
- Open the dummy besluit app
- Insert and empty besluit
- Insert an article-container
- Ensure that the newly created default article is correctly connected to the decision

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
