### PR TITLE
Use `composition` to compose quick successive structure title changes

### DIFF
--- a/.changeset/red-ghosts-listen.md
+++ b/.changeset/red-ghosts-listen.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Implement quick successive structure title changes using transaction composition

--- a/addon/utils/_private/transaction-utils.ts
+++ b/addon/utils/_private/transaction-utils.ts
@@ -1,0 +1,11 @@
+// TODO: move these utility functions to the `@lblod/ember-rdfa-editor` package
+
+import { Transaction } from '@lblod/ember-rdfa-editor';
+
+export function setCompositionID(tr: Transaction, compositionID: unknown) {
+  return tr.setMeta('composition', compositionID);
+}
+
+export function getCompositionID(tr: Transaction): unknown {
+  return tr.getMeta('composition');
+}


### PR DESCRIPTION
### Overview
This PR ensures that structure title changes which quickly succeed eachother are composed using the `composition` transaction meta.

If `prosemirror-history` encounters successive transactions with the same `composition` ID, it bundles them together into one event. 
While this `composition` meta is part of the internal API, it seems to be the best way to compose successive transactions as one history event.

Internally, prosemirror uses the `composition` ID in combination with the [compositionstart](https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionstart_event) and [compositionend](https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionend_event) events.

### How to test/reproduce
- Start the dummy app
- Open the RS page
- Insert any structure with an editable title
- Apply some changes to the title in quick succession
- Ensure that those changes are bundled together into one history event

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
