### PR TITLE
GN-4881: support for truncated addresses

### DIFF
--- a/.changeset/hot-comics-act.md
+++ b/.changeset/hot-comics-act.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add support for inserting truncated addresses

--- a/addon/components/location-plugin/edit.gts
+++ b/addon/components/location-plugin/edit.gts
@@ -37,6 +37,7 @@ import { type Point } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/locat
 import { type NodeContentsUtils } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node-contents';
 import { type LocationType } from './map';
 import { type SafeString } from '@ember/template';
+import { tracked } from '@glimmer/tracking';
 
 interface Message {
   skin: AuAlertSignature['Args']['skin'];
@@ -63,6 +64,7 @@ type Signature = {
 
 export default class LocationPluginEditComponent extends Component<Signature> {
   @service declare intl: IntlService;
+  @tracked fullAddressRequired = false;
 
   @trackedReset({
     memo: 'currentAddress',
@@ -316,6 +318,11 @@ export default class LocationPluginEditComponent extends Component<Signature> {
     this.args.setPlaceName((event.target as HTMLInputElement).value);
   }
 
+  @action
+  insertFullAddress(event: InputEvent) {
+    this.fullAddressRequired = event as HTMLFormElement;
+  }
+
   searchMunicipality = restartableTask(async (term: string) => {
     await timeout(200);
     return fetchMunicipalities(term);
@@ -462,7 +469,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
           {{/if}}
         </div>
       </AuFormRow>
-      <AuCheckbox @onChange={{this.addFullAddress}}>{{t
+      <AuCheckbox @onChange={{this.insertFullAddress}}>{{t
           'location-plugin.modal.checkbox-message'
         }}</AuCheckbox>
       <AuHelptext @skin='tertiary'>{{t

--- a/addon/components/location-plugin/edit.gts
+++ b/addon/components/location-plugin/edit.gts
@@ -194,7 +194,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
 
   get currentTruncateAddressValue() {
     if (this.currentAddress instanceof Address) {
-      return this.currentAddress.truncateAddressValue;
+      return this.currentAddress.truncated;
     } else {
       return undefined;
     }
@@ -238,7 +238,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
       newMunicipality === this.currentAddress.municipality &&
       newHousenumber === this.currentAddress.housenumber &&
       newBusnumber === this.currentAddress.busnumber &&
-      newTruncateAddressValue === this.currentAddress.truncateAddressValue
+      newTruncateAddressValue === this.currentAddress.truncated
     ) {
       // No need to re-search, nothing has changed
       return;
@@ -252,7 +252,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
             municipality: newMunicipality,
             busnumber: newBusnumber,
             housenumber: newHousenumber,
-            truncateAddressValue: newTruncateAddressValue,
+            truncated: newTruncateAddressValue,
           })
         ) {
           return this.currentAddress;
@@ -265,7 +265,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
                 municipality: newMunicipality,
                 housenumber: newHousenumber,
                 busnumber: newBusnumber,
-                truncateAddressValue: newTruncateAddressValue,
+                truncated: newTruncateAddressValue,
               },
               this.args.nodeContentsUtils,
             );
@@ -276,7 +276,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
               {
                 street: newStreetName,
                 municipality: newMunicipality,
-                truncateAddressValue: newTruncateAddressValue,
+                truncated: newTruncateAddressValue,
               },
               this.args.nodeContentsUtils,
             );
@@ -301,7 +301,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
           municipality: newMunicipality,
           housenumber: newHousenumber,
           busnumber: newBusnumber,
-          truncateAddressValue: true,
+          truncated: true,
         },
         this.args.nodeContentsUtils,
       );

--- a/addon/components/location-plugin/edit.gts
+++ b/addon/components/location-plugin/edit.gts
@@ -19,6 +19,8 @@ import AuFormRow from '@appuniversum/ember-appuniversum/components/au-form-row';
 import AuRadioGroup from '@appuniversum/ember-appuniversum/components/au-radio-group';
 import AuFieldset from '@appuniversum/ember-appuniversum/components/au-fieldset';
 import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
+import AuCheckbox from '@appuniversum/ember-appuniversum/components/au-checkbox';
+import AuHelptext from '@appuniversum/ember-appuniversum/components/au-help-text';
 import { AlertTriangleIcon } from '@appuniversum/ember-appuniversum/components/icons/alert-triangle';
 import { CheckIcon } from '@appuniversum/ember-appuniversum/components/icons/check';
 import { ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
@@ -460,6 +462,12 @@ export default class LocationPluginEditComponent extends Component<Signature> {
           {{/if}}
         </div>
       </AuFormRow>
+      <AuCheckbox @onChange={{this.addFullAddress}}>{{t
+          'location-plugin.modal.checkbox-message'
+        }}</AuCheckbox>
+      <AuHelptext @skin='tertiary'>{{t
+          'location-plugin.modal.checkbox-helptext'
+        }}</AuHelptext>
 
       {{#if this.message}}
         <AuAlert

--- a/addon/components/location-plugin/edit.gts
+++ b/addon/components/location-plugin/edit.gts
@@ -102,10 +102,10 @@ export default class LocationPluginEditComponent extends Component<Signature> {
   @trackedReset({
     memo: 'currentAddress',
     update(component: LocationPluginEditComponent) {
-      return component.currentTruncateAddressValue;
+      return component.currentTruncatedValue;
     },
   })
-  newTruncateAddressValue?: boolean;
+  newTruncatedValue?: boolean;
 
   get message(): Message | undefined {
     const value = this.newAddress.value as Address | undefined;
@@ -192,12 +192,8 @@ export default class LocationPluginEditComponent extends Component<Signature> {
     }
   }
 
-  get currentTruncateAddressValue() {
-    if (this.currentAddress instanceof Address) {
-      return this.currentAddress.truncated;
-    } else {
-      return undefined;
-    }
+  get currentTruncatedValue() {
+    return this.currentAddress?.truncated;
   }
 
   get canUpdateStreet() {
@@ -230,7 +226,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
       newMunicipality,
       newHousenumber,
       newBusnumber,
-      newTruncateAddressValue,
+      newTruncatedValue,
     } = this;
     if (
       this.currentAddress &&
@@ -238,7 +234,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
       newMunicipality === this.currentAddress.municipality &&
       newHousenumber === this.currentAddress.housenumber &&
       newBusnumber === this.currentAddress.busnumber &&
-      newTruncateAddressValue === this.currentAddress.truncated
+      newTruncatedValue === this.currentAddress.truncated
     ) {
       // No need to re-search, nothing has changed
       return;
@@ -252,7 +248,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
             municipality: newMunicipality,
             busnumber: newBusnumber,
             housenumber: newHousenumber,
-            truncated: newTruncateAddressValue,
+            truncated: newTruncatedValue ?? false,
           })
         ) {
           return this.currentAddress;
@@ -265,7 +261,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
                 municipality: newMunicipality,
                 housenumber: newHousenumber,
                 busnumber: newBusnumber,
-                truncated: newTruncateAddressValue,
+                truncated: newTruncatedValue ?? false,
               },
               this.args.nodeContentsUtils,
             );
@@ -276,7 +272,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
               {
                 street: newStreetName,
                 municipality: newMunicipality,
-                truncated: newTruncateAddressValue,
+                truncated: newTruncatedValue ?? false,
               },
               this.args.nodeContentsUtils,
             );
@@ -295,18 +291,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
         this.args.setIsLoading?.(false);
       }
     } else {
-      const address = await resolveAddress(
-        {
-          street: newStreetName,
-          municipality: newMunicipality,
-          housenumber: newHousenumber,
-          busnumber: newBusnumber,
-          truncated: true,
-        },
-        this.args.nodeContentsUtils,
-      );
-      this.args.setAddressToInsert(address);
-      return address;
+      return;
     }
   });
 
@@ -318,7 +303,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
       this.newStreetName,
       this.newHousenumber,
       this.newBusnumber,
-      this.newTruncateAddressValue,
+      this.newTruncatedValue,
     ],
   );
 
@@ -355,8 +340,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
 
   @action
   truncateAddress(value: boolean) {
-    this.newTruncateAddressValue = value;
-    console.log('this.newTruncateAddressValue', this.newTruncateAddressValue);
+    this.newTruncatedValue = value;
   }
 
   searchMunicipality = restartableTask(async (term: string) => {
@@ -507,7 +491,7 @@ export default class LocationPluginEditComponent extends Component<Signature> {
       </AuFormRow>
       {{#if this.newStreetName}}
         <AuCheckbox
-          @checked={{this.newTruncateAddressValue}}
+          @checked={{this.newTruncatedValue}}
           @onChange={{this.truncateAddress}}
         >{{t 'location-plugin.modal.checkbox-message'}}</AuCheckbox>
         <AuHelptext @skin='tertiary'>{{t

--- a/addon/plugins/location-plugin/node-contents/address.ts
+++ b/addon/plugins/location-plugin/node-contents/address.ts
@@ -12,8 +12,6 @@ import { constructGeometrySpec } from './point';
 import { type NodeContentsUtils } from './';
 
 export const constructAddressSpec = (address: Address) => {
-  const shouldIncludeCity = address.includeCityAndPostcode;
-
   const housenumberNode = address.housenumber
     ? [
         ' ',
@@ -40,19 +38,7 @@ export const constructAddressSpec = (address: Address) => {
         }),
       ]
     : [];
-  const cityAndPostcodeNode = shouldIncludeCity
-    ? [
-        span({ property: LOCN('postcode').full }, address.zipcode),
-        ' ',
-        span(
-          {
-            property: ADRES('gemeentenaam').full,
-            language: 'nl',
-          },
-          address.municipality,
-        ),
-      ]
-    : [];
+
   return span(
     { resource: address.uri, typeof: LOCN('Address').full },
     span(
@@ -64,7 +50,6 @@ export const constructAddressSpec = (address: Address) => {
     ...housenumberNode,
     ...busnumberNode,
     ', ',
-    ...cityAndPostcodeNode,
     ...belgianUriNode,
     constructGeometrySpec(address.location, ADRES('positie')),
   );

--- a/addon/plugins/location-plugin/node-contents/address.ts
+++ b/addon/plugins/location-plugin/node-contents/address.ts
@@ -12,6 +12,8 @@ import { constructGeometrySpec } from './point';
 import { type NodeContentsUtils } from './';
 
 export const constructAddressSpec = (address: Address) => {
+  const shouldIncludeCity = address.includeCityAndPostcode;
+
   const housenumberNode = address.housenumber
     ? [
         ' ',
@@ -38,6 +40,19 @@ export const constructAddressSpec = (address: Address) => {
         }),
       ]
     : [];
+  const cityAndPostcodeNode = shouldIncludeCity
+    ? [
+        span({ property: LOCN('postcode').full }, address.zipcode),
+        ' ',
+        span(
+          {
+            property: ADRES('gemeentenaam').full,
+            language: 'nl',
+          },
+          address.municipality,
+        ),
+      ]
+    : [];
   return span(
     { resource: address.uri, typeof: LOCN('Address').full },
     span(
@@ -49,20 +64,7 @@ export const constructAddressSpec = (address: Address) => {
     ...housenumberNode,
     ...busnumberNode,
     ', ',
-    span(
-      {
-        property: LOCN('postcode').full,
-      },
-      address.zipcode,
-    ),
-    ' ',
-    span(
-      {
-        property: ADRES('gemeentenaam').full,
-        language: 'nl',
-      },
-      address.municipality,
-    ),
+    ...cityAndPostcodeNode,
     ...belgianUriNode,
     constructGeometrySpec(address.location, ADRES('positie')),
   );

--- a/addon/plugins/location-plugin/utils/address-helpers.ts
+++ b/addon/plugins/location-plugin/utils/address-helpers.ts
@@ -156,14 +156,15 @@ export class Address {
   sameAs(
     other?: Pick<
       Address,
-      'street' | 'housenumber' | 'busnumber' | 'municipality'
+      'street' | 'housenumber' | 'busnumber' | 'municipality' | 'truncated'
     > | null,
   ) {
     return (
       this.street === other?.street &&
       this.housenumber === other?.housenumber &&
       this.busnumber === other?.busnumber &&
-      this.municipality === other?.municipality
+      this.municipality === other?.municipality &&
+      this.truncated === other?.truncated
     );
   }
 
@@ -256,6 +257,7 @@ export async function fetchStreets(term: string, municipality: string) {
 type StreetInfo = {
   municipality: string;
   street: string;
+  truncated: boolean;
 };
 
 export async function resolveStreet(
@@ -283,7 +285,7 @@ export async function resolveStreet(
         street: unwrap(streetinfo.Thoroughfarename),
         municipality: streetinfo.Municipality,
         zipcode: unwrap(streetinfo.Zipcode),
-        truncated: false,
+        truncated: info.truncated,
         location: new Point({
           uri: nodeContentsUtils.fallbackGeometryUri(),
           location: {
@@ -317,6 +319,7 @@ type AddressInfo = {
   street: string;
   housenumber: string;
   busnumber?: string;
+  truncated: boolean;
 };
 
 export async function resolveAddress(
@@ -340,7 +343,7 @@ export async function resolveAddress(
         municipality: result.gemeente.gemeentenaam.geografischeNaam.spelling,
         uri: nodeContentsUtils.fallbackAddressUri(),
         belgianAddressUri: result.identificator.id,
-        truncated: false,
+        truncated: info.truncated,
         location: new Point({
           uri: `${result.identificator.id}/1`,
           location: {
@@ -361,6 +364,7 @@ export async function resolveAddress(
       {
         street: info.street,
         municipality: info.municipality,
+        truncated: info.truncated,
       },
       nodeContentsUtils,
     );

--- a/addon/plugins/location-plugin/utils/address-helpers.ts
+++ b/addon/plugins/location-plugin/utils/address-helpers.ts
@@ -114,7 +114,6 @@ export class Address {
   declare housenumber?: string;
   declare busnumber?: string;
   declare location: Point;
-  declare includeCityAndPostcode?: boolean;
   constructor(
     args: Pick<
       Address,
@@ -126,23 +125,18 @@ export class Address {
       | 'busnumber'
       | 'location'
       | 'belgianAddressUri'
-      | 'includeCityAndPostcode'
     >,
   ) {
     Object.assign(this, args);
   }
 
   get formatted() {
-    const cityAndPostcode = this.includeCityAndPostcode
-      ? `, ${this.zipcode} ${this.municipality}`
-      : '';
-
     if (this.housenumber && this.busnumber) {
-      return `${this.street} ${this.housenumber} bus ${this.busnumber} ${cityAndPostcode}`;
+      return `${this.street} ${this.housenumber} bus ${this.busnumber}, ${this.zipcode} ${this.municipality}`;
     } else if (this.housenumber) {
-      return `${this.street} ${this.housenumber} ${cityAndPostcode}`;
+      return `${this.street} ${this.housenumber}, ${this.zipcode} ${this.municipality}`;
     } else {
-      return `${this.street} ${cityAndPostcode}`;
+      return `${this.street}, ${this.zipcode} ${this.municipality}`;
     }
   }
 

--- a/addon/plugins/location-plugin/utils/address-helpers.ts
+++ b/addon/plugins/location-plugin/utils/address-helpers.ts
@@ -114,7 +114,7 @@ export class Address {
   declare housenumber?: string;
   declare busnumber?: string;
   declare location: Point;
-  declare truncateAddressValue: boolean;
+  declare truncated: boolean;
 
   constructor(
     args: Pick<
@@ -127,14 +127,14 @@ export class Address {
       | 'busnumber'
       | 'location'
       | 'belgianAddressUri'
-      | 'truncateAddressValue'
+      | 'truncated'
     >,
   ) {
     Object.assign(this, args);
   }
 
   get formatted() {
-    if (this.truncateAddressValue) {
+    if (this.truncated) {
       if (this.housenumber && this.busnumber) {
         return `${this.street} ${this.housenumber} bus ${this.busnumber}`;
       } else if (this.housenumber) {
@@ -283,7 +283,7 @@ export async function resolveStreet(
         street: unwrap(streetinfo.Thoroughfarename),
         municipality: streetinfo.Municipality,
         zipcode: unwrap(streetinfo.Zipcode),
-        truncateAddressValue: false,
+        truncated: false,
         location: new Point({
           uri: nodeContentsUtils.fallbackGeometryUri(),
           location: {
@@ -340,7 +340,7 @@ export async function resolveAddress(
         municipality: result.gemeente.gemeentenaam.geografischeNaam.spelling,
         uri: nodeContentsUtils.fallbackAddressUri(),
         belgianAddressUri: result.identificator.id,
-        truncateAddressValue: false,
+        truncated: false,
         location: new Point({
           uri: `${result.identificator.id}/1`,
           location: {

--- a/addon/plugins/location-plugin/utils/address-helpers.ts
+++ b/addon/plugins/location-plugin/utils/address-helpers.ts
@@ -114,6 +114,8 @@ export class Address {
   declare housenumber?: string;
   declare busnumber?: string;
   declare location: Point;
+  declare truncateAddressValue: boolean;
+
   constructor(
     args: Pick<
       Address,
@@ -125,18 +127,29 @@ export class Address {
       | 'busnumber'
       | 'location'
       | 'belgianAddressUri'
+      | 'truncateAddressValue'
     >,
   ) {
     Object.assign(this, args);
   }
 
   get formatted() {
-    if (this.housenumber && this.busnumber) {
-      return `${this.street} ${this.housenumber} bus ${this.busnumber}, ${this.zipcode} ${this.municipality}`;
-    } else if (this.housenumber) {
-      return `${this.street} ${this.housenumber}, ${this.zipcode} ${this.municipality}`;
+    if (this.truncateAddressValue) {
+      if (this.housenumber && this.busnumber) {
+        return `${this.street} ${this.housenumber} bus ${this.busnumber}`;
+      } else if (this.housenumber) {
+        return `${this.street} ${this.housenumber}`;
+      } else {
+        return `${this.street}`;
+      }
     } else {
-      return `${this.street}, ${this.zipcode} ${this.municipality}`;
+      if (this.housenumber && this.busnumber) {
+        return `${this.street} ${this.housenumber} bus ${this.busnumber}, ${this.zipcode} ${this.municipality}`;
+      } else if (this.housenumber) {
+        return `${this.street} ${this.housenumber}, ${this.zipcode} ${this.municipality}`;
+      } else {
+        return `${this.street}, ${this.zipcode} ${this.municipality}`;
+      }
     }
   }
 
@@ -270,6 +283,7 @@ export async function resolveStreet(
         street: unwrap(streetinfo.Thoroughfarename),
         municipality: streetinfo.Municipality,
         zipcode: unwrap(streetinfo.Zipcode),
+        truncateAddressValue: false,
         location: new Point({
           uri: nodeContentsUtils.fallbackGeometryUri(),
           location: {
@@ -326,6 +340,7 @@ export async function resolveAddress(
         municipality: result.gemeente.gemeentenaam.geografischeNaam.spelling,
         uri: nodeContentsUtils.fallbackAddressUri(),
         belgianAddressUri: result.identificator.id,
+        truncateAddressValue: false,
         location: new Point({
           uri: `${result.identificator.id}/1`,
           location: {

--- a/addon/plugins/location-plugin/utils/address-helpers.ts
+++ b/addon/plugins/location-plugin/utils/address-helpers.ts
@@ -114,6 +114,7 @@ export class Address {
   declare housenumber?: string;
   declare busnumber?: string;
   declare location: Point;
+  declare includeCityAndPostcode?: boolean;
   constructor(
     args: Pick<
       Address,
@@ -125,18 +126,23 @@ export class Address {
       | 'busnumber'
       | 'location'
       | 'belgianAddressUri'
+      | 'includeCityAndPostcode'
     >,
   ) {
     Object.assign(this, args);
   }
 
   get formatted() {
+    const cityAndPostcode = this.includeCityAndPostcode
+      ? `, ${this.zipcode} ${this.municipality}`
+      : '';
+
     if (this.housenumber && this.busnumber) {
-      return `${this.street} ${this.housenumber} bus ${this.busnumber}, ${this.zipcode} ${this.municipality}`;
+      return `${this.street} ${this.housenumber} bus ${this.busnumber} ${cityAndPostcode}`;
     } else if (this.housenumber) {
-      return `${this.street} ${this.housenumber}, ${this.zipcode} ${this.municipality}`;
+      return `${this.street} ${this.housenumber} ${cityAndPostcode}`;
     } else {
-      return `${this.street}, ${this.zipcode} ${this.municipality}`;
+      return `${this.street} ${cityAndPostcode}`;
     }
   }
 

--- a/addon/utils/namespace.ts
+++ b/addon/utils/namespace.ts
@@ -102,7 +102,7 @@ export function findChildWithRdfaAttribute(
   attr: string,
   value: Resource,
 ) {
-  return [...element.children].find((child) => {
+  return Array.from(element.children).find((child) => {
     const result = child.getAttribute(attr)?.split(' ');
     return result?.includes(value.full) || result?.includes(value.prefixed);
   });

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -476,7 +476,7 @@ location-plugin:
     insert: Insert location
     edit: Edit location
     confirm: Set location
-    checkbox-message: Insert full address?
+    checkbox-message: Truncate address?
     checkbox-helptext: Checking this will add the postcode and municipalty to the address output.
   nodeview:
     placeholder: Insert location

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -477,7 +477,7 @@ location-plugin:
     edit: Edit location
     confirm: Set location
     checkbox-message: Truncate address?
-    checkbox-helptext: Checking this will add the postcode and municipalty to the address output.
+    checkbox-helptext: Checking this will remove the zipcode and municipality from the address.
   nodeview:
     placeholder: Insert location
   types:

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -476,6 +476,8 @@ location-plugin:
     insert: Insert location
     edit: Edit location
     confirm: Set location
+    checkbox-message: Insert full address?
+    checkbox-helptext: Checking this will add the postcode and municipalty to the address output.
   nodeview:
     placeholder: Insert location
   types:
@@ -522,7 +524,6 @@ location-plugin:
       http-error: 'Something went wrong while resolving this address, status code: {status}.'
       projection-error: 'Unable to convert location coordinates: {coords}'
       contact: In case of persisting issues, contact <a href="mailto:{email}">{email}</a>.
-
 lpdc-plugin:
   insert:
     title: Insert LPDC

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -473,7 +473,7 @@ location-plugin:
     insert: locatie invoegen
     edit: Bewerk locatie
     confirm: Locatie instellen
-    checkbox-message: Volledig adres invoegen?
+    checkbox-message: Verkort adres tonen?
     checkbox-helptext: Aanvinken voegt de postcode en gemeente toe aan de output van het adres.
   nodeview:
     placeholder: Voeg locatie in

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -474,7 +474,7 @@ location-plugin:
     edit: Bewerk locatie
     confirm: Locatie instellen
     checkbox-message: Verkort adres tonen?
-    checkbox-helptext: Aanvinken voegt de postcode en gemeente toe aan de output van het adres.
+    checkbox-helptext: Aanvinken verwijdert de postcode en gemeente van het adres.
   nodeview:
     placeholder: Voeg locatie in
   types:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -473,6 +473,8 @@ location-plugin:
     insert: locatie invoegen
     edit: Bewerk locatie
     confirm: Locatie instellen
+    checkbox-message: Volledig adres invoegen?
+    checkbox-helptext: Aanvinken voegt de postcode en gemeente toe aan de output van het adres.
   nodeview:
     placeholder: Voeg locatie in
   types:


### PR DESCRIPTION
### Overview
This PR includes support for inserting truncated addresses.
A truncated address is an address without the zipcode and municipality name shown. These attributes are still encoded in hidden RDFa.

##### connected issues and PRs:
[GN-4881](https://binnenland.atlassian.net/browse/GN-4881?atlOrigin=eyJpIjoiNGFhYzAwNDUwMGI2NGVlY2FlNzgyOTBkMGJhZGRjMDAiLCJwIjoiaiJ9)

### Setup
None

### How to test/reproduce
- Start the dummy app
- Click on the 'Insert location' sidebar button
- While filling in an address, ensure that you can select whether or not it should be inserted in a 'truncated' format
- Ensure the truncated/non-truncated address format is persisted across document reloads

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
