### PR TITLE
Add support for moving and numbering structures to structure plugin

### DIFF
--- a/.changeset/blue-suns-guess.md
+++ b/.changeset/blue-suns-guess.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Include ability to modify start numbers in structure plugin

--- a/.changeset/smooth-insects-pull.md
+++ b/.changeset/smooth-insects-pull.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Add support for moving article structures to generic structure plugin

--- a/addon/components/structure-plugin/_private/control-card.gts
+++ b/addon/components/structure-plugin/_private/control-card.gts
@@ -24,9 +24,12 @@ import { moveStructure } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/st
 import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
+import { regenerateRdfaLinks } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/structure-plugin/regenerate-rdfa-links';
+
 interface Sig {
   Args: { controller: SayController };
 }
+
 export default class StructureControlCardComponent extends Component<Sig> {
   @service declare intl: IntlService;
   get controller(): SayController {
@@ -71,14 +74,18 @@ export default class StructureControlCardComponent extends Component<Sig> {
       if (withContent) {
         this.controller.withTransaction((tr, state) => {
           tr.replace(pos, pos + node.nodeSize);
-          return transactionCombinator<boolean>(state, tr)([recalculateNumbers])
-            .transaction;
+          return transactionCombinator<boolean>(
+            state,
+            tr,
+          )([recalculateNumbers, regenerateRdfaLinks]).transaction;
         });
       } else {
         this.controller.withTransaction((tr, state) => {
           tr.replaceWith(pos, pos + node.nodeSize, node.content);
-          return transactionCombinator<boolean>(state, tr)([recalculateNumbers])
-            .transaction;
+          return transactionCombinator<boolean>(
+            state,
+            tr,
+          )([recalculateNumbers, regenerateRdfaLinks]).transaction;
         });
       }
     }
@@ -148,7 +155,10 @@ export default class StructureControlCardComponent extends Component<Sig> {
                       {{hover.handleHover}}
                       {{on 'click' (fn this.removeStructure false)}}
                     >
-                      {{t 'article-structure-plugin.remove.article'}}
+                      {{t
+                        'structure-plugin.remove'
+                        structureName=this.structureName
+                      }}
                     </AuButton>
                   </:hover>
                   <:tooltip as |tooltip|>
@@ -170,7 +180,8 @@ export default class StructureControlCardComponent extends Component<Sig> {
                       {{on 'click' (fn this.removeStructure true)}}
                     >
                       {{t
-                        'article-structure-plugin.remove-with-content.article'
+                        'structure-plugin.remove-with-content'
+                        structureName=this.structureName
                       }}
                     </AuButton>
                   </:hover>

--- a/addon/plugins/article-structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/article-structure-plugin/commands/insert-structure.ts
@@ -13,27 +13,18 @@ const insertStructure = (
   uriGenerator: StructurePluginOptions['uriGenerator'],
 ): Command => {
   return (state, dispatch) => {
-    const insertStructureTransaction = findHowToInsertStructure(
-      state,
-      structureType,
-      uriGenerator,
-    );
-    if (insertStructureTransaction) {
-      const { result, transaction } = transactionCombinator(
-        state,
-        insertStructureTransaction,
-        // Prevent calculations that will not fail, if the command is just being tested
-      )(dispatch ? [recalculateNumbers, regenerateRdfaLinks] : []);
+    const { result, transaction } = transactionCombinator(state)([
+      findHowToInsertStructure(structureType, uriGenerator),
+      // Prevent calculations that will not fail, if the command is just being tested
+      ...(dispatch ? [recalculateNumbers, regenerateRdfaLinks] : []),
+    ]);
 
-      transaction.scrollIntoView();
-      if (result.every((ok) => ok)) {
-        if (dispatch) {
-          dispatch(transaction);
-        }
-        return true;
-      } else {
-        return false;
+    transaction.scrollIntoView();
+    if (result.every((ok) => ok)) {
+      if (dispatch) {
+        dispatch(transaction);
       }
+      return true;
     } else {
       return false;
     }

--- a/addon/plugins/article-structure-plugin/utils/structure.ts
+++ b/addon/plugins/article-structure-plugin/utils/structure.ts
@@ -1,5 +1,6 @@
 import {
   Attrs,
+  NodeSelection,
   NodeSpec,
   NodeType,
   PNode,
@@ -255,7 +256,22 @@ export function constructStructureHeaderNodeSpec({
   };
 }
 
+/**
+ * Find an ancestor of the current selection of one of the given nodetypes. Includes the selection
+ * itself if it is a NodeSelection
+ */
 export function findAncestorOfType(selection: Selection, ...types: NodeType[]) {
+  if (
+    selection instanceof NodeSelection &&
+    types.includes(selection.node.type)
+  ) {
+    return {
+      node: selection.node,
+      pos: selection.from,
+      start: selection.from,
+      depth: selection.$from.depth,
+    };
+  }
   const parent = findParentNodeOfType(types)(selection);
   if (parent) {
     return parent;

--- a/addon/plugins/decision-plugin/utils/build-article-structure.ts
+++ b/addon/plugins/decision-plugin/utils/build-article-structure.ts
@@ -1,6 +1,5 @@
 import { Schema } from '@lblod/ember-rdfa-editor';
 import {
-  BESLUIT,
   ELI,
   PROV,
   RDF,
@@ -11,7 +10,10 @@ import {
 } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { v4 as uuid } from 'uuid';
-import { type StructureConfig } from '../../structure-plugin/structure-types';
+import {
+  DECISION_ARTICLE,
+  type StructureConfig,
+} from '../../structure-plugin/structure-types';
 
 export function generateStructureAttrs({
   config,
@@ -67,15 +69,7 @@ export function buildArticleStructure(
   return schema.node(
     'structure',
     generateStructureAttrs({
-      config: {
-        structureType: 'article',
-        rdfType: BESLUIT('Artikel'),
-        resourceUri: 'http://data.lblod.info/artikels/',
-        hasTitle: false,
-        headerFormat: 'name',
-        romanize: false,
-        headerTag: 'h5',
-      },
+      config: DECISION_ARTICLE,
       subject: articleResource,
       properties: [
         {

--- a/addon/plugins/structure-plugin/insert-structure.ts
+++ b/addon/plugins/structure-plugin/insert-structure.ts
@@ -3,10 +3,10 @@ import {
   EditorState,
   findWrapping,
   NodeSelection,
-  Transaction,
 } from '@lblod/ember-rdfa-editor';
 import { findHowToWrapIncludingParents } from '@lblod/ember-rdfa-editor/utils/wrap-utils';
 import { findAncestors } from '@lblod/ember-rdfa-editor/utils/position-utils';
+import { type TransactionMonad } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
 import { generateStructureAttrs } from '../decision-plugin/utils/build-article-structure';
 import {
   type StructurePluginOptions,
@@ -29,111 +29,130 @@ import {
  * selection
  */
 export function findHowToInsertStructure(
-  state: EditorState,
   structureType: StructureType,
   uriGenerator: StructurePluginOptions['uriGenerator'],
-): Transaction | false {
-  const structConfig = STRUCTURE_HIERARCHY.find(
-    ({ structureType: type }) => type === structureType,
-  );
-  const hierarchyRank =
-    structConfig && findRankInHierarchy(structConfig.rdfType.full);
-  if (!structConfig || isNone(hierarchyRank)) {
-    console.warn(
-      "Trying to insert a structure type that isn't valid",
-      structureType,
+): TransactionMonad<boolean> {
+  return (state: EditorState) => {
+    let tr = state.tr;
+    const structConfig = STRUCTURE_HIERARCHY.find(
+      ({ structureType: type }) => type === structureType,
     );
-    return false;
-  }
-  let subject: string;
-  if (typeof uriGenerator === 'function') {
-    subject = uriGenerator(structureType);
-  } else {
-    subject =
-      structConfig.resourceUri +
-      (uriGenerator === 'uuid4' ? uuid() : `--ref-uuid4-${uuid()}`);
-  }
-  const structAttrs = generateStructureAttrs({ config: structConfig, subject });
+    const hierarchyRank =
+      structConfig && findRankInHierarchy(structConfig.rdfType.full);
+    if (!structConfig || isNone(hierarchyRank)) {
+      console.warn(
+        "Trying to insert a structure type that isn't valid",
+        structureType,
+      );
+      return { initialState: state, transaction: tr, result: false };
+    }
+    let subject: string;
+    if (typeof uriGenerator === 'function') {
+      subject = uriGenerator(structureType);
+    } else {
+      subject =
+        structConfig.resourceUri +
+        (uriGenerator === 'uuid4' ? uuid() : `--ref-uuid4-${uuid()}`);
+    }
+    const structAttrs = generateStructureAttrs({
+      config: structConfig,
+      subject,
+    });
 
-  const { schema, selection } = state;
-  // ### Find the nearest parent structure which is higher in the hierarchy
+    const { schema, selection } = state;
+    // ### Find the nearest parent structure which is higher in the hierarchy
 
-  // parents which are structure nodes, not necessarily higher in the hierarchy
-  // parentStructures goes from nearest -> furthest
-  const parentStructures = findAncestors(selection.$from, isHierarchyNode)
-    .map(calculateHierarchyRank)
-    .filter(isSome);
-  if (selection instanceof NodeSelection) {
-    // 'findAncestors' doesn't include the current selection, so incude it if relevant
-    const node = selection.node;
-    if (isHierarchyNode(node)) {
-      const selectedStructureRank = calculateHierarchyRank({
-        node,
-        pos: selection.from,
-      });
-      if (isSome(selectedStructureRank)) {
-        parentStructures.unshift(selectedStructureRank);
+    // parents which are structure nodes, not necessarily higher in the hierarchy
+    // parentStructures goes from nearest -> furthest
+    const parentStructures = findAncestors(selection.$from, isHierarchyNode)
+      .map(calculateHierarchyRank)
+      .filter(isSome);
+    if (selection instanceof NodeSelection) {
+      // 'findAncestors' doesn't include the current selection, so incude it if relevant
+      const node = selection.node;
+      if (isHierarchyNode(node)) {
+        const selectedStructureRank = calculateHierarchyRank({
+          node,
+          pos: selection.from,
+        });
+        if (isSome(selectedStructureRank)) {
+          parentStructures.unshift(selectedStructureRank);
+        }
       }
     }
-  }
 
-  const closestAncestorRank = parentStructures[0]?.rank;
-  // ### Either there is no parent structure or the nearest parent is higher in the hierarchy
-  if (parentStructures.length === 0 || closestAncestorRank < hierarchyRank) {
-    if (selection instanceof NodeSelection && isHierarchyNode(selection.node)) {
-      // We're selecting a hierarchy node, so don't wrap, insert inside it
-      const selFrom = selection.anchor;
-      const node = schema.nodes['structure'].create(
-        structAttrs,
-        schema.nodes['paragraph'].create(),
-      );
-      return state.tr.replaceWith(selFrom + 1, selFrom + 1, node);
-    }
-
-    return findHowToWrapIncludingParents(
-      state,
-      schema.nodes['structure'],
-      structAttrs,
-    );
-  } else {
-    // ### We have parent structures that are lower in the hierarchy, so find one where we can insert
-    for (let i = 0; i < parentStructures.length; i++) {
-      const parentStructure = parentStructures[i];
-      const parentRank = parentStructure.rank;
-      if (hierarchyRank === parentRank) {
-        // ### If parent we are looking at is same structure type, put an empty structure after that one
-        const insertLocation =
-          parentStructure.pos + parentStructure.node.nodeSize;
+    const closestAncestorRank = parentStructures[0]?.rank;
+    // ### Either there is no parent structure or the nearest parent is higher in the hierarchy
+    if (parentStructures.length === 0 || closestAncestorRank < hierarchyRank) {
+      if (
+        selection instanceof NodeSelection &&
+        isHierarchyNode(selection.node)
+      ) {
+        // We're selecting a hierarchy node, so don't wrap, insert inside it
+        const selFrom = selection.anchor;
         const node = schema.nodes['structure'].create(
           structAttrs,
           schema.nodes['paragraph'].create(),
         );
-        return state.tr.replaceWith(insertLocation, insertLocation, node);
-      } else if (hierarchyRank < parentRank) {
-        // ### Parent is a structure that can fit inside our new one. Look at the structure above
-        // that to know how to insert
-        const parentOfParentRank: Option<number> =
-          parentStructures[i + 1] && parentStructures[i + 1].rank;
-        if (isNone(parentOfParentRank) || parentOfParentRank < hierarchyRank) {
-          // wrap parent and put inside parent of parent if it exists...
-          const $from = state.doc.resolve(parentStructure.pos);
-          const $to = state.doc.resolve(
-            parentStructure.pos + parentStructure.node.nodeSize,
+        tr = state.tr.replaceWith(selFrom + 1, selFrom + 1, node);
+        return { initialState: state, transaction: tr, result: true };
+      }
+
+      const wrapTr = findHowToWrapIncludingParents(
+        state,
+        schema.nodes['structure'],
+        structAttrs,
+      );
+      if (wrapTr) {
+        return { initialState: state, transaction: wrapTr, result: true };
+      } else {
+        return { initialState: state, transaction: tr, result: false };
+      }
+    } else {
+      // ### We have parent structures that are lower in the hierarchy, so find one where we can insert
+      for (let i = 0; i < parentStructures.length; i++) {
+        const parentStructure = parentStructures[i];
+        const parentRank = parentStructure.rank;
+        if (hierarchyRank === parentRank) {
+          // ### If parent we are looking at is same structure type, put an empty structure after that one
+          const insertLocation =
+            parentStructure.pos + parentStructure.node.nodeSize;
+          const node = schema.nodes['structure'].create(
+            structAttrs,
+            schema.nodes['paragraph'].create(),
           );
-          const range = $from.blockRange($to);
-          const wrapping =
-            range &&
-            findWrapping(range, schema.nodes['structure'], structAttrs);
-          if (wrapping) {
-            return state.tr.wrap(range, wrapping);
-          } else {
-            return false;
+          tr = state.tr.replaceWith(insertLocation, insertLocation, node);
+          return { initialState: state, transaction: tr, result: true };
+        } else if (hierarchyRank < parentRank) {
+          // ### Parent is a structure that can fit inside our new one. Look at the structure above
+          // that to know how to insert
+          const parentOfParentRank: Option<number> =
+            parentStructures[i + 1] && parentStructures[i + 1].rank;
+          if (
+            isNone(parentOfParentRank) ||
+            parentOfParentRank < hierarchyRank
+          ) {
+            // wrap parent and put inside parent of parent if it exists...
+            const $from = state.doc.resolve(parentStructure.pos);
+            const $to = state.doc.resolve(
+              parentStructure.pos + parentStructure.node.nodeSize,
+            );
+            const range = $from.blockRange($to);
+            const wrapping =
+              range &&
+              findWrapping(range, schema.nodes['structure'], structAttrs);
+            if (wrapping) {
+              tr = state.tr.wrap(range, wrapping);
+              return { initialState: state, transaction: tr, result: true };
+            } else {
+              return { initialState: state, transaction: tr, result: false };
+            }
           }
         }
+        // Keep looking
       }
-      // Keep looking
+      // This should never happen as all realistic cases should have been handled
+      return { initialState: state, transaction: tr, result: false };
     }
-    // This should never happen as all realistic cases should have been handled
-    return false;
-  }
+  };
 }

--- a/addon/plugins/structure-plugin/move-structure.ts
+++ b/addon/plugins/structure-plugin/move-structure.ts
@@ -34,7 +34,10 @@ export function moveStructure(direction: 'up' | 'down'): Command {
         findNodePosUp(doc, pos, ($pos: ResolvedPos) => {
           const nodeAfter = $pos.nodeAfter;
           if (nodeAfter) {
-            return nodeAfter.type.name === 'structure';
+            return (
+              nodeAfter.type.name === 'structure' &&
+              nodeAfter.attrs.structureType === node.attrs.structureType
+            );
           }
           return false;
         }).next().value ?? null;
@@ -77,7 +80,10 @@ export function moveStructure(direction: 'up' | 'down'): Command {
           doc,
           doc.resolve(pos + node.nodeSize),
           (parent: PNode) => {
-            return parent.type.name === 'structure';
+            return (
+              parent.type.name === 'structure' &&
+              parent.attrs.structureType === node.attrs.structureType
+            );
           },
         ).next().value ?? null;
       if (isNone(nextStructureParentPos)) {

--- a/addon/plugins/structure-plugin/move-structure.ts
+++ b/addon/plugins/structure-plugin/move-structure.ts
@@ -4,17 +4,18 @@ import {
   ResolvedPos,
   TextSelection,
 } from '@lblod/ember-rdfa-editor';
-import { findAncestorOfType } from '../article-structure-plugin/utils/structure';
 import {
   findNodePosDown,
   findNodePosUp,
 } from '@lblod/ember-rdfa-editor/utils/position-utils';
+import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
+import { findAncestorOfType } from '../article-structure-plugin/utils/structure';
 import {
   isNone,
   unwrap,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { recalculateNumbers } from './recalculate-structure-numbers';
-import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
+import { regenerateRdfaLinks } from './regenerate-rdfa-links';
 
 export function moveStructure(direction: 'up' | 'down'): Command {
   return (state, dispatch) => {
@@ -53,7 +54,7 @@ export function moveStructure(direction: 'up' | 'down'): Command {
           const { transaction: newTr } = transactionCombinator(
             state,
             transaction,
-          )([recalculateNumbers]);
+          )([recalculateNumbers, regenerateRdfaLinks]);
 
           // previousStructurePos should now point to the position right before our moved structure
           // so we can simply add 1 to get the first position inside of it, and for the end
@@ -89,6 +90,9 @@ export function moveStructure(direction: 'up' | 'down'): Command {
       if (dispatch) {
         const transaction = state.tr;
         const $structurePos = doc.resolve(nextStructurePos);
+        if (isNone($structurePos.nodeAfter)) {
+          return false;
+        }
         const nextStructureNode = unwrap($structurePos.nodeAfter);
 
         transaction.delete(pos, pos + node.nodeSize);
@@ -100,7 +104,7 @@ export function moveStructure(direction: 'up' | 'down'): Command {
         const { transaction: newTr } = transactionCombinator(
           state,
           transaction,
-        )([recalculateNumbers]);
+        )([recalculateNumbers, regenerateRdfaLinks]);
 
         // since we've deleted something before the insert position, we have to map
         // the positions through the transaction to find the moved node's new position

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -207,6 +207,7 @@ export const emberNodeConfig: (config?: StructureConfig) => EmberNodeConfig = (
         attrs: {
           'data-say-render-as': 'structure',
           'data-say-has-title': hasTitle,
+          // Should we use the RDFa type instead of a data attribute for this?
           'data-say-structure-type': structureType,
           'data-say-header-format': headerFormat,
           'data-say-header-tag': tag,

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -90,6 +90,9 @@ export const emberNodeConfig: (config?: StructureConfig) => EmberNodeConfig = (
       number: {
         default: 1,
       },
+      startNumber: {
+        default: null,
+      },
       isOnlyArticle: {
         default: false,
       },
@@ -118,6 +121,7 @@ export const emberNodeConfig: (config?: StructureConfig) => EmberNodeConfig = (
       const tag = node.attrs.headerTag;
       const structureType = node.attrs.structureType as StructureType;
       const number = node.attrs.number as number;
+      const startNumber = node.attrs.startNumber as number | null;
       const isOnlyArticle = node.attrs.isOnlyArticle as boolean;
       const hasTitle = node.attrs.hasTitle as boolean;
       const titleHTML = hasTitle
@@ -207,6 +211,7 @@ export const emberNodeConfig: (config?: StructureConfig) => EmberNodeConfig = (
           'data-say-header-format': headerFormat,
           'data-say-header-tag': tag,
           'data-say-number': number,
+          'data-say-start-number': startNumber,
           'data-say-romanize': romanizeNumber,
           'data-say-is-only-article': isOnlyArticle,
         },
@@ -252,6 +257,9 @@ export const emberNodeConfig: (config?: StructureConfig) => EmberNodeConfig = (
               headerFormat,
               headerTag: node.dataset.sayHeaderTag,
               number: Number(node.dataset.sayNumber),
+              startNumber:
+                node.dataset.sayStartNumber &&
+                Number(node.dataset.sayStartNumber),
               romanize: parseBooleanDatasetAttribute(node, 'sayRomanize'),
               isOnlyArticle: parseBooleanDatasetAttribute(
                 node,

--- a/addon/plugins/structure-plugin/recalculate-structure-numbers.ts
+++ b/addon/plugins/structure-plugin/recalculate-structure-numbers.ts
@@ -19,7 +19,12 @@ export function recalculateNumbers(
       doc.descendants((node, pos) => {
         if (node.type.name === 'structure') {
           if (hasOutgoingNamedNodeTriple(node.attrs, RDF('type'), rdfType)) {
-            counter += 1;
+            const startNumber = node.attrs.startNumber;
+            if (startNumber) {
+              counter = startNumber;
+            } else {
+              counter += 1;
+            }
             lastNodePos = pos;
             if (node.attrs.isOnlyArticle === true) {
               tr.setNodeAttribute(pos, 'isOnlyArticle', false);

--- a/addon/plugins/structure-plugin/regenerate-rdfa-links.ts
+++ b/addon/plugins/structure-plugin/regenerate-rdfa-links.ts
@@ -65,6 +65,7 @@ function linkAllChildrenToParent(parent: PNode): TransactionMonad<boolean>[] {
   return monads;
 }
 
+// TODO add support for decision structure nodes to this to remove their current manual linking
 export const regenerateRdfaLinks = composeMonads((state) => {
   const monads: TransactionMonad<boolean>[] = [];
   // First find all the nodes that are in the hierarchy, but do not have a parent that is part of

--- a/addon/plugins/structure-plugin/structure-types.ts
+++ b/addon/plugins/structure-plugin/structure-types.ts
@@ -1,5 +1,6 @@
 import { type PNode } from '@lblod/ember-rdfa-editor';
 import {
+  BESLUIT,
   RDF,
   SAY,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
@@ -36,6 +37,11 @@ export interface StructureConfig {
   headerFormat?: 'plain-number' | 'name' | 'section-symbol';
   headerTag?: string;
   romanize: boolean;
+  /**
+   * If numbering is done for the whole document, rather than restarting for each parent structure,
+   * e.g. if false: Chapter 1 > Section 1, Chapter 2 > Section 1
+   */
+  absoluteNumbering: boolean;
 }
 
 export const STRUCTURE_HIERARCHY: StructureConfig[] = [
@@ -49,6 +55,7 @@ export const STRUCTURE_HIERARCHY: StructureConfig[] = [
     headerFormat: 'name',
     headerTag: 'h3',
     romanize: false,
+    absoluteNumbering: false,
   },
   {
     rdfType: SAY('Chapter'),
@@ -60,6 +67,7 @@ export const STRUCTURE_HIERARCHY: StructureConfig[] = [
     headerFormat: 'name',
     headerTag: 'h4',
     romanize: true,
+    absoluteNumbering: false,
   },
   {
     rdfType: SAY('Section'),
@@ -71,6 +79,7 @@ export const STRUCTURE_HIERARCHY: StructureConfig[] = [
     headerFormat: 'name',
     headerTag: 'h5',
     romanize: true,
+    absoluteNumbering: false,
   },
   {
     rdfType: SAY('Subsection'),
@@ -82,6 +91,7 @@ export const STRUCTURE_HIERARCHY: StructureConfig[] = [
     headerFormat: 'name',
     headerTag: 'h6',
     romanize: false,
+    absoluteNumbering: false,
   },
   {
     rdfType: SAY('Article'),
@@ -90,6 +100,7 @@ export const STRUCTURE_HIERARCHY: StructureConfig[] = [
     resourceUri: 'http://data.lblod.info/articles/',
     headerFormat: 'name',
     romanize: false,
+    absoluteNumbering: true,
   },
   {
     rdfType: SAY('Paragraph'),
@@ -98,8 +109,20 @@ export const STRUCTURE_HIERARCHY: StructureConfig[] = [
     resourceUri: 'http://data.lblod.info/paragraphs/',
     headerFormat: 'section-symbol',
     romanize: false,
+    absoluteNumbering: false,
   },
 ];
+
+export const DECISION_ARTICLE: StructureConfig = {
+  structureType: 'article',
+  rdfType: BESLUIT('Artikel'),
+  resourceUri: 'http://data.lblod.info/artikels/',
+  hasTitle: false,
+  headerFormat: 'name',
+  romanize: false,
+  headerTag: 'h5',
+  absoluteNumbering: true,
+};
 
 export function isHierarchyNode(node: PNode) {
   return STRUCTURE_HIERARCHY.some(({ rdfType }) =>

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@glint/template": "^1.5.0",
     "@graphy/content.ttl.write": "^4.3.7",
     "@graphy/memory.dataset.fast": "4.3.3",
-    "@lblod/ember-rdfa-editor": "10.11.3-dev.c2559f04be861fe765fcfdce55bedda9fd98e9ed",
+    "@lblod/ember-rdfa-editor": "10.11.3-dev.19b78a1110c284a94cc3124d4e2f40a8f973d109",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^4.0.0",
     "@tsconfig/ember": "^3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         specifier: 4.3.3
         version: 4.3.3
       '@lblod/ember-rdfa-editor':
-        specifier: 10.11.3-dev.c2559f04be861fe765fcfdce55bedda9fd98e9ed
-        version: 10.11.3-dev.c2559f04be861fe765fcfdce55bedda9fd98e9ed(yoyfyml64mqihij3sklf3znvz4)
+        specifier: 10.11.3-dev.19b78a1110c284a94cc3124d4e2f40a8f973d109
+        version: 10.11.3-dev.19b78a1110c284a94cc3124d4e2f40a8f973d109(yoyfyml64mqihij3sklf3znvz4)
       '@rdfjs/types':
         specifier: ^1.1.0
         version: 1.1.0
@@ -1590,8 +1590,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@lblod/ember-rdfa-editor@10.11.3-dev.c2559f04be861fe765fcfdce55bedda9fd98e9ed':
-    resolution: {integrity: sha512-dytC+5xQreF8LJBdFcBrzWN1oLCrw2wW+Md+q8ceDv9lF3XM4XA5dv/bfQezTTND5SKbHuZaQ0oc19Jnr7UAmg==}
+  '@lblod/ember-rdfa-editor@10.11.3-dev.19b78a1110c284a94cc3124d4e2f40a8f973d109':
+    resolution: {integrity: sha512-UMpbcRn4odM5kmPsJwaIrP+ttFKv1YrlFI9bcLH6telOACqXinhwP5Sx9/b8SFJeD5VG54jc9v0PHGg2HBmQWg==}
     engines: {node: 16.* || 18.* || >= 20}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.4.2
@@ -10776,7 +10776,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@lblod/ember-rdfa-editor@10.11.3-dev.c2559f04be861fe765fcfdce55bedda9fd98e9ed(yoyfyml64mqihij3sklf3znvz4)':
+  '@lblod/ember-rdfa-editor@10.11.3-dev.19b78a1110c284a94cc3124d4e2f40a8f973d109(yoyfyml64mqihij3sklf3znvz4)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.4.2(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@3.3.0)(webpack@5.97.1)
       '@babel/core': 7.26.0
@@ -11315,27 +11315,6 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
-  '@types/ember@4.0.11':
-    dependencies:
-      '@types/ember__application': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__array': 4.0.10(@babel/core@7.26.0)
-      '@types/ember__component': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__controller': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__debug': 4.0.8(@babel/core@7.26.0)
-      '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__error': 4.0.6
-      '@types/ember__object': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__polyfills': 4.0.6
-      '@types/ember__routing': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__runloop': 4.0.10
-      '@types/ember__service': 4.0.9(@babel/core@7.26.0)
-      '@types/ember__string': 3.16.3
-      '@types/ember__template': 4.0.7
-      '@types/ember__test': 4.0.6(@babel/core@7.26.0)
-      '@types/ember__utils': 4.0.7
-      '@types/rsvp': 4.0.9
-    optional: true
-
   '@types/ember@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@types/ember__application': 4.0.11(@babel/core@7.26.0)
@@ -11363,7 +11342,7 @@ snapshots:
   '@types/ember__application@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
-      '@types/ember': 4.0.11
+      '@types/ember': 4.0.11(@babel/core@7.26.0)
       '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
       '@types/ember__object': 4.0.12(@babel/core@7.26.0)
       '@types/ember__owner': 4.0.9
@@ -11465,11 +11444,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@types/ember__runloop@4.0.10':
-    dependencies:
-      '@types/ember': 4.0.11
-    optional: true
-
   '@types/ember__runloop@4.0.10(@babel/core@7.26.0)':
     dependencies:
       '@types/ember': 4.0.11(@babel/core@7.26.0)
@@ -11500,11 +11474,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    optional: true
-
-  '@types/ember__utils@4.0.7':
-    dependencies:
-      '@types/ember': 4.0.11
     optional: true
 
   '@types/ember__utils@4.0.7(@babel/core@7.26.0)':

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -2,6 +2,10 @@ import Controller from '@ember/controller';
 import applyDevTools from 'prosemirror-dev-tools';
 import { action } from '@ember/object';
 import { tracked } from 'tracked-built-ins';
+import { getOwner } from '@ember/owner';
+import { service } from '@ember/service';
+import IntlService from 'ember-intl/services/intl';
+import { ComponentLike } from '@glint/template';
 import { EditorState, PNode, SayController } from '@lblod/ember-rdfa-editor';
 import { Schema, Plugin } from '@lblod/ember-rdfa-editor';
 import {
@@ -26,8 +30,6 @@ import {
   tablePlugin,
 } from '@lblod/ember-rdfa-editor/plugins/table';
 import { link, linkView } from '@lblod/ember-rdfa-editor/nodes/link';
-
-import { service } from '@ember/service';
 import ImportRdfaSnippet from '@lblod/ember-rdfa-editor-lblod-plugins/services/import-rdfa-snippet';
 import {
   tableOfContentsView,
@@ -39,7 +41,6 @@ import {
   STRUCTURE_NODES,
   STRUCTURE_SPECS,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/structures';
-import IntlService from 'ember-intl/services/intl';
 import {
   bulletListWithConfig,
   listItemWithConfig,
@@ -122,7 +123,6 @@ import {
   editableNodePlugin,
   getActiveEditableNode,
 } from '@lblod/ember-rdfa-editor/plugins/editable-node';
-import { ComponentLike } from '@glint/template';
 import {
   snippetPlaceholder,
   snippetPlaceholderView,
@@ -134,7 +134,7 @@ import {
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
 import { BlockRDFaView } from '@lblod/ember-rdfa-editor/nodes/block-rdfa';
 import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
-import { getOwner } from '@ember/owner';
+import StructureControlCardComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/structure-plugin/_private/control-card';
 
 export default class RegulatoryStatementSampleController extends Controller {
   queryParams = ['editableNodes'];
@@ -144,6 +144,7 @@ export default class RegulatoryStatementSampleController extends Controller {
   DebugInfo = DebugInfo;
   AttributeEditor = AttributeEditor;
   RdfaEditor = RdfaEditor;
+  StructureControlCard = StructureControlCardComponent;
   @tracked editableNodes = false;
 
   @action

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -125,10 +125,7 @@
                 @variableTypes={{this.variableTypes}}
                 @templateMode={{true}}
               />
-              <ArticleStructurePlugin::StructureCard
-                @controller={{this.controller}}
-                @options={{this.config.structures}}
-              />
+              <this.StructureControlCard @controller={{this.controller}} />
               <VariablePlugin::Address::Edit
                 @controller={{this.controller}}
                 @defaultMunicipality='Gent'

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -16,6 +16,8 @@ common:
 structure-plugin:
   move-up: 'Move {structureName} up'
   move-down: 'Move {structureName} down'
+  remove: 'Remove {structureName}'
+  remove-with-content: 'Remove {structureName} with content'
   only-article-title: Only article
   shortened-article: Art.
   types:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -16,6 +16,8 @@ common:
 structure-plugin:
   move-up: '{structureName} naar boven verplaatsen'
   move-down: '{structureName} naar beneden verplaatsen'
+  remove: '{structureName} verwijderen'
+  remove-with-content: '{structureName} en inhoud verwijderen'
   only-article-title: Enig artikel
   shortened-article: Art.
   types:


### PR DESCRIPTION
### Overview
The structure plugin code for this was generic enough that this was easy, just needed some tweaking and translations. ~~Still need to include the 'start number' functionality to replace the article structure card.~~

For reviewing, I recommend the 'hide whitespace changes' option.

##### connected issues and PRs:
Part of https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/535
Jira ticket: [binnenland.atlassian.net/browse/GN-4866](https://binnenland.atlassian.net/browse/GN-4866)

### Setup
N/A

### How to test/reproduce
The card to move and remove structures in the RS part of the dummy app should work as expected.
Setting start numbers should work as expected.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
