### PR TITLE
roadsign-regulation plugin: deprecate `articleUriGenrator` in favour for `articleUriGenerator` option

### DIFF
--- a/.changeset/short-walls-sparkle.md
+++ b/.changeset/short-walls-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+roadsign-regulation-plugin: deprecate `articleUriGenrator` in favour for `articleUriGenerator` option

--- a/addon/components/roadsign-regulation-plugin/roadsigns-modal.ts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-modal.ts
@@ -324,7 +324,8 @@ export default class RoadsignsModal extends Component<Args> {
     const passedDecisionUri = this.args.options.decisionContext?.decisionUri;
     const article = buildArticleStructure(
       this.controller.activeEditorState.schema,
-      this.args.options.articleUriGenrator,
+      this.args.options.articleUriGenerator ??
+        this.args.options.articleUriGenrator,
       this.args.options.decisionContext?.decisionUri,
     );
     const contentFragment = ProseParser.fromSchema(

--- a/addon/plugins/roadsign-regulation-plugin/index.ts
+++ b/addon/plugins/roadsign-regulation-plugin/index.ts
@@ -1,10 +1,20 @@
 export type RoadsignRegulationPluginOptions = {
   endpoint: string;
   imageBaseUrl: string;
-  articleUriGenrator?: () => string;
   /** Instead of finding a decision node in the document, pass the relevant URI and type */
   decisionContext?: {
     decisionUri: string;
     decisionType?: string;
   };
-};
+} & (
+  | {
+      articleUriGenerator?: never;
+      /** @deprecated use `articleUriGenerator` instead */
+      articleUriGenrator?: () => string;
+    }
+  | {
+      articleUriGenerator?: () => string;
+      /** @deprecated use `articleUriGenerator` instead */
+      articleUriGenrator?: never;
+    }
+);


### PR DESCRIPTION
### Overview
This PR deprecates the mistyped  `articleUriGenrator` in favour for `articleUriGenerator` option in the roadsign-regulation plugin.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
