### PR TITLE
Feat/convert snippet plugin to uris

### DIFF
--- a/.changeset/cold-tomatoes-enjoy.md
+++ b/.changeset/cold-tomatoes-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Convert snippet plugin to use uri instead of id

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -126,6 +126,7 @@ export default class SnippetNode extends Component<Signature> {
           )([recalculateNumbers]).transaction;
         });
       } else {
+        console.log(getSnippetListIdsFromNode(this.node));
         const node = createSnippetPlaceholder({
           listProperties: {
             placeholderId: this.node.attrs.placeholderId,
@@ -194,6 +195,7 @@ export default class SnippetNode extends Component<Signature> {
       start = pos;
       end = pos + this.node.nodeSize;
     }
+    console.log(getSnippetListIdsFromNode(this.node));
     this.controller.doCommand(
       insertSnippet({
         content,

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -126,7 +126,6 @@ export default class SnippetNode extends Component<Signature> {
           )([recalculateNumbers]).transaction;
         });
       } else {
-        console.log(getSnippetListUrisFromNode(this.node));
         const node = createSnippetPlaceholder({
           listProperties: {
             placeholderId: this.node.attrs.placeholderId,
@@ -195,7 +194,6 @@ export default class SnippetNode extends Component<Signature> {
       start = pos;
       end = pos + this.node.nodeSize;
     }
-    console.log(getSnippetListUrisFromNode(this.node));
     this.controller.doCommand(
       insertSnippet({
         content,

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -126,7 +126,7 @@ export default class SnippetNode extends Component<Signature> {
           )([recalculateNumbers]).transaction;
         });
       } else {
-        console.log(getSnippetListIdsFromNode(this.node));
+        console.log(getSnippetListUrisFromNode(this.node));
         const node = createSnippetPlaceholder({
           listProperties: {
             placeholderId: this.node.attrs.placeholderId,
@@ -195,7 +195,7 @@ export default class SnippetNode extends Component<Signature> {
       start = pos;
       end = pos + this.node.nodeSize;
     }
-    console.log(getSnippetListIdsFromNode(this.node));
+    console.log(getSnippetListUrisFromNode(this.node));
     this.controller.doCommand(
       insertSnippet({
         content,

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -32,7 +32,7 @@ import { recalculateNumbers } from '@lblod/ember-rdfa-editor-lblod-plugins/plugi
 import { createSnippetPlaceholder } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/nodes/snippet-placeholder';
 import { hasDecendant } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/has-descendant';
 import SnippetPlaceholder from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/nodes/placeholder';
-import { getSnippetListIdsFromNode } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
+import { getSnippetListUrisFromNode } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 
 interface ButtonSig {
   Args: {
@@ -130,7 +130,7 @@ export default class SnippetNode extends Component<Signature> {
         const node = createSnippetPlaceholder({
           listProperties: {
             placeholderId: this.node.attrs.placeholderId,
-            listIds: getSnippetListIdsFromNode(this.node),
+            listUris: getSnippetListUrisFromNode(this.node),
             names: this.node.attrs.snippetListNames,
             importedResources: this.node.attrs.importedResources,
           },
@@ -202,7 +202,7 @@ export default class SnippetNode extends Component<Signature> {
         title,
         listProperties: {
           placeholderId: this.node.attrs.placeholderId,
-          listIds: getSnippetListIdsFromNode(this.node),
+          listUris: getSnippetListUrisFromNode(this.node),
           names: this.node.attrs.snippetListNames,
           importedResources: this.node.attrs.importedResources,
         },
@@ -261,7 +261,7 @@ export default class SnippetNode extends Component<Signature> {
       @closeModal={{this.closeModal}}
       @config={{this.node.attrs.config}}
       @onInsert={{this.onInsert}}
-      @snippetListIds={{getSnippetListIdsFromNode this.node}}
+      @snippetListUris={{getSnippetListUrisFromNode this.node}}
       @snippetListNames={{this.node.attrs.snippetListNames}}
     />
   </template>

--- a/addon/components/snippet-plugin/search-modal.ts
+++ b/addon/components/snippet-plugin/search-modal.ts
@@ -59,7 +59,6 @@ export default class SnippetPluginSearchModalComponent extends Component<Args> {
   }
 
   snippetsSearch = restartableTask(async () => {
-    console.log(this.args.snippetListUris);
     await timeout(500);
 
     const abortController = new AbortController();

--- a/addon/components/snippet-plugin/search-modal.ts
+++ b/addon/components/snippet-plugin/search-modal.ts
@@ -11,7 +11,7 @@ import { SnippetPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plug
 
 interface Args {
   config: SnippetPluginConfig;
-  snippetListIds: string[] | undefined;
+  snippetListUris: string[] | undefined;
   snippetListNames: string[] | undefined;
   closeModal: () => void;
   open: boolean;
@@ -69,7 +69,7 @@ export default class SnippetPluginSearchModalComponent extends Component<Args> {
         abortSignal: abortController.signal,
         filter: {
           name: this.inputSearchText ?? undefined,
-          snippetListIds: this.args.snippetListIds ?? undefined,
+          snippetListUris: this.args.snippetListUris ?? undefined,
         },
         pagination: {
           pageNumber: this.pageNumber,
@@ -92,7 +92,7 @@ export default class SnippetPluginSearchModalComponent extends Component<Args> {
     this.inputSearchText,
     this.pageNumber,
     this.pageSize,
-    this.args.snippetListIds,
+    this.args.snippetListUris,
   ]);
 
   @action

--- a/addon/components/snippet-plugin/search-modal.ts
+++ b/addon/components/snippet-plugin/search-modal.ts
@@ -59,6 +59,7 @@ export default class SnippetPluginSearchModalComponent extends Component<Args> {
   }
 
   snippetsSearch = restartableTask(async () => {
+    console.log(this.args.snippetListUris);
     await timeout(500);
 
     const abortController = new AbortController();

--- a/addon/components/snippet-plugin/snippet-insert-placeholder.gts
+++ b/addon/components/snippet-plugin/snippet-insert-placeholder.gts
@@ -42,6 +42,7 @@ export default class SnippetPluginSnippetInsertPlaceholder extends Component<Sig
     lists: SnippetList[] | undefined,
     allowMultipleSnippets: boolean,
   ) {
+    console.log(lists);
     if (lists) {
       const node = createSnippetPlaceholder({
         lists,

--- a/addon/components/snippet-plugin/snippet-insert-placeholder.gts
+++ b/addon/components/snippet-plugin/snippet-insert-placeholder.gts
@@ -72,7 +72,7 @@ export default class SnippetPluginSnippetInsertPlaceholder extends Component<Sig
     </li>
     <SnippetListModal
       @config={{@config}}
-      @snippetListIds={{empty}}
+      @snippetListUris={{empty}}
       @allowMultipleSnippets={{false}}
       @onSaveSnippetLists={{this.insertPlaceholder}}
       @open={{this.isModalOpen}}

--- a/addon/components/snippet-plugin/snippet-insert-placeholder.gts
+++ b/addon/components/snippet-plugin/snippet-insert-placeholder.gts
@@ -42,7 +42,6 @@ export default class SnippetPluginSnippetInsertPlaceholder extends Component<Sig
     lists: SnippetList[] | undefined,
     allowMultipleSnippets: boolean,
   ) {
-    console.log(lists);
     if (lists) {
       const node = createSnippetPlaceholder({
         lists,

--- a/addon/components/snippet-plugin/snippet-insert-rdfa.gts
+++ b/addon/components/snippet-plugin/snippet-insert-rdfa.gts
@@ -7,7 +7,7 @@ import {
   type SnippetPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import { findParentNodeClosestToPos } from '@curvenote/prosemirror-utils';
-import { getSnippetListIdsFromNode } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
+import { getSnippetListUrisFromNode } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
 import SnippetInsert from './snippet-insert';
 
@@ -22,12 +22,11 @@ interface Sig {
 export default class SnippetInsertRdfaComponent extends Component<Sig> {
   get listProperties(): SnippetListProperties | undefined {
     const activeNode = this.args.node.value;
-    const listIds = getSnippetListIdsFromNode(activeNode);
-    console.log(listIds);
+    const listUris = getSnippetListUrisFromNode(activeNode);
 
-    if (listIds.length > 0) {
+    if (listUris.length > 0) {
       return {
-        listIds,
+        listUris,
         placeholderId: activeNode.attrs.placeholderId,
         names: activeNode.attrs.snippetListNames,
         importedResources: activeNode.attrs.importedResources,
@@ -45,11 +44,11 @@ export default class SnippetInsertRdfaComponent extends Component<Sig> {
       isResourceNode(node),
     );
     while (parentNode) {
-      const listIds = getSnippetListIdsFromNode(parentNode.node);
+      const listUris = getSnippetListUrisFromNode(parentNode.node);
 
-      if (listIds.length > 0) {
+      if (listUris.length > 0) {
         return {
-          listIds,
+          listUris,
           placeholderId: parentNode.node.attrs.placeholderId,
           names: parentNode.node.attrs.snippetListNames,
           importedResources: parentNode.node.attrs.importedResources,

--- a/addon/components/snippet-plugin/snippet-insert-rdfa.gts
+++ b/addon/components/snippet-plugin/snippet-insert-rdfa.gts
@@ -23,6 +23,7 @@ export default class SnippetInsertRdfaComponent extends Component<Sig> {
   get listProperties(): SnippetListProperties | undefined {
     const activeNode = this.args.node.value;
     const listIds = getSnippetListIdsFromNode(activeNode);
+    console.log(listIds);
 
     if (listIds.length > 0) {
       return {

--- a/addon/components/snippet-plugin/snippet-insert.gts
+++ b/addon/components/snippet-plugin/snippet-insert.gts
@@ -31,7 +31,7 @@ export default class SnippetInsertComponent extends Component<Sig> {
     return this.args.controller;
   }
   get disabled() {
-    return (this.args.listProperties?.listIds.length ?? 0) === 0;
+    return (this.args.listProperties?.listUris.length ?? 0) === 0;
   }
 
   @action
@@ -88,7 +88,7 @@ export default class SnippetInsertComponent extends Component<Sig> {
       @closeModal={{this.closeModal}}
       @config={{@config}}
       @onInsert={{this.onInsert}}
-      @snippetListIds={{@listProperties.listIds}}
+      @snippetListUris={{@listProperties.listUris}}
       @snippetListNames={{@listProperties.names}}
     />
   </template>

--- a/addon/components/snippet-plugin/snippet-list-select.gts
+++ b/addon/components/snippet-plugin/snippet-list-select.gts
@@ -16,7 +16,7 @@ import {
   type SnippetList,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import {
-  getAssignedSnippetListsIdsFromProperties,
+  getAssignedSnippetListsUrisFromProperties,
   getSnippetListUrisProperties,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { updateSnippetPlaceholder } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/commands';
@@ -54,7 +54,7 @@ export default class SnippetListSelect extends Component<Signature> {
   }
 
   get snippetListUris(): string[] {
-    return getAssignedSnippetListsIdsFromProperties(
+    return getAssignedSnippetListsUrisFromProperties(
       this.snippetListUrisProperties,
     );
   }

--- a/addon/components/snippet-plugin/snippet-list-select.gts
+++ b/addon/components/snippet-plugin/snippet-list-select.gts
@@ -17,7 +17,7 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
 import {
   getAssignedSnippetListsIdsFromProperties,
-  getSnippetListIdsProperties,
+  getSnippetListUrisProperties,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { updateSnippetPlaceholder } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/commands';
 
@@ -49,13 +49,13 @@ export default class SnippetListSelect extends Component<Signature> {
     return isResourceNode(this.args.node.value);
   }
 
-  get snippetListIdsProperties(): OutgoingTriple[] {
-    return getSnippetListIdsProperties(this.args.node.value);
+  get snippetListUrisProperties(): OutgoingTriple[] {
+    return getSnippetListUrisProperties(this.args.node.value);
   }
 
-  get snippetListIds(): string[] {
+  get snippetListUris(): string[] {
     return getAssignedSnippetListsIdsFromProperties(
-      this.snippetListIdsProperties,
+      this.snippetListUrisProperties,
     );
   }
 
@@ -73,7 +73,7 @@ export default class SnippetListSelect extends Component<Signature> {
       this.args.controller?.doCommand(
         updateSnippetPlaceholder({
           resource: this.currentResource,
-          oldSnippetProperties: this.snippetListIdsProperties ?? [],
+          oldSnippetProperties: this.snippetListUrisProperties ?? [],
           newSnippetLists: lists,
           oldImportedResources: this.imported,
           node: this.args.node,
@@ -99,7 +99,7 @@ export default class SnippetListSelect extends Component<Signature> {
 
       <SnippetListModal
         @config={{@config}}
-        @snippetListIds={{this.snippetListIds}}
+        @snippetListUris={{this.snippetListUris}}
         @onSaveSnippetLists={{this.onSaveSnippetLists}}
         @allowMultipleSnippets={{this.allowMultipleSnippets}}
         @open={{this.showModal}}

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.hbs
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.hbs
@@ -19,7 +19,7 @@
           {{else}}
             <SnippetPlugin::SnippetList::SnippetListView
               @snippetLists={{this.snippetListResource.value}}
-              @snippetListIds={{this.snippetListIds}}
+              @snippetListUris={{this.snippetListUris}}
               @listNameFilter={{this.nameFilterText}}
               @sort={{this.sort}}
               @onChange={{this.onChange}}

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-modal.ts
@@ -23,7 +23,7 @@ interface Signature {
       lists: SnippetList[],
       allowMultipleSnippets: boolean,
     ) => void;
-    snippetListIds: string[] | undefined;
+    snippetListUris: string[] | undefined;
     closeModal: () => void;
     open: boolean;
     allowMultipleSnippets?: boolean;
@@ -40,8 +40,8 @@ export default class SnippetListModalComponent extends Component<Signature> {
   // Display
   @tracked error: unknown;
 
-  @trackedReset('args.snippetListIds')
-  snippetListIds: string[] = [...(this.args.snippetListIds ?? [])];
+  @trackedReset('args.snippetListUris')
+  snippetListUris: string[] = [...(this.args.snippetListUris ?? [])];
 
   @localCopy('args.allowMultipleSnippets') allowMultipleSnippets = false;
 
@@ -63,7 +63,7 @@ export default class SnippetListModalComponent extends Component<Signature> {
   @action
   saveAndClose() {
     const snippetLists = this.snippetListResource.value?.filter((snippetList) =>
-      this.snippetListIds.includes(snippetList.id),
+      this.snippetListUris.includes(snippetList.uri),
     );
     this.args.onSaveSnippetLists(
       snippetLists || [],
@@ -71,7 +71,7 @@ export default class SnippetListModalComponent extends Component<Signature> {
     );
     this.args.closeModal();
     // Clear selection for next time
-    this.snippetListIds = [];
+    this.snippetListUris = [];
   }
 
   snippetListSearch = restartableTask(async () => {
@@ -105,7 +105,7 @@ export default class SnippetListModalComponent extends Component<Signature> {
   );
 
   @action
-  onChange(snippetListIds: string[]) {
-    this.snippetListIds = snippetListIds;
+  onChange(snippetListUris: string[]) {
+    this.snippetListUris = snippetListUris;
   }
 }

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
@@ -52,8 +52,8 @@
           <td class='snippet-list-table-select-column'>
             <AuCheckbox
               id={{row.label}}
-              @onChange={{fn this.onChange row.id}}
-              @checked={{in-array @snippetListUris row.id}}
+              @onChange={{fn this.onChange row.uri}}
+              @checked={{in-array @snippetListUris row.uri}}
             />
           </td>
           <td>{{row.label}}</td>

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-view.hbs
@@ -53,7 +53,7 @@
             <AuCheckbox
               id={{row.label}}
               @onChange={{fn this.onChange row.id}}
-              @checked={{in-array @snippetListIds row.id}}
+              @checked={{in-array @snippetListUris row.id}}
             />
           </td>
           <td>{{row.label}}</td>

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-view.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-view.ts
@@ -12,15 +12,15 @@ interface Args {
 
 export default class SnippetListViewComponent extends Component<Args> {
   @action
-  onChange(snippetId: string, isSelected: boolean) {
+  onChange(snippetUri: string, isSelected: boolean) {
     if (isSelected) {
-      const newSnippetListUris = [...this.args.snippetListUris, snippetId];
+      const newSnippetListUris = [...this.args.snippetListUris, snippetUri];
 
       return this.args.onChange(newSnippetListUris);
     }
 
     const newSnippetListUris = this.args.snippetListUris.filter(
-      (id) => id !== snippetId,
+      (uri) => uri !== snippetUri,
     );
 
     return this.args.onChange(newSnippetListUris);
@@ -40,15 +40,15 @@ export default class SnippetListViewComponent extends Component<Args> {
       return;
     }
 
-    const snippetListId = snippetList.id;
+    const snippetListUri = snippetList.uri;
 
-    if (!snippetListId) {
+    if (!snippetListUri) {
       return;
     }
 
-    const isSelected = this.args.snippetListUris.includes(snippetListId);
+    const isSelected = this.args.snippetListUris.includes(snippetListUri);
 
-    this.onChange(snippetListId, !isSelected);
+    this.onChange(snippetListUri, !isSelected);
   }
 
   get snippetLists() {

--- a/addon/components/snippet-plugin/snippet-list/snippet-list-view.ts
+++ b/addon/components/snippet-plugin/snippet-list/snippet-list-view.ts
@@ -4,26 +4,26 @@ import { SnippetList } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snip
 
 interface Args {
   snippetLists: SnippetList[];
-  snippetListIds: string[];
+  snippetListUris: string[];
   listNameFilter: string | null;
   isLoading: boolean;
-  onChange: (snippetListIds: string[]) => void;
+  onChange: (snippetListUris: string[]) => void;
 }
 
 export default class SnippetListViewComponent extends Component<Args> {
   @action
   onChange(snippetId: string, isSelected: boolean) {
     if (isSelected) {
-      const newSnippetListIds = [...this.args.snippetListIds, snippetId];
+      const newSnippetListUris = [...this.args.snippetListUris, snippetId];
 
-      return this.args.onChange(newSnippetListIds);
+      return this.args.onChange(newSnippetListUris);
     }
 
-    const newSnippetListIds = this.args.snippetListIds.filter(
+    const newSnippetListUris = this.args.snippetListUris.filter(
       (id) => id !== snippetId,
     );
 
-    return this.args.onChange(newSnippetListIds);
+    return this.args.onChange(newSnippetListUris);
   }
 
   @action
@@ -46,7 +46,7 @@ export default class SnippetListViewComponent extends Component<Args> {
       return;
     }
 
-    const isSelected = this.args.snippetListIds.includes(snippetListId);
+    const isSelected = this.args.snippetListUris.includes(snippetListId);
 
     this.onChange(snippetListId, !isSelected);
   }

--- a/addon/plugins/snippet-plugin/commands/update-snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/commands/update-snippet-placeholder.ts
@@ -2,7 +2,6 @@ import { Command } from '@lblod/ember-rdfa-editor';
 import { addProperty, removeProperty } from '@lblod/ember-rdfa-editor/commands';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { SNIPPET_LIST_RDFA_PREDICATE } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
-import { getSnippetUriFromId } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { type OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import { type ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
 import {
@@ -50,7 +49,7 @@ export const updateSnippetPlaceholder = ({
           resource,
           property: {
             predicate: SNIPPET_LIST_RDFA_PREDICATE.prefixed,
-            object: sayDataFactory.namedNode(getSnippetUriFromId(list.id)),
+            object: sayDataFactory.namedNode(list.uri),
           },
           transaction,
         })(newState, (newTransaction) => {

--- a/addon/plugins/snippet-plugin/index.ts
+++ b/addon/plugins/snippet-plugin/index.ts
@@ -38,7 +38,7 @@ export type ImportedResourceMap = Record<string, Option<string>>;
 
 export type SnippetListProperties = {
   placeholderId: string;
-  listIds: string[];
+  listUris: string[];
   names: string[];
   importedResources: ImportedResourceMap;
 };

--- a/addon/plugins/snippet-plugin/index.ts
+++ b/addon/plugins/snippet-plugin/index.ts
@@ -44,20 +44,20 @@ export type SnippetListProperties = {
 };
 
 export type SnippetListArgs = {
-  id: string;
+  uri: string;
   label: string;
   createdOn: string;
   importedResources: string[];
 };
 
 export class SnippetList {
-  id: string;
+  uri: string;
   label: string;
   createdOn: string | null;
   importedResources: string[];
 
-  constructor({ id, label, createdOn, importedResources }: SnippetListArgs) {
-    this.id = getSnippetIdFromUri(id);
+  constructor({ uri, label, createdOn, importedResources }: SnippetListArgs) {
+    this.uri = uri;
     this.label = label;
     this.createdOn = dateValue(createdOn);
     this.importedResources = importedResources;

--- a/addon/plugins/snippet-plugin/index.ts
+++ b/addon/plugins/snippet-plugin/index.ts
@@ -6,7 +6,6 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { dateValue } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/strings';
 import { SafeString } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/types';
-import { getSnippetIdFromUri } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 
 export const DEFAULT_CONTENT_STRING = 'block+';
 

--- a/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
@@ -58,7 +58,7 @@ export function createSnippetPlaceholder({
   ...args
 }: CreateSnippetPlaceholderArgs) {
   let additionalProperties: OutgoingTriple[];
-  let listProps: Omit<SnippetListProperties, 'listIds'>;
+  let listProps: Omit<SnippetListProperties, 'listUris'>;
   if ('lists' in args) {
     listProps = {
       // This is a completely new placeholder, so new id
@@ -72,7 +72,7 @@ export function createSnippetPlaceholder({
   } else {
     // Replacing the last snippet, so keep the id
     listProps = args.listProperties;
-    additionalProperties = args.listProperties.listIds.map(
+    additionalProperties = args.listProperties.listUris.map(
       tripleForSnippetListId,
     );
   }

--- a/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet-placeholder.ts
@@ -25,7 +25,7 @@ import {
   type SnippetList,
   type SnippetPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
-import { tripleForSnippetListId } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
+import { tripleForSnippetListUri } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin/utils/rdfa-predicate';
 import { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 
 export function importedResourcesFromSnippetLists(
@@ -67,13 +67,13 @@ export function createSnippetPlaceholder({
       importedResources: importedResourcesFromSnippetLists(args.lists),
     };
     additionalProperties = args.lists.map((list) =>
-      tripleForSnippetListId(list.id),
+      tripleForSnippetListUri(list.uri),
     );
   } else {
     // Replacing the last snippet, so keep the id
     listProps = args.listProperties;
     additionalProperties = args.listProperties.listUris.map(
-      tripleForSnippetListId,
+      tripleForSnippetListUri,
     );
   }
   const mappingResource = `http://example.net/lblod-snippet-placeholder/${uuidv4()}`;

--- a/addon/plugins/snippet-plugin/nodes/snippet.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet.ts
@@ -35,7 +35,7 @@ import {
   SnippetListProperties,
   type SnippetPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
-import { tripleForSnippetListId } from '../utils/rdfa-predicate';
+import { tripleForSnippetListUri } from '../utils/rdfa-predicate';
 
 function outgoingFromBacklink(
   backlink: IncomingTriple,
@@ -110,7 +110,7 @@ export function createSnippet({
   });
   const properties = [
     ...defaultProperties,
-    ...listUris.map(tripleForSnippetListId),
+    ...listUris.map(tripleForSnippetListUri),
   ];
   const node = schema.node(
     'snippet',
@@ -214,7 +214,7 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
             ? rdfaAttrs.properties
             : [
                 ...rdfaAttrs.properties,
-                ...legacySnippetListUris.map(tripleForSnippetListId),
+                ...legacySnippetListUris.map(tripleForSnippetListUri),
               ];
           return {
             ...rdfaAttrs,

--- a/addon/plugins/snippet-plugin/nodes/snippet.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet.ts
@@ -35,7 +35,10 @@ import {
   SnippetListProperties,
   type SnippetPluginConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
-import { tripleForSnippetListUri } from '../utils/rdfa-predicate';
+import {
+  tripleForSnippetListUri,
+  tripleForSnippetListId,
+} from '../utils/rdfa-predicate';
 
 function outgoingFromBacklink(
   backlink: IncomingTriple,
@@ -207,14 +210,14 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
           // risking having no ability to insert another snippet.
           const placeholderId =
             node.getAttribute('data-snippet-placeholder-id') || uuidv4();
-          const legacySnippetListUris = node
+          const legacySnippetListIds = node
             .getAttribute('data-assigned-snippet-ids')
             ?.split(',');
-          const properties = !legacySnippetListUris
+          const properties = !legacySnippetListIds
             ? rdfaAttrs.properties
             : [
                 ...rdfaAttrs.properties,
-                ...legacySnippetListUris.map(tripleForSnippetListUri),
+                ...legacySnippetListIds.map(tripleForSnippetListId),
               ];
           return {
             ...rdfaAttrs,

--- a/addon/plugins/snippet-plugin/nodes/snippet.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet.ts
@@ -86,7 +86,7 @@ export function createSnippet({
   title,
   allowMultipleSnippets,
   listProperties: {
-    listIds,
+    listUris,
     names: snippetListNames,
     importedResources,
     placeholderId,
@@ -110,7 +110,7 @@ export function createSnippet({
   });
   const properties = [
     ...defaultProperties,
-    ...listIds.map(tripleForSnippetListId),
+    ...listUris.map(tripleForSnippetListId),
   ];
   const node = schema.node(
     'snippet',
@@ -207,14 +207,14 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
           // risking having no ability to insert another snippet.
           const placeholderId =
             node.getAttribute('data-snippet-placeholder-id') || uuidv4();
-          const legacySnippetListIds = node
+          const legacySnippetListUris = node
             .getAttribute('data-assigned-snippet-ids')
             ?.split(',');
-          const properties = !legacySnippetListIds
+          const properties = !legacySnippetListUris
             ? rdfaAttrs.properties
             : [
                 ...rdfaAttrs.properties,
-                ...legacySnippetListIds.map(tripleForSnippetListId),
+                ...legacySnippetListUris.map(tripleForSnippetListId),
               ];
           return {
             ...rdfaAttrs,

--- a/addon/plugins/snippet-plugin/utils/fetch-data.ts
+++ b/addon/plugins/snippet-plugin/utils/fetch-data.ts
@@ -147,7 +147,7 @@ const buildSnippetListFetchQuery = ({
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         PREFIX say: <https://say.data.gift/ns/>
 
-        SELECT (?snippetLists as ?id) ?label ?createdOn ?importedResources WHERE {
+        SELECT (?snippetLists as ?uri) ?label ?createdOn ?importedResources WHERE {
           ?snippetLists a say:SnippetList;
             skos:prefLabel ?label;
             pav:createdOn ?createdOn.
@@ -241,13 +241,13 @@ export const fetchSnippetLists = async ({
   const results = [
     ...queryResult.results.bindings
       .map((binding) => ({
-        id: binding.id?.value,
+        uri: binding.uri?.value,
         label: binding.label?.value,
         createdOn: binding.createdOn?.value,
         importedResources: binding.importedResources?.value,
       }))
       .reduce((mappedResults, bindings) => {
-        const existing = mappedResults.get(bindings.id) ?? {
+        const existing = mappedResults.get(bindings.uri) ?? {
           ...bindings,
           importedResources: [],
         };
@@ -257,7 +257,7 @@ export const fetchSnippetLists = async ({
             bindings.importedResources,
           ];
         }
-        return mappedResults.set(bindings.id, existing);
+        return mappedResults.set(bindings.uri, existing);
       }, new Map<string, SnippetListArgs>())
       .values(),
   ].map((slArgs) => new SnippetList(slArgs));

--- a/addon/plugins/snippet-plugin/utils/fetch-data.ts
+++ b/addon/plugins/snippet-plugin/utils/fetch-data.ts
@@ -94,8 +94,7 @@ const buildSnippetFetchQuery = ({
           OPTIONAL {
             ?snippet schema:position ?position.
           }
-          ?snippetList mu:uuid ?snippetListId;
-                       pav:createdOn ?snippetListCreatedOn.
+          ?snippetList pav:createdOn ?snippetListCreatedOn.
           ?snippetVersion dct:title ?title ;
                           ext:editorDocumentContent ?content.
           OPTIONAL { ?snippetVersion schema:validThrough ?validThrough. }

--- a/addon/plugins/snippet-plugin/utils/fetch-data.ts
+++ b/addon/plugins/snippet-plugin/utils/fetch-data.ts
@@ -3,6 +3,7 @@ import {
   executeCountQuery,
   executeQuery,
   sparqlEscapeString,
+  sparqlEscapeUri,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/sparql-helpers';
 import { Snippet, SnippetList, SnippetListArgs } from '../index';
 
@@ -41,10 +42,9 @@ const buildSnippetCountQuery = ({ name, snippetListUris }: Filter) => {
               : ''
           }
           ${
-            //TODO: Find sparqlEscapeUri
             snippetListUris && snippetListUris.length
               ? `FILTER (?snippetList IN (${snippetListUris
-                  .map((from) => `<${from}>`)
+                  .map(sparqlEscapeUri)
                   .join(', ')}))`
               : ''
           }
@@ -107,7 +107,7 @@ const buildSnippetFetchQuery = ({
           ${
             snippetListUris && snippetListUris.length
               ? `FILTER (?snippetList IN (${snippetListUris
-                  .map((from) => `<${from}>`)
+                  .map(sparqlEscapeUri)
                   .join(', ')}))`
               : ''
           }

--- a/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
+++ b/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
@@ -8,15 +8,13 @@ export const SNIPPET_LIST_RDFA_PREDICATE = SAY('allowedSnippetList');
 
 const snippetListBase = 'http://lblod.data.gift/snippet-lists/';
 
-export const getSnippetUriFromId = (id: string) => `${snippetListBase}${id}`;
-
 export const getSnippetIdFromUri = (uri: string) =>
   uri.replace(snippetListBase, '');
 
-export function tripleForSnippetListId(id: string) {
+export function tripleForSnippetListUri(uri: string) {
   return {
     predicate: SNIPPET_LIST_RDFA_PREDICATE.full,
-    object: sayDataFactory.namedNode(getSnippetUriFromId(id)),
+    object: sayDataFactory.namedNode(uri),
   };
 }
 

--- a/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
+++ b/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
@@ -29,9 +29,7 @@ export const getAssignedSnippetListsIdsFromProperties = (
 ) => {
   return snippetListIdsProperty
     .map((property) => property.object.value)
-    .filter((object) => object !== undefined)
-    .map(getSnippetIdFromUri)
-    .filter((id) => id !== undefined);
+    .filter((object) => object !== undefined);
 };
 
 export const getSnippetListIdsFromNode = (node: PNode) =>

--- a/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
+++ b/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
@@ -6,11 +6,6 @@ import { getOutgoingTripleList } from '@lblod/ember-rdfa-editor-lblod-plugins/ut
 
 export const SNIPPET_LIST_RDFA_PREDICATE = SAY('allowedSnippetList');
 
-const snippetListBase = 'http://lblod.data.gift/snippet-lists/';
-
-export const getSnippetIdFromUri = (uri: string) =>
-  uri.replace(snippetListBase, '');
-
 export function tripleForSnippetListUri(uri: string) {
   return {
     predicate: SNIPPET_LIST_RDFA_PREDICATE.full,

--- a/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
+++ b/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
@@ -20,17 +20,17 @@ export function tripleForSnippetListId(id: string) {
   };
 }
 
-export const getSnippetListIdsProperties = (node: PNode) => {
+export const getSnippetListUrisProperties = (node: PNode) => {
   return getOutgoingTripleList(node.attrs, SNIPPET_LIST_RDFA_PREDICATE);
 };
 
-export const getAssignedSnippetListsIdsFromProperties = (
-  snippetListIdsProperty: OutgoingTriple[] | undefined = [],
+export const getAssignedSnippetListsUrisFromProperties = (
+  snippetListUrisProperty: OutgoingTriple[] | undefined = [],
 ) => {
-  return snippetListIdsProperty
+  return snippetListUrisProperty
     .map((property) => property.object.value)
     .filter((object) => object !== undefined);
 };
 
-export const getSnippetListIdsFromNode = (node: PNode) =>
-  getAssignedSnippetListsIdsFromProperties(getSnippetListIdsProperties(node));
+export const getSnippetListUrisFromNode = (node: PNode) =>
+  getAssignedSnippetListsUrisFromProperties(getSnippetListUrisProperties(node));

--- a/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
+++ b/addon/plugins/snippet-plugin/utils/rdfa-predicate.ts
@@ -6,6 +6,14 @@ import { getOutgoingTripleList } from '@lblod/ember-rdfa-editor-lblod-plugins/ut
 
 export const SNIPPET_LIST_RDFA_PREDICATE = SAY('allowedSnippetList');
 
+const snippetListBase = 'http://lblod.data.gift/snippet-lists/';
+
+export const getSnippetUriFromId = (id: string) => `${snippetListBase}${id}`;
+
+export function tripleForSnippetListId(id: string) {
+  return tripleForSnippetListUri(getSnippetUriFromId(id));
+}
+
 export function tripleForSnippetListUri(uri: string) {
   return {
     predicate: SNIPPET_LIST_RDFA_PREDICATE.full,

--- a/addon/utils/sparql-helpers.ts
+++ b/addon/utils/sparql-helpers.ts
@@ -20,6 +20,16 @@ interface QueryConfig {
 export const sparqlEscapeString = (value: string) =>
   '"""' + value.replace(/[\\"]/g, (match) => '\\' + match) + '"""';
 
+export const sparqlEscapeUri = (value: string) => {
+  return (
+    '<' +
+    value.replace(/[\\"<>]/g, function (match) {
+      return '\\' + match;
+    }) +
+    '>'
+  );
+};
+
 export async function executeQuery<Binding = Record<string, RDF.Term>>({
   query,
   endpoint,


### PR DESCRIPTION
### Overview
The snippet plugin was somehow making weird things converting uris to ids to call the backend, and converting them back to uris, this messed up with uris with a different base, or when the ids didn't match the uris, so I converted everything to just use the uris

##### connected issues and PRs:
GN-5087


### Setup
None

### How to test/reproduce
Play with the snippets and snippets placeholder, verify that everything still works as before

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
