### PR TITLE
fix(irgn): fix functionality of code dropdown

### DIFF
--- a/.changeset/poor-walls-flash.md
+++ b/.changeset/poor-walls-flash.md
@@ -1,0 +1,6 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+IRGN plugin: use `xsd:boolean` type instead of custom `mu` boolean type in SPARQL queries.
+This fixes the functionality of the mobility measure code dropdown.

--- a/addon/plugins/roadsign-regulation-plugin/queries/sign-codes.ts
+++ b/addon/plugins/roadsign-regulation-plugin/queries/sign-codes.ts
@@ -1,6 +1,7 @@
 import {
   executeQuery,
   objectify,
+  sparqlEscapeBool,
   sparqlEscapeString,
   sparqlEscapeUri,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/sparql-helpers';
@@ -89,7 +90,7 @@ export default async function querySignCodes(
       ?uri mobiliteit:heeftMaatregelconcept ?measure.
       ?uri a ?signType;
               skos:prefLabel ?label;
-              ext:valid "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>.
+              ext:valid ${sparqlEscapeBool(true)}.
       ${filterStatement}
     }
     ORDER BY ASC(?label)

--- a/addon/utils/sparql-helpers.ts
+++ b/addon/utils/sparql-helpers.ts
@@ -20,6 +20,10 @@ interface QueryConfig {
 export const sparqlEscapeString = (value: string) =>
   '"""' + value.replace(/[\\"]/g, (match) => '\\' + match) + '"""';
 
+export const sparqlEscapeBool = (value: boolean) => {
+  return value ? '"true"^^xsd:boolean' : '"false"^^xsd:boolean';
+};
+
 export const sparqlEscapeUri = (value: string) => {
   return (
     '<' +


### PR DESCRIPTION
### Overview
This PR fixes the functionality of the 'code' dropdown/filter in the IRGN plugin.
The plugin now uses the native `xsd:boolean` type in the SPARQL queries.

##### connected issues and PRs:
https://github.com/lblod/app-mow-registry/pull/112

### How to test/reproduce
- Start the dummy app
- Insert a decision with type 'reglement'
- Open the IRGN modal
- Notice you can correctly filter on the code of a measure

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
