### PR TITLE
Change decision theme to use dct:subject in place of eli:is_about

### DIFF
--- a/.changeset/clean-shoes-repeat.md
+++ b/.changeset/clean-shoes-repeat.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Change predicate used for decision theme to match application profile

--- a/addon/components/besluit-topic-plugin/besluit-topic-toolbar-dropdown.ts
+++ b/addon/components/besluit-topic-plugin/besluit-topic-toolbar-dropdown.ts
@@ -3,7 +3,6 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { SayController } from '@lblod/ember-rdfa-editor';
 import { trackedFunction } from 'reactiveweb/function';
-import { ELI } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { AlertTriangleIcon } from '@appuniversum/ember-appuniversum/components/icons/alert-triangle';
 import { CrossIcon } from '@appuniversum/ember-appuniversum/components/icons/cross';
 import { MailIcon } from '@appuniversum/ember-appuniversum/components/icons/mail';
@@ -18,7 +17,8 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-topic-plugin/utils/helpers';
 import {
   updateBesluitTopicResource,
-  ELI_SUBJECT,
+  TOPIC_PREDICATE,
+  TOPIC_PREDICATE_DEPRECATED,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-topic-plugin/commands/update-besluit-topic-resource';
 import { getOutgoingTripleList } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 
@@ -82,10 +82,16 @@ export default class BesluitTopicToolbarDropdownComponent extends Component<Args
       return;
     }
 
-    const outgoingBesluitTopics = getOutgoingTripleList(
+    let outgoingBesluitTopics = getOutgoingTripleList(
       this.decisionRange.node.attrs,
-      ELI(ELI_SUBJECT),
+      TOPIC_PREDICATE,
     );
+    if (outgoingBesluitTopics.length === 0) {
+      outgoingBesluitTopics = getOutgoingTripleList(
+        this.decisionRange.node.attrs,
+        TOPIC_PREDICATE_DEPRECATED,
+      );
+    }
 
     const besluitTopicsRelevant = outgoingBesluitTopics.filter(
       (topic) =>

--- a/addon/plugins/besluit-topic-plugin/commands/update-besluit-topic-resource.ts
+++ b/addon/plugins/besluit-topic-plugin/commands/update-besluit-topic-resource.ts
@@ -2,9 +2,13 @@ import { BesluitTopic } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/bes
 import { Command } from '@lblod/ember-rdfa-editor';
 import { addProperty, removeProperty } from '@lblod/ember-rdfa-editor/commands';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
-import { ELI } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import {
+  DCT,
+  ELI,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 
-export const ELI_SUBJECT = 'is_about';
+export const TOPIC_PREDICATE = DCT('subject');
+export const TOPIC_PREDICATE_DEPRECATED = ELI('is_about');
 
 export const updateBesluitTopicResource = ({
   resource,
@@ -24,16 +28,18 @@ export const updateBesluitTopicResource = ({
         previousTopics.forEach((uri) => {
           newState = state.apply(transaction);
 
-          removeProperty({
-            resource,
-            property: {
-              predicate: ELI(ELI_SUBJECT).full,
-              object: sayDataFactory.namedNode(uri),
-            },
-            transaction,
-          })(newState, (newTransaction) => {
-            transaction = newTransaction;
-          });
+          [TOPIC_PREDICATE, TOPIC_PREDICATE_DEPRECATED].forEach((PREDICATE) =>
+            removeProperty({
+              resource,
+              property: {
+                predicate: PREDICATE.full,
+                object: sayDataFactory.namedNode(uri),
+              },
+              transaction,
+            })(newState, (newTransaction) => {
+              transaction = newTransaction;
+            }),
+          );
         });
       }
 
@@ -43,7 +49,7 @@ export const updateBesluitTopicResource = ({
         addProperty({
           resource,
           property: {
-            predicate: ELI(ELI_SUBJECT).full,
+            predicate: TOPIC_PREDICATE.full,
             object: sayDataFactory.namedNode(besluitTopic.uri),
           },
           transaction,


### PR DESCRIPTION
### Overview
Supports the old predicate but migrates away from it on any change.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5021

### Setup
N/A

### How to test/reproduce
Set up a decision before applying the change to make sure you test backwards compatibility. Setting or unsetting themes should work as expected.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
