### PR TITLE
fix(structures): add css solution to fix title behavior

### DIFF
--- a/.changeset/sharp-parents-eat.md
+++ b/.changeset/sharp-parents-eat.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Rework the css of the structures to make their behavior more intuitive

--- a/addon/components/structure-plugin/_private/structure.gts
+++ b/addon/components/structure-plugin/_private/structure.gts
@@ -180,7 +180,9 @@ export default class Structure extends Component<Sig> {
       <div class='say-structure__header' contenteditable='false'>
 
         {{#let (element this.headerTag) as |Tag|}}
-          <Tag>{{this.title}}
+          <Tag class='say-structure__header-element'><span
+              class='say-structure__name'
+            >{{this.title}}</span>
 
             {{#if this.hasTitle}}
               <span

--- a/app/styles/structure-plugin.scss
+++ b/app/styles/structure-plugin.scss
@@ -31,7 +31,6 @@
     .say-structure__title {
       flex: 1 1 100%;
 
-
       border: none;
       flex-grow: 1;
       display: inline-block;
@@ -88,11 +87,11 @@
   outline: none;
 }
 
-.ember-node.say-active>.say-structure {
+.ember-node.say-active > .say-structure {
   border-color: var(--au-blue-700);
   border-width: 0.2rem;
 
-  >.say-structure__header {
+  > .say-structure__header {
     border-bottom-color: var(--au-blue-700);
     border-bottom-width: 0.2rem;
   }

--- a/app/styles/structure-plugin.scss
+++ b/app/styles/structure-plugin.scss
@@ -6,39 +6,77 @@
   flex-direction: column;
   white-space: normal;
 }
+
 .say-structure__header {
   background-color: var(--au-gray-100);
-  display: flex;
-  gap: 5px;
-  flex-direction: row;
   padding-left: 0.7rem;
   border-bottom: 1px solid var(--au-gray-300);
   border-radius: 0.1em 0.1em 0 0;
 
-  h5 {
+  .say-structure__header-element {
     margin: 0;
     font-weight: var(--au-medium);
-    font-size: var(--au-h-functional);
-  }
-  .say-structure__title {
-    flex-grow: 1;
-  }
-  [contenteditable] {
-    border: none;
-    font-size: var(--au-h4);
-    flex-grow: 1;
-    &:focus {
-      outline: none;
+    /* font-size: var(--au-h-functional); */
+    gap: 5px;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    display: flex;
+    width: 100%;
+    align-content: baseline;
+
+    .say-structure__name {
+      flex: 0 0 content;
     }
-    padding: 0;
-    white-space: break-spaces;
-    word-break: break-word;
-    word-wrap: break-word;
+
+    .say-structure__title {
+      flex: 1 1 100%;
+
+
+      border: none;
+      flex-grow: 1;
+      display: inline-block;
+
+      &:focus {
+        outline: none;
+      }
+
+      padding: 0;
+      white-space: break-spaces;
+      word-break: break-word;
+      word-wrap: break-word;
+    }
+  }
+
+  h1.say-structure__header-element {
+    font-size: var(--au-h1);
+  }
+
+  h2.say-structure__header-element {
+    font-size: var(--au-h2);
+  }
+
+  h3.say-structure__header-element {
+    font-size: var(--au-h3);
+  }
+
+  h4.say-structure__header-element {
+    font-size: var(--au-h4);
+  }
+
+  h5.say-structure__header-element {
+    font-size: var(--au-h5);
+  }
+
+  h6.say-structure__header-element {
+    font-size: var(--au-h6);
   }
 }
+
 .say-structure__content {
   padding: 0.7rem;
   padding-right: 3rem;
+  margin-top: 0 !important;
+
   [data-slot] {
     white-space: break-spaces;
     word-break: break-word;
@@ -50,10 +88,11 @@
   outline: none;
 }
 
-.ember-node.say-active > .say-structure {
+.ember-node.say-active>.say-structure {
   border-color: var(--au-blue-700);
   border-width: 0.2rem;
-  > .say-structure__header {
+
+  >.say-structure__header {
     border-bottom-color: var(--au-blue-700);
     border-bottom-width: 0.2rem;
   }

--- a/app/styles/structure-plugin.scss
+++ b/app/styles/structure-plugin.scss
@@ -71,10 +71,12 @@
   }
 }
 
+.say-structure > .say-structure__content {
+  margin-top: 0;
+}
 .say-structure__content {
   padding: 0.7rem;
   padding-right: 3rem;
-  margin-top: 0 !important;
 
   [data-slot] {
     white-space: break-spaces;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11315,6 +11315,27 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
+  '@types/ember@4.0.11':
+    dependencies:
+      '@types/ember__application': 4.0.11(@babel/core@7.26.0)
+      '@types/ember__array': 4.0.10(@babel/core@7.26.0)
+      '@types/ember__component': 4.0.22(@babel/core@7.26.0)
+      '@types/ember__controller': 4.0.12(@babel/core@7.26.0)
+      '@types/ember__debug': 4.0.8(@babel/core@7.26.0)
+      '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
+      '@types/ember__error': 4.0.6
+      '@types/ember__object': 4.0.12(@babel/core@7.26.0)
+      '@types/ember__polyfills': 4.0.6
+      '@types/ember__routing': 4.0.22(@babel/core@7.26.0)
+      '@types/ember__runloop': 4.0.10
+      '@types/ember__service': 4.0.9(@babel/core@7.26.0)
+      '@types/ember__string': 3.16.3
+      '@types/ember__template': 4.0.7
+      '@types/ember__test': 4.0.6(@babel/core@7.26.0)
+      '@types/ember__utils': 4.0.7
+      '@types/rsvp': 4.0.9
+    optional: true
+
   '@types/ember@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@types/ember__application': 4.0.11(@babel/core@7.26.0)
@@ -11342,7 +11363,7 @@ snapshots:
   '@types/ember__application@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
-      '@types/ember': 4.0.11(@babel/core@7.26.0)
+      '@types/ember': 4.0.11
       '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
       '@types/ember__object': 4.0.12(@babel/core@7.26.0)
       '@types/ember__owner': 4.0.9
@@ -11444,6 +11465,11 @@ snapshots:
       - supports-color
     optional: true
 
+  '@types/ember__runloop@4.0.10':
+    dependencies:
+      '@types/ember': 4.0.11
+    optional: true
+
   '@types/ember__runloop@4.0.10(@babel/core@7.26.0)':
     dependencies:
       '@types/ember': 4.0.11(@babel/core@7.26.0)
@@ -11474,6 +11500,11 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    optional: true
+
+  '@types/ember__utils@4.0.7':
+    dependencies:
+      '@types/ember': 4.0.11
     optional: true
 
   '@types/ember__utils@4.0.7(@babel/core@7.26.0)':


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->
Makes clicking in titles work better by leveraging flex rendering to make the title box as wide as the whole header

also removes the margin from the content, which came from a rule somewhere in the editor stylings. I used important here to get around it, which is not ideal but it works.

This prevents the state where clicking in just the wrong spot node-selects the structure (characterized by having no blinking cursor), after which typing would replace the whole structure with the typed text.

Another way to prevent this would have been making the structure no longer node-selectable, but that then interferes with how we likely want the backspace into the structure nodes to behave.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->

built on #535 

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
