### PR TITLE
Convert citation into a keyed plugin

### DIFF
--- a/.changeset/popular-countries-listen.md
+++ b/.changeset/popular-countries-listen.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Convert citation into a keyed plugin

--- a/addon/components/citation-plugin/citation-card.ts
+++ b/addon/components/citation-plugin/citation-card.ts
@@ -12,9 +12,11 @@ import {
 import {
   CitationDecoration,
   CitationPluginEmberComponentConfig,
+  CitationPluginState,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
 import {
   DecorationSet,
+  PluginKey,
   SayController,
   Transaction,
 } from '@lblod/ember-rdfa-editor';
@@ -75,7 +77,7 @@ export default class CitationCardComponent extends Component<Args> {
     return !this.controller.inEmbeddedView && this.activeDecoration;
   }
 
-  get plugin() {
+  get plugin(): PluginKey<CitationPluginState> {
     return citationPluginKey;
   }
 

--- a/addon/components/citation-plugin/citation-card.ts
+++ b/addon/components/citation-plugin/citation-card.ts
@@ -32,6 +32,7 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin/utils/legal-documents';
 import { cleanCaches } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin/utils/cache';
 import { SearchIcon } from '@appuniversum/ember-appuniversum/components/icons/search';
+import { citationPluginKey } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
 
 interface Args {
   controller: SayController;
@@ -77,7 +78,7 @@ export default class CitationCardComponent extends Component<Args> {
   }
 
   get plugin() {
-    return this.args.plugin;
+    return citationPluginKey;
   }
 
   get config() {

--- a/addon/components/citation-plugin/citation-card.ts
+++ b/addon/components/citation-plugin/citation-card.ts
@@ -11,7 +11,6 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import {
   CitationDecoration,
-  CitationPlugin,
   CitationPluginEmberComponentConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/citation-plugin';
 import {
@@ -36,7 +35,6 @@ import { citationPluginKey } from '@lblod/ember-rdfa-editor-lblod-plugins/plugin
 
 interface Args {
   controller: SayController;
-  plugin: CitationPlugin;
   config: CitationPluginEmberComponentConfig;
 }
 

--- a/addon/components/citation-plugin/citations/legal-document-detail.ts
+++ b/addon/components/citation-plugin/citations/legal-document-detail.ts
@@ -58,8 +58,6 @@ export default class LegalDocumentDetailComponent extends Component<Args> {
       });
       this.totalCount = results.totalCount;
 
-      console.log({ result: results.articles });
-
       return results.articles;
     } catch (e) {
       console.warn(e); // eslint-ignore-line no-console

--- a/addon/plugins/citation-plugin/index.ts
+++ b/addon/plugins/citation-plugin/index.ts
@@ -9,13 +9,12 @@ import {
   ProsePlugin,
   ResolvedPos,
   Schema,
+  PluginKey,
 } from '@lblod/ember-rdfa-editor';
 import processMatch, {
   RegexpMatchArrayWithIndices,
 } from './utils/process-match';
 import { changedDescendants } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/changed-descendants';
-import { findParentNodeOfTypeClosestToPos } from '@curvenote/prosemirror-utils';
-import { PluginKey } from 'prosemirror-state';
 
 const BASIC_MULTIPLANE_CHARACTER = '\u0021-\uFFFF'; // most of the characters used around the world
 
@@ -154,7 +153,9 @@ export type CitationPluginEmberComponentConfig = CitationPluginConfig & {
   defaultDecisionsGovernmentName?: string;
 };
 
-export const citationPluginKey = new PluginKey('say-citation-plugin');
+export const citationPluginKey: PluginKey<CitationPluginState> = new PluginKey(
+  'say-citation-plugin',
+);
 
 export function citationPlugin(config: CitationPluginConfig): CitationPlugin {
   const citation: CitationPlugin = new ProsePlugin({

--- a/addon/plugins/citation-plugin/index.ts
+++ b/addon/plugins/citation-plugin/index.ts
@@ -15,6 +15,7 @@ import processMatch, {
   RegexpMatchArrayWithIndices,
 } from './utils/process-match';
 import { changedDescendants } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/changed-descendants';
+import { findParentNodeOfTypeClosestToPos } from '@curvenote/prosemirror-utils';
 
 const BASIC_MULTIPLANE_CHARACTER = '\u0021-\uFFFF'; // most of the characters used around the world
 
@@ -112,7 +113,7 @@ export interface CitationDecoration extends Decoration {
   spec: CitationDecorationSpec;
 }
 
-interface CitationPluginState {
+export interface CitationPluginState {
   highlights: DecorationSet;
   activeRanges: [number, number][];
 }

--- a/addon/plugins/citation-plugin/index.ts
+++ b/addon/plugins/citation-plugin/index.ts
@@ -15,6 +15,7 @@ import processMatch, {
 } from './utils/process-match';
 import { changedDescendants } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/changed-descendants';
 import { findParentNodeOfTypeClosestToPos } from '@curvenote/prosemirror-utils';
+import { PluginKey } from 'prosemirror-state';
 
 const BASIC_MULTIPLANE_CHARACTER = '\u0021-\uFFFF'; // most of the characters used around the world
 
@@ -153,8 +154,11 @@ export type CitationPluginEmberComponentConfig = CitationPluginConfig & {
   defaultDecisionsGovernmentName?: string;
 };
 
+export const citationPluginKey = new PluginKey('say-citation-plugin');
+
 export function citationPlugin(config: CitationPluginConfig): CitationPlugin {
   const citation: CitationPlugin = new ProsePlugin({
+    key: citationPluginKey,
     state: {
       init(stateConfig: EditorStateConfig, state: EditorState) {
         return calculateCitationPluginState(state, config);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4977,7 +4977,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -147,7 +147,6 @@
               />
               <CitationPlugin::CitationCard
                 @controller={{this.controller}}
-                @plugin={{this.citationPlugin}}
                 @config={{this.config.citation}}
               />
               <ImportSnippetPlugin::Card @controller={{this.controller}} />


### PR DESCRIPTION
### Overview
Convert the citation plugin into a keyed one, so we don't have to pass it as an argument to the citation card, and makes it easier to configure the frontend

##### connected issues and PRs:
https://github.com/lblod/frontend-gelinkt-notuleren/pull/792


### Setup
None

### How to test/reproduce
Check the citation plugin is working as it should

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
