### PR TITLE
bugfix: cleanup incorrect attribute serializations

### DIFF
--- a/.changeset/hot-mugs-decide.md
+++ b/.changeset/hot-mugs-decide.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Clean-up incorrect attribute serializations

--- a/addon/plugins/snippet-plugin/nodes/snippet.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet.ts
@@ -183,7 +183,6 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
       renderable: node,
       tag: 'div',
       attrs: {
-        ...node.attrs,
         'data-snippet-placeholder-id': node.attrs.placeholderId,
         'data-list-names': listNames && JSON.stringify(listNames),
         'data-imported-resources': JSON.stringify(node.attrs.importedResources),

--- a/addon/plugins/variable-plugin/variables/autofilled.ts
+++ b/addon/plugins/variable-plugin/variables/autofilled.ts
@@ -129,7 +129,6 @@ const toDOM = (node: PNode): DOMOutputSpec => {
     renderable: node,
     tag: 'span',
     attrs: {
-      ...node.attrs,
       'data-autofill-key': node.attrs.autofillKey,
       'data-convert-to-string': node.attrs.convertToString,
       'data-initialized': node.attrs.initialized,

--- a/addon/plugins/variable-plugin/variables/text.ts
+++ b/addon/plugins/variable-plugin/variables/text.ts
@@ -114,7 +114,7 @@ const toDOM = (node: PNode): DOMOutputSpec => {
   return renderRdfaAware({
     renderable: node,
     tag: 'span',
-    attrs: node.attrs,
+    attrs: {},
     content: 0,
   });
 };


### PR DESCRIPTION
### Overview
This PR includes some adjustments to the attribute serializations of the following nodespecs:
- `autofilled` variable
- `snippet` node
- `text` variable

These nodespecs incorrectly serialized all their attributes (including non-legal HTML attributes).

##### connected issues and PRs:
None

### How to test/reproduce
- Start the app
- Ensure that the `autofilled`, `text` and `snippet` nodes still serialize + parse correctly

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
