### PR TITLE
Add ability to link locations with the wider document automatically

### DIFF
--- a/.changeset/few-buses-pay.md
+++ b/.changeset/few-buses-pay.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add configuration option to location plugin to automatically link to resources in the wider document

--- a/.changeset/five-suits-pull.md
+++ b/.changeset/five-suits-pull.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Use prov:atLocation predicate for locations instead of dct:spatial

--- a/.changeset/wicked-berries-sing.md
+++ b/.changeset/wicked-berries-sing.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Remove vestigual 'mapping' RDFa from oslo location nodes as they are no longer 'variables' so no longer need it

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -24,7 +24,7 @@ import {
   Point,
   Polygon,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/utils/geo-helpers';
-import { replaceSelectionWithAddress } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/utils/node-utils';
+import { replaceSelectionWithLocation } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/utils/node-utils';
 import { type LocationPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node';
 import { NodeContentsUtils } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node-contents';
 import Edit from './edit';
@@ -190,12 +190,13 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
   @action
   insertOrEditAddress() {
     if (!this.selectedLocationNode) {
-      replaceSelectionWithAddress(
+      replaceSelectionWithLocation(
         this.controller,
         this.intl.t('location-plugin.default-label', {
           locale: this.documentLanguage,
         }),
         this.args.templateMode,
+        this.args.config.subjectTypesToLinkTo,
       );
     }
     this.modalOpen = true;

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -153,13 +153,11 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
   get disableConfirm() {
     switch (this.locationType) {
       case 'place':
-        return (
-          !this.selectedLocationNode || !this.placeName || !this.chosenPoint
-        );
+        return !this.placeName || !this.chosenPoint;
       case 'address':
-        return !this.selectedLocationNode || !this.addressToInsert;
+        return !this.addressToInsert;
       default:
-        return !this.selectedLocationNode || !this.placeName || !this.savedArea;
+        return !this.placeName || !this.savedArea;
     }
   }
 
@@ -189,16 +187,6 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
 
   @action
   insertOrEditAddress() {
-    if (!this.selectedLocationNode) {
-      replaceSelectionWithLocation(
-        this.controller,
-        this.intl.t('location-plugin.default-label', {
-          locale: this.documentLanguage,
-        }),
-        this.args.templateMode,
-        this.args.config.subjectTypesToLinkTo,
-      );
-    }
     this.modalOpen = true;
   }
 
@@ -222,48 +210,47 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
 
   @action
   confirmLocation() {
-    if (this.selectedLocationNode) {
-      let toInsert: Address | Place | Area | undefined;
-      const { pos } = this.selectedLocationNode;
-      if (this.locationType === 'address' && this.addressToInsert) {
-        toInsert = this.addressToInsert;
-      } else if (
-        this.locationType === 'place' &&
-        this.chosenPoint?.global &&
-        this.placeName
-      ) {
-        toInsert = new Place({
-          uri: this.nodeContentsUtils.fallbackPlaceUri(),
-          name: this.placeName,
-          location: new Point({
-            uri: this.nodeContentsUtils.fallbackGeometryUri(),
-            location: {
-              lambert: convertWGS84CoordsToLambert(this.chosenPoint.global),
-              global: this.chosenPoint?.global,
-            },
-          }),
-        });
-        this.chosenPoint = undefined;
-      } else if (
-        this.locationType === 'area' &&
-        this.savedArea &&
-        this.placeName
-      ) {
-        toInsert = new Area({
-          uri: this.nodeContentsUtils.fallbackPlaceUri(),
-          name: this.placeName,
-          shape: new Polygon({
-            uri: this.nodeContentsUtils.fallbackGeometryUri(),
-            locations: this.savedArea,
-          }),
-        });
-      }
-      if (toInsert) {
-        this.controller.withTransaction((tr) => {
-          return tr.setNodeAttribute(pos, 'value', toInsert);
-        });
-        this.modalOpen = false;
-      }
+    let toInsert: Address | Place | Area | undefined;
+    if (this.locationType === 'address' && this.addressToInsert) {
+      toInsert = this.addressToInsert;
+    } else if (
+      this.locationType === 'place' &&
+      this.chosenPoint?.global &&
+      this.placeName
+    ) {
+      toInsert = new Place({
+        uri: this.nodeContentsUtils.fallbackPlaceUri(),
+        name: this.placeName,
+        location: new Point({
+          uri: this.nodeContentsUtils.fallbackGeometryUri(),
+          location: {
+            lambert: convertWGS84CoordsToLambert(this.chosenPoint.global),
+            global: this.chosenPoint?.global,
+          },
+        }),
+      });
+      this.chosenPoint = undefined;
+    } else if (
+      this.locationType === 'area' &&
+      this.savedArea &&
+      this.placeName
+    ) {
+      toInsert = new Area({
+        uri: this.nodeContentsUtils.fallbackPlaceUri(),
+        name: this.placeName,
+        shape: new Polygon({
+          uri: this.nodeContentsUtils.fallbackGeometryUri(),
+          locations: this.savedArea,
+        }),
+      });
+    }
+    if (toInsert) {
+      replaceSelectionWithLocation(
+        this.controller,
+        toInsert,
+        this.args.config.subjectTypesToLinkTo,
+      );
+      this.modalOpen = false;
     }
   }
 

--- a/addon/plugins/location-plugin/node-contents/address.ts
+++ b/addon/plugins/location-plugin/node-contents/address.ts
@@ -5,18 +5,13 @@ import {
   LOCN,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { findChildWithRdfaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
-import {
-  contentSpan,
-  span,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/dom-output-spec-helpers';
+import { span } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/dom-output-spec-helpers';
 import { Address } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/utils/address-helpers';
 import { Point } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/utils/geo-helpers';
 import { constructGeometrySpec } from './point';
 import { type NodeContentsUtils } from './';
-import { PNode } from '@lblod/ember-rdfa-editor';
-import { IncomingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 
-export const constructAddressSpec = (address: Address, node: PNode) => {
+export const constructAddressSpec = (address: Address) => {
   const housenumberNode = address.housenumber
     ? [
         ' ',
@@ -43,18 +38,8 @@ export const constructAddressSpec = (address: Address, node: PNode) => {
         }),
       ]
     : [];
-  const linkingSpans = ((node.attrs.backlinks as IncomingTriple[]) ?? []).map(
-    (bl) =>
-      span({
-        about: bl.subject.value,
-        property: bl.predicate,
-        resource: address.uri,
-      }),
-  );
-  // TODO Should dump the 'typeof', etc. as this is a hangover from being a variable
-  return contentSpan(
+  return span(
     { resource: address.uri, typeof: LOCN('Address').full },
-    ...linkingSpans,
     span(
       {
         property: LOCN('thoroughfare').full,

--- a/addon/plugins/location-plugin/node-contents/area.ts
+++ b/addon/plugins/location-plugin/node-contents/area.ts
@@ -1,6 +1,8 @@
+import { PNode } from '@lblod/ember-rdfa-editor';
+import { IncomingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import {
-  DCT,
   LOCN,
+  PROV,
   RDFS,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { findChildWithRdfaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
@@ -12,13 +14,21 @@ import {
 import { constructGeometrySpec } from './point';
 import { type NodeContentsUtils } from './';
 
-export const constructAreaSpec = (area: Area) => {
+export const constructAreaSpec = (area: Area, node: PNode) => {
+  const linkingSpans = ((node.attrs.backlinks as IncomingTriple[]) ?? []).map(
+    (bl) =>
+      span({
+        rev: bl.predicate,
+        resource: bl.subject.value,
+      }),
+  );
   return span(
     {
       resource: area.uri,
       typeof: LOCN('Location').full,
-      property: DCT('spatial').full,
+      property: PROV('atLocation').full,
     },
+    ...linkingSpans,
     span(
       {
         property: RDFS('label').full,

--- a/addon/plugins/location-plugin/node-contents/area.ts
+++ b/addon/plugins/location-plugin/node-contents/area.ts
@@ -1,8 +1,5 @@
-import { PNode } from '@lblod/ember-rdfa-editor';
-import { IncomingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import {
   LOCN,
-  PROV,
   RDFS,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { findChildWithRdfaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
@@ -14,21 +11,12 @@ import {
 import { constructGeometrySpec } from './point';
 import { type NodeContentsUtils } from './';
 
-export const constructAreaSpec = (area: Area, node: PNode) => {
-  const linkingSpans = ((node.attrs.backlinks as IncomingTriple[]) ?? []).map(
-    (bl) =>
-      span({
-        rev: bl.predicate,
-        resource: bl.subject.value,
-      }),
-  );
+export const constructAreaSpec = (area: Area) => {
   return span(
     {
       resource: area.uri,
       typeof: LOCN('Location').full,
-      property: PROV('atLocation').full,
     },
-    ...linkingSpans,
     span(
       {
         property: RDFS('label').full,
@@ -41,12 +29,7 @@ export const constructAreaSpec = (area: Area, node: PNode) => {
 
 export const parseAreaElement =
   (nodeContentsUtils: NodeContentsUtils) =>
-  (element: Element): Area | undefined => {
-    const placeNode = findChildWithRdfaAttribute(
-      element,
-      'typeof',
-      LOCN('Location'),
-    );
+  (placeNode: Element): Area | undefined => {
     const placeResource = placeNode?.getAttribute('resource');
     const label =
       placeNode &&

--- a/addon/plugins/location-plugin/node-contents/place.ts
+++ b/addon/plugins/location-plugin/node-contents/place.ts
@@ -1,8 +1,5 @@
-import { PNode } from '@lblod/ember-rdfa-editor';
-import { IncomingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import {
   LOCN,
-  PROV,
   RDFS,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { findChildWithRdfaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
@@ -14,21 +11,12 @@ import {
 import { constructGeometrySpec } from './point';
 import { type NodeContentsUtils } from './';
 
-export const constructPlaceSpec = (place: Place, node: PNode) => {
-  const linkingSpans = ((node.attrs.backlinks as IncomingTriple[]) ?? []).map(
-    (bl) =>
-      span({
-        rev: bl.predicate,
-        resource: bl.subject.value,
-      }),
-  );
+export const constructPlaceSpec = (place: Place) => {
   return span(
     {
       resource: place.uri,
       typeof: LOCN('Location').full,
-      property: PROV('atLocation').full,
     },
-    ...linkingSpans,
     span(
       {
         property: RDFS('label').full,
@@ -41,12 +29,7 @@ export const constructPlaceSpec = (place: Place, node: PNode) => {
 
 export const parsePlaceElement =
   (nodeContentsUtils: NodeContentsUtils) =>
-  (element: Element): Place | undefined => {
-    const placeNode = findChildWithRdfaAttribute(
-      element,
-      'typeof',
-      LOCN('Location'),
-    );
+  (placeNode: Element): Place | undefined => {
     const placeResource = placeNode?.getAttribute('resource');
     const label =
       placeNode &&

--- a/addon/plugins/location-plugin/node-contents/place.ts
+++ b/addon/plugins/location-plugin/node-contents/place.ts
@@ -1,6 +1,8 @@
+import { PNode } from '@lblod/ember-rdfa-editor';
+import { IncomingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import {
-  DCT,
   LOCN,
+  PROV,
   RDFS,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { findChildWithRdfaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
@@ -12,13 +14,21 @@ import {
 import { constructGeometrySpec } from './point';
 import { type NodeContentsUtils } from './';
 
-export const constructPlaceSpec = (place: Place) => {
+export const constructPlaceSpec = (place: Place, node: PNode) => {
+  const linkingSpans = ((node.attrs.backlinks as IncomingTriple[]) ?? []).map(
+    (bl) =>
+      span({
+        rev: bl.predicate,
+        resource: bl.subject.value,
+      }),
+  );
   return span(
     {
       resource: place.uri,
       typeof: LOCN('Location').full,
-      property: DCT('spatial').full,
+      property: PROV('atLocation').full,
     },
+    ...linkingSpans,
     span(
       {
         property: RDFS('label').full,

--- a/addon/plugins/location-plugin/node.ts
+++ b/addon/plugins/location-plugin/node.ts
@@ -168,11 +168,11 @@ const serialize =
       // it for now
       // const type = getOutgoingTriple(node.attrs, RDF('type'));
       if (value instanceof Address) {
-        contentNode = nodeContentsUtils.address.construct(value);
+        contentNode = nodeContentsUtils.address.construct(value, node);
       } else if (value instanceof Place) {
-        contentNode = nodeContentsUtils.place.construct(value);
+        contentNode = nodeContentsUtils.place.construct(value, node);
       } else if (value instanceof Area) {
-        contentNode = nodeContentsUtils.area.construct(value);
+        contentNode = nodeContentsUtils.area.construct(value, node);
       }
     }
     if (!contentNode) {

--- a/addon/plugins/location-plugin/node.ts
+++ b/addon/plugins/location-plugin/node.ts
@@ -20,6 +20,7 @@ import {
 import {
   DCT,
   EXT,
+  LOCN,
   RDF,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import {
@@ -42,6 +43,7 @@ import {
   Area,
   Place,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/utils/geo-helpers';
+import { findChildWithRdfaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 import { NodeContentsUtils } from './node-contents';
 import { recreateVariableUris } from '../variable-plugin/utils/recreate-variable-uris';
 
@@ -55,6 +57,35 @@ export interface LocationPluginConfig {
 const parseDOM = (config: LocationPluginConfig): TagParseRule[] => {
   const nodeContentsUtils = new NodeContentsUtils(config);
   return [
+    {
+      tag: 'span',
+      getAttrs(node: HTMLElement) {
+        const attrs = getRdfaAttrs(node, { rdfaAware: true });
+        if (!attrs) {
+          return false;
+        }
+        const contentContainer = node.querySelector(
+          '[data-content-container="true"]',
+        );
+        if (attrs.rdfaNodeType !== 'resource') {
+          return false;
+        }
+        if (contentContainer) {
+          const location =
+            nodeContentsUtils.address.parse(contentContainer.children[0]) ||
+            nodeContentsUtils.place.parse(contentContainer.children[0]) ||
+            nodeContentsUtils.area.parse(contentContainer.children[0]);
+          if (location) {
+            return {
+              ...attrs,
+              value: location,
+            };
+          }
+        }
+        return false;
+      },
+    },
+    // Match 'variable style' node, with additional 'mapping' wrapper
     {
       tag: 'span',
       getAttrs(node: HTMLElement) {
@@ -82,10 +113,20 @@ const parseDOM = (config: LocationPluginConfig): TagParseRule[] => {
           const addressNode = [...dataContainer.children].find((el) =>
             hasRDFaAttribute(el, 'property', EXT('content')),
           );
-          const location =
-            nodeContentsUtils.address.parse(addressNode) ||
-            nodeContentsUtils.place.parse(dataContainer) ||
-            nodeContentsUtils.area.parse(dataContainer);
+          let location: Place | Area | Address | undefined =
+            nodeContentsUtils.address.parse(addressNode);
+          if (addressNode && !location) {
+            const placeNode = findChildWithRdfaAttribute(
+              addressNode,
+              'typeof',
+              LOCN('Location'),
+            );
+            if (placeNode) {
+              location =
+                nodeContentsUtils.place.parse(placeNode) ||
+                nodeContentsUtils.area.parse(placeNode);
+            }
+          }
           return {
             ...attrs,
             value:
@@ -163,16 +204,12 @@ const serialize =
     const { value } = node.attrs;
     let contentNode: DOMOutputSpec | undefined;
     if (value) {
-      // TODO we should be setting the type properly rather than using the address placeholder which
-      // does not have the correct RDFa properties but that's a bigger change, so just hack around
-      // it for now
-      // const type = getOutgoingTriple(node.attrs, RDF('type'));
       if (value instanceof Address) {
-        contentNode = nodeContentsUtils.address.construct(value, node);
+        contentNode = nodeContentsUtils.address.construct(value);
       } else if (value instanceof Place) {
-        contentNode = nodeContentsUtils.place.construct(value, node);
+        contentNode = nodeContentsUtils.place.construct(value);
       } else if (value instanceof Area) {
-        contentNode = nodeContentsUtils.area.construct(value, node);
+        contentNode = nodeContentsUtils.area.construct(value);
       }
     }
     if (!contentNode) {

--- a/addon/plugins/location-plugin/node.ts
+++ b/addon/plugins/location-plugin/node.ts
@@ -32,6 +32,7 @@ import {
 import {
   hasOutgoingNamedNodeTriple,
   hasRDFaAttribute,
+  Resource,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 import { contentSpan } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/dom-output-spec-helpers';
 import AddressNodeviewComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/nodeview';
@@ -48,6 +49,7 @@ export interface LocationPluginConfig {
   defaultAddressUriRoot: string;
   defaultPlaceUriRoot: string;
   defaultPointUriRoot: string;
+  subjectTypesToLinkTo?: Resource[];
 }
 
 const parseDOM = (config: LocationPluginConfig): TagParseRule[] => {

--- a/addon/plugins/location-plugin/utils/node-utils.ts
+++ b/addon/plugins/location-plugin/utils/node-utils.ts
@@ -38,6 +38,9 @@ export function replaceSelectionWithLocation(
       resourceToLink = findAncestors(
         controller.mainEditorState.selection.$from,
         (node) => {
+          if ('typeof' in node.attrs) {
+            return subjectType.matches(node.attrs.typeof);
+          }
           return hasOutgoingNamedNodeTriple(
             node.attrs,
             RDF('type'),

--- a/addon/plugins/location-plugin/utils/node-utils.ts
+++ b/addon/plugins/location-plugin/utils/node-utils.ts
@@ -1,8 +1,6 @@
 import { SayController, NodeSelection, PNode } from '@lblod/ember-rdfa-editor';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
-  DCT,
-  EXT,
   PROV,
   RDF,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
@@ -12,6 +10,8 @@ import {
   Resource,
   hasOutgoingNamedNodeTriple,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import { Area, Place } from './geo-helpers';
+import { Address } from './address-helpers';
 
 /**
  * Creates an 'OSLO location' node in place of the selection, along with the RDFa to create a triple
@@ -20,16 +20,14 @@ import {
  * clean up the RDFa structure inherited from variables and to make it work well with 'undo', this
  * work was put off until then.
  * @param controller - SayController
- * @param label - label to add to the node
- * @param templateMode - Whether to create template URIs in place of 'real' URIs
+ * @param toInsert - The object representing the location to insert
  * @param subjectTypes - A list of Resources, each will be looked at in turn to compare the
  * `rdf:type` of the resource, if no parent is found matching the first, then the second will be
  * used, etc.
  */
 export function replaceSelectionWithLocation(
   controller: SayController,
-  label?: string,
-  templateMode?: boolean,
+  toInsert: Place | Address | Area,
   subjectTypes?: Resource[],
 ) {
   let resourceToLink: { pos: number; node: PNode } | undefined;
@@ -61,36 +59,14 @@ export function replaceSelectionWithLocation(
         },
       ];
 
-  const mappingResource = `http://data.lblod.info/mappings/${
-    templateMode ? '--ref-uuid4-' : ''
-  }$${uuidv4()}`;
-  const variableInstance = `http://data.lblod.info/variables/${
-    templateMode ? '--ref-uuid4-' : ''
-  }$${uuidv4()}`;
   controller.withTransaction((tr) => {
     tr.replaceSelectionWith(
       controller.schema.node('oslo_location', {
-        subject: mappingResource,
+        subject: toInsert.uri,
         rdfaNodeType: 'resource',
         __rdfaId: uuidv4(),
-        properties: [
-          {
-            predicate: RDF('type').full,
-            object: sayDataFactory.namedNode(EXT('Mapping').full),
-          },
-          {
-            predicate: EXT('instance').full,
-            object: sayDataFactory.namedNode(variableInstance),
-          },
-          {
-            predicate: DCT('type').full,
-            object: sayDataFactory.literal('address'),
-          },
-          {
-            predicate: EXT('label').full,
-            object: sayDataFactory.literal(label || ''),
-          },
-        ],
+        value: toInsert,
+        properties: [],
         backlinks,
       }),
     );

--- a/addon/plugins/location-plugin/utils/node-utils.ts
+++ b/addon/plugins/location-plugin/utils/node-utils.ts
@@ -1,17 +1,63 @@
-import { SayController, NodeSelection } from '@lblod/ember-rdfa-editor';
+import { SayController, NodeSelection, PNode } from '@lblod/ember-rdfa-editor';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   DCT,
   EXT,
+  PROV,
   RDF,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { v4 as uuidv4 } from 'uuid';
+import { findAncestors } from '@lblod/ember-rdfa-editor/utils/position-utils';
+import {
+  Resource,
+  hasOutgoingNamedNodeTriple,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 
-export function replaceSelectionWithAddress(
+/**
+ * Creates an 'OSLO location' node in place of the selection, along with the RDFa to create a triple
+ * with the nearest parent of one of the passed types as the subject and the predicate
+ * prov:atLocation. This doesn't work well with the RDFa tools, but since refactoring is required to
+ * clean up the RDFa structure inherited from variables and to make it work well with 'undo', this
+ * work was put off until then.
+ * @param controller - SayController
+ * @param label - label to add to the node
+ * @param templateMode - Whether to create template URIs in place of 'real' URIs
+ * @param subjectTypes - A list of Resources, each will be looked at in turn to compare the
+ * `rdf:type` of the resource, if no parent is found matching the first, then the second will be
+ * used, etc.
+ */
+export function replaceSelectionWithLocation(
   controller: SayController,
   label?: string,
   templateMode?: boolean,
+  subjectTypes?: Resource[],
 ) {
+  let resourceToLink: { pos: number; node: PNode } | undefined;
+  subjectTypes?.forEach((subjectType) => {
+    if (!resourceToLink) {
+      resourceToLink = findAncestors(
+        controller.mainEditorState.selection.$from,
+        (node) => {
+          return hasOutgoingNamedNodeTriple(
+            node.attrs,
+            RDF('type'),
+            subjectType,
+          );
+        },
+      )[0];
+    }
+  });
+  const backlinks = !resourceToLink
+    ? []
+    : [
+        {
+          predicate: PROV('atLocation').full,
+          subject: sayDataFactory.resourceNode(
+            resourceToLink.node.attrs.subject,
+          ),
+        },
+      ];
+
   const mappingResource = `http://data.lblod.info/mappings/${
     templateMode ? '--ref-uuid4-' : ''
   }$${uuidv4()}`;
@@ -42,6 +88,7 @@ export function replaceSelectionWithAddress(
             object: sayDataFactory.literal(label || ''),
           },
         ],
+        backlinks,
       }),
     );
     if (tr.selection.$anchor.nodeBefore) {

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -298,6 +298,7 @@ export default class BesluitSampleController extends Controller {
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/plaats/',
         defaultAddressUriRoot:
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
+        subjectTypesToLinkTo: [BESLUIT('Artikel'), BESLUIT('Besluit')],
       },
       mandateeTable: {
         config: MANDATEE_TABLE_SAMPLE_CONFIG,

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -75,6 +75,10 @@ import {
   autofilled_variable,
   autofilledVariableView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
+import {
+  osloLocation,
+  osloLocationView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node';
 import { VariableConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/insert-variable-card';
 import {
   templateComment,
@@ -126,6 +130,7 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet';
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
 import { BlockRDFaView } from '@lblod/ember-rdfa-editor/nodes/block-rdfa';
+import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 
 export default class RegulatoryStatementSampleController extends Controller {
   SnippetInsert = SnippetInsertRdfaComponent;
@@ -179,6 +184,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       autofilled_variable,
       number,
       location,
+      oslo_location: osloLocation(this.config.location),
       codelist,
       ...STRUCTURE_NODES,
       heading: headingWithConfig({ rdfaAware: false }),
@@ -330,6 +336,20 @@ export default class RegulatoryStatementSampleController extends Controller {
       autofilledVariable: {
         autofilledValues: {},
       },
+      location: {
+        defaultPointUriRoot:
+          'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/geometrie/',
+        defaultPlaceUriRoot:
+          'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/plaats/',
+        defaultAddressUriRoot:
+          'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
+        subjectTypesToLinkTo: [
+          SAY('Article'),
+          SAY('Subsection'),
+          SAY('Section'),
+          SAY('Chapter'),
+        ],
+      },
     };
   }
 
@@ -354,6 +374,7 @@ export default class RegulatoryStatementSampleController extends Controller {
       text_variable: textVariableView(controller),
       person_variable: personVariableView(controller),
       location: locationView(controller),
+      oslo_location: osloLocationView(this.config.location)(controller),
       codelist: codelistView(controller),
       templateComment: templateCommentView(controller),
       address: addressView(controller),

--- a/tests/dummy/app/controllers/snippet-edit-sample.ts
+++ b/tests/dummy/app/controllers/snippet-edit-sample.ts
@@ -111,6 +111,7 @@ import {
   snippetView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet';
 import { BlockRDFaView } from '@lblod/ember-rdfa-editor/nodes/block-rdfa';
+import { BESLUIT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 
 export default class RegulatoryStatementSampleController extends Controller {
   SnippetListSelect = SnippetListSelect;
@@ -287,6 +288,7 @@ export default class RegulatoryStatementSampleController extends Controller {
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/plaats/',
         defaultAddressUriRoot:
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
+        subjectTypesToLinkTo: [BESLUIT('Artikel'), BESLUIT('Besluit')],
       },
       snippet: {
         endpoint: 'https://dev.reglementairebijlagen.lblod.info/sparql',

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -115,6 +115,10 @@
                   @controller={{this.controller}}
                   @config={{this.config.snippet}}
                 />
+                <LocationPlugin::Insert
+                  @controller={{this.controller}}
+                  @config={{this.config.location}}
+                />
               </Sidebar.Collapsible>
               <VariablePlugin::InsertVariableCard
                 @controller={{this.controller}}


### PR DESCRIPTION
### Overview
Also move from dct:spatial to prov:atLocation.

I spent some time refactoring the address variable to re-use a load of the code from the oslo location node and so to benefit from these changes, but I realised that substantially increases the scope of the changes. Instead of finishing those changes, I've not committed them. If we think we should include them, I'll add them, otherwise I'll hold on to them for now.

The links are made in RDFa but only the backlink works in the RDFa tools. This is unfixed as we need to refactor how these nodes work anyway, so should do this then.

Edit: In order to avoid a weird situation of having 2 `prov:atLocation` triples with different objects for each location, I included a more substantial refactor which 'de-variable-ifies' the location code. So, now:
- It no longer inserts a placeholder first, then edits that placeholder with the address. We perhaps need an 'insert placeholder' for building templates, but the old behaviour was weird anyway, as it involved inserting a location, then closing the modal without setting it, which is not ideal.
- It no longer inserts a load of extra RDFa for 'mappings' and variable types.
- Supports importing locations from before this change, but does not remove the 'extra' RDFa until the location is edited.

Things this does not include:
- A fix for the 'incorrect RDFa' issue, which is a quick fix, but needs more work to also support address variables.
- Support for template UUIDs in locations. It's unclear whether we want this as we no longer have the 'mappings', but it would be a simple fix to add if we want it.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5022
GN PR: https://github.com/lblod/frontend-gelinkt-notuleren/pull/794
RB PR: https://github.com/lblod/frontend-reglementaire-bijlage/pull/306

### Setup
N/A

### How to test/reproduce
In the besluit or snippet sample pages, insert locations into arbitrary documents, inside Besluits and inside Articles. The expectation (see jira) is that it will link the location to an article if it can find one or a besluit if it cannot. If it can't find either, it will be unlinked.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
