### PR TITLE
Redesign of fragment nodes

### DIFF
--- a/.changeset/fluffy-carrots-drum.md
+++ b/.changeset/fluffy-carrots-drum.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Redesign of fragment nodes

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -8,7 +8,6 @@ import t from 'ember-intl/helpers/t';
 import AuIcon, {
   type AuIconSignature,
 } from '@appuniversum/ember-appuniversum/components/au-icon';
-import AuBadge from '@appuniversum/ember-appuniversum/components/au-badge';
 import { SynchronizeIcon } from '@appuniversum/ember-appuniversum/components/icons/synchronize';
 import { BinIcon } from '@appuniversum/ember-appuniversum/components/icons/bin';
 import { AddIcon } from '@appuniversum/ember-appuniversum/components/icons/add';

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -8,6 +8,7 @@ import t from 'ember-intl/helpers/t';
 import AuIcon, {
   type AuIconSignature,
 } from '@appuniversum/ember-appuniversum/components/au-icon';
+import AuBadge from '@appuniversum/ember-appuniversum/components/au-badge';
 import { SynchronizeIcon } from '@appuniversum/ember-appuniversum/components/icons/synchronize';
 import { BinIcon } from '@appuniversum/ember-appuniversum/components/icons/bin';
 import { AddIcon } from '@appuniversum/ember-appuniversum/components/icons/add';
@@ -219,7 +220,12 @@ export default class SnippetNode extends Component<Signature> {
       />
     {{else}}
       <div class='say-snippet-card'>
-        <div class='say-snippet-title'>{{this.node.attrs.title}}</div>
+        <div class='say-snippet-title'>
+          <span class='au-c-badge au-c-badge--small say-snippet-title-icon'>
+            <AuIcon @icon='plus-text' />
+          </span>
+          {{this.node.attrs.title}}
+        </div>
         <div class='say-snippet-content'>{{yield}}</div>
         <div class='say-snippet-icons' contenteditable='false'>
           <SnippetButton

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -225,29 +225,31 @@ export default class SnippetNode extends Component<Signature> {
           </span>
           {{this.node.attrs.title}}
         </div>
-        <div class='say-snippet-content'>{{yield}}</div>
-        <div class='say-snippet-icons' contenteditable='false'>
-          <SnippetButton
-            @icon={{SynchronizeIcon}}
-            @helpText='snippet-plugin.snippet-node.change-fragment'
-            {{on 'click' this.editFragment}}
-            @isActive={{this.isActive}}
-          />
-          <SnippetButton
-            @icon={{BinIcon}}
-            @helpText='snippet-plugin.snippet-node.remove-fragment'
-            {{on 'click' this.deleteFragment}}
-            @isActive={{this.isActive}}
-            class='say-snippet-remove-button'
-          />
-          {{#if this.allowMultipleSnippets}}
+        <div class='say-snippet-content'>
+          {{yield}}
+          <div class='say-snippet-icons' contenteditable='false'>
             <SnippetButton
-              @icon={{AddIcon}}
-              @helpText='snippet-plugin.snippet-node.add-fragment'
-              {{on 'click' this.addFragment}}
+              @icon={{SynchronizeIcon}}
+              @helpText='snippet-plugin.snippet-node.change-fragment'
+              {{on 'click' this.editFragment}}
               @isActive={{this.isActive}}
             />
-          {{/if}}
+            <SnippetButton
+              @icon={{BinIcon}}
+              @helpText='snippet-plugin.snippet-node.remove-fragment'
+              {{on 'click' this.deleteFragment}}
+              @isActive={{this.isActive}}
+              class='say-snippet-remove-button'
+            />
+            {{#if this.allowMultipleSnippets}}
+              <SnippetButton
+                @icon={{AddIcon}}
+                @helpText='snippet-plugin.snippet-node.add-fragment'
+                {{on 'click' this.addFragment}}
+                @isActive={{this.isActive}}
+              />
+            {{/if}}
+          </div>
         </div>
 
       </div>

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -95,7 +95,7 @@
     font-size: 1.6rem;
     font-weight: var(--au-medium);
     padding: 5px;
-    border-bottom: 1px solid  var(--au-blue-300);
+    border-bottom: 1px solid var(--au-blue-300);
     color: var(--au-blue-700);
     .say-snippet-title-icon {
       background-color: var(--au-blue-300);
@@ -150,15 +150,14 @@
   }
 }
 
-
 .ember-node.say-active:has(> .say-snippet-card) {
   outline: none;
 }
 
-.ember-node.say-active > .say-snippet-card{
+.ember-node.say-active > .say-snippet-card {
   border-color: var(--au-blue-700);
   border-width: 0.2rem;
-  > .say-snippet-title{
+  > .say-snippet-title {
     border-bottom-color: var(--au-blue-700);
     border-bottom-width: 0.2rem;
   }

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -105,14 +105,16 @@
   .say-snippet-content {
     padding: 20px;
     min-height: 100px;
-    padding-right: 44px;
+    padding-right: 50px;
+    margin-top: 0;
   }
   .say-snippet-icons {
     display: flex;
     width: fit-content;
     position: absolute !important;
     right: 5px;
-    bottom: 5px;
+    top: 0;
+    margin-top: 0;
     flex-direction: column;
     .say-snippet-button {
       height: 32px;

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -90,10 +90,17 @@
   border: 1px solid var(--au-blue-300);
   border-radius: var(--au-radius);
   .say-snippet-title {
-    background-color: var(--au-blue-300);
+    background-color: var(--au-gray-100);
+    border-radius: 0.1em 0.1em 0 0;
     font-size: 1.6rem;
     font-weight: var(--au-medium);
     padding: 5px;
+    border-bottom: 1px solid  var(--au-blue-300);
+    color: var(--au-blue-700);
+    .say-snippet-title-icon {
+      background-color: var(--au-blue-300);
+      color: black;
+    }
   }
   .say-snippet-content {
     padding: 20px;
@@ -140,6 +147,20 @@
         display: flex;
       }
     }
+  }
+}
+
+
+.ember-node.say-active:has(> .say-snippet-card) {
+  outline: none;
+}
+
+.ember-node.say-active > .say-snippet-card{
+  border-color: var(--au-blue-700);
+  border-width: 0.2rem;
+  > .say-snippet-title{
+    border-bottom-color: var(--au-blue-700);
+    border-bottom-width: 0.2rem;
   }
 }
 


### PR DESCRIPTION
### Overview
Redesigned fragment nodes according to the new design 

##### connected issues and PRs:
GN-5120


### Setup
None

### How to test/reproduce
Insert a snippet, and check that the design of it is the same as in the figma attached to the issue 

### Challenges/uncertainties
Nobody was here so I must have missed something on the design, but didn't see anything more. Also might need to check with saska because I had to recreate the badge which I don't really like



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
