### PR TITLE
Fix: recalculate article numbers when inserting article container

### DIFF
--- a/.changeset/young-eagles-exist.md
+++ b/.changeset/young-eagles-exist.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Execute `recalculateNumbers` transaction-monad when inserting article container

--- a/addon/plugins/decision-plugin/commands/insert-article-container.ts
+++ b/addon/plugins/decision-plugin/commands/insert-article-container.ts
@@ -7,6 +7,7 @@ import { PROV } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { buildArticleStructure } from '../utils/build-article-structure';
 import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
+import { recalculateNumbers } from '../../structure-plugin/recalculate-structure-numbers';
 
 interface InsertArticleContainerArgs {
   intl: IntlService;
@@ -46,6 +47,7 @@ export default function insertArticleContainer({
           object: factory.literalNode(articleContainerId),
         },
       }),
+      recalculateNumbers,
     ]);
     if (dispatch && result.every((ok) => ok)) {
       dispatch(newTr.scrollIntoView());


### PR DESCRIPTION
### Overview
This PR ensures that the `recalculateNumbers` transaction-monad is executed when inserting an article container.

##### connected issues and PRs:
None

### Setup
None

### How to test/reproduce
- Start the dummy app
- Insert an empty decision without an article block
**Scenario 1**
- Insert an article block
- Ensure that the default article shows 'Only article'
**Scenario 2**
- Insert an article freely
- Then insert an article block
- The article numbering should be correct

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
