### PR TITLE
Feat/add person annotations

### DIFF
--- a/.changeset/wet-zebras-run.md
+++ b/.changeset/wet-zebras-run.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Add rdfa to the person variable

--- a/addon/plugins/variable-plugin/variables/person.ts
+++ b/addon/plugins/variable-plugin/variables/person.ts
@@ -3,6 +3,7 @@ import {
   FOAF,
   RDF,
   PERSOON,
+  PERSON,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import {
   createEmberNodeSpec,
@@ -56,7 +57,7 @@ const parseDOM = [
         const contentNode = node.querySelector(
           '[data-content-container="true"]',
         );
-        const aboutNode = contentNode?.querySelector('[about]');
+        const aboutNode = contentNode?.querySelector('[resource]');
         if (aboutNode) {
           const firstNameNode = aboutNode.querySelector(
             `[property="${FOAF('gebruikteVoornaam').full}"],[property="${FOAF('gebruikteVoornaam').prefixed}"]`,
@@ -65,7 +66,7 @@ const parseDOM = [
             `[property="${PERSOON('familyName').full}"],[property="${PERSOON('familyName').prefixed}"]`,
           );
           value = {
-            uri: aboutNode.getAttribute('about') || '',
+            uri: aboutNode.getAttribute('resource') || '',
             firstName: firstNameNode?.textContent || '',
             lastName: lastNameNode?.textContent || '',
           };
@@ -102,7 +103,8 @@ function generatePersonHtml(person: Person) {
   return [
     'span',
     {
-      about: person.uri,
+      resource: person.uri,
+      typeof: PERSON('Person').full,
     },
     [
       'span',

--- a/addon/plugins/variable-plugin/variables/person.ts
+++ b/addon/plugins/variable-plugin/variables/person.ts
@@ -99,7 +99,7 @@ const serialize = (node: PNode, state: EditorState): DOMOutputSpec => {
   });
 };
 
-function generatePersonHtml(person: Person) {
+function generatePersonHtml(person: Person): DOMOutputSpec {
   return [
     'span',
     {

--- a/addon/plugins/variable-plugin/variables/person.ts
+++ b/addon/plugins/variable-plugin/variables/person.ts
@@ -59,10 +59,10 @@ const parseDOM = [
         const aboutNode = contentNode?.querySelector('[about]');
         if (aboutNode) {
           const firstNameNode = aboutNode.querySelector(
-            `[property="${FOAF('gebruikteVoornaam').full}"]`,
+            `[property="${FOAF('gebruikteVoornaam').full}"],[property="${FOAF('gebruikteVoornaam').prefixed}"]`,
           );
           const lastNameNode = aboutNode.querySelector(
-            `[property="${PERSOON('familyName').full}"]`,
+            `[property="${PERSOON('familyName').full}"],[property="${PERSOON('familyName').prefixed}"]`,
           );
           value = {
             uri: aboutNode.getAttribute('about') || '',

--- a/addon/plugins/variable-plugin/variables/person.ts
+++ b/addon/plugins/variable-plugin/variables/person.ts
@@ -136,6 +136,7 @@ function generatePersonHtml(person: Person): DOMOutputSpec {
       },
       person.firstName,
     ],
+    ' ',
     [
       'span',
       {

--- a/addon/plugins/variable-plugin/variables/person.ts
+++ b/addon/plugins/variable-plugin/variables/person.ts
@@ -57,7 +57,9 @@ const parseDOM = [
         const contentNode = node.querySelector(
           '[data-content-container="true"]',
         );
-        const aboutNode = contentNode?.querySelector('[resource]');
+        const aboutNode = contentNode?.querySelector(
+          `[property="${EXT('content').full}"],[property="${EXT('content').prefixed}]`,
+        );
         if (aboutNode) {
           const firstNameNode = aboutNode.querySelector(
             `[property="${FOAF('gebruikteVoornaam').full}"],[property="${FOAF('gebruikteVoornaam').prefixed}"]`,
@@ -70,6 +72,26 @@ const parseDOM = [
             firstName: firstNameNode?.textContent || '',
             lastName: lastNameNode?.textContent || '',
           };
+        } else {
+          // Backwards compatibility
+          if (node.dataset.value) {
+            value = JSON.parse(node.dataset.value) as Person | undefined;
+          } else if (node.dataset.mandatee) {
+            const mandatee = JSON.parse(node.dataset.mandatee) as
+              | {
+                  personUri: string;
+                  firstName: string;
+                  lastName: string;
+                }
+              | undefined;
+            if (mandatee) {
+              value = {
+                uri: mandatee.personUri,
+                firstName: mandatee.firstName,
+                lastName: mandatee.lastName,
+              };
+            }
+          }
         }
         return {
           ...attrs,
@@ -103,6 +125,7 @@ function generatePersonHtml(person: Person): DOMOutputSpec {
   return [
     'span',
     {
+      property: EXT('content').full,
       resource: person.uri,
       typeof: PERSON('Person').full,
     },

--- a/addon/utils/constants.ts
+++ b/addon/utils/constants.ts
@@ -50,6 +50,7 @@ export const PERSOON = namespace(
   'http://data.vlaanderen.be/ns/persoon#',
   'persoon',
 );
+export const PERSON = namespace('http://www.w3.org/ns/person#', 'person');
 export const BESTUURSPERIODES = {
   '2012-2019':
     'http://data.lblod.info/id/concept/Bestuursperiode/845dbc7f-139e-4632-b200-f90e180f1dba',

--- a/addon/utils/constants.ts
+++ b/addon/utils/constants.ts
@@ -46,6 +46,10 @@ export const SRO = namespace(
   'https://data.vlaanderen.be/ns/slimmeraadpleegomgeving#',
   'sro',
 );
+export const PERSOON = namespace(
+  'http://data.vlaanderen.be/ns/persoon#',
+  'persoon',
+);
 export const BESTUURSPERIODES = {
   '2012-2019':
     'http://data.lblod.info/id/concept/Bestuursperiode/845dbc7f-139e-4632-b200-f90e180f1dba',


### PR DESCRIPTION
### Overview
Add rdfa annotations on the person variable for URI, firstname and lastname

##### connected issues and PRs:
GN-5240


### Setup
None

### How to test/reproduce
Insert a person from LMB and click on show raw export, notice that the person variable now includes info about the uri, firstname and lastname

### Challenges/uncertainties
Not sure if the rdfa generated is correct or could be improved 



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
