### PR TITLE
GN-5468: add support for configuring location types

### DIFF
--- a/.changeset/fair-months-invent.md
+++ b/.changeset/fair-months-invent.md
@@ -1,0 +1,14 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Location plugin: add support for configuring the location types to show.
+The location types may be configured through the `@locationTypes` argument of the `location-plugin/insert` component.
+
+The `@locationTypes` argument expects an array of `LocationType` values.
+Supported `LocationType` values are:
+- 'address'
+- 'place'
+- 'area'
+
+By default the value of `@locationTypes` is `['address', 'place', 'area']`

--- a/addon/components/location-plugin/edit.gts
+++ b/addon/components/location-plugin/edit.gts
@@ -109,16 +109,6 @@ export default class LocationPluginEditComponent extends Component<Signature> {
   newTruncatedValue?: boolean;
 
   get locationTypes() {
-    const unsupportedLocationType = this.args.locationTypes?.find(
-      (locationType) => !SUPPORTED_LOCATION_TYPES.includes(locationType),
-    );
-    if (unsupportedLocationType) {
-      throw new Error(
-        `${unsupportedLocationType} is not supported. Supported location types are ${SUPPORTED_LOCATION_TYPES.join(
-          ', ',
-        )}`,
-      );
-    }
     return this.args.locationTypes ?? SUPPORTED_LOCATION_TYPES;
   }
 

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -69,6 +69,20 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
   @tracked chosenPoint: GeoPos | undefined;
   @tracked isLoading = false;
 
+  constructor(owner: unknown, args: Signature['Args']) {
+    super(owner, args);
+    const unsupportedLocationType = this.args.locationTypes?.find(
+      (locationType) => !SUPPORTED_LOCATION_TYPES.includes(locationType),
+    );
+    if (unsupportedLocationType) {
+      throw new Error(
+        `${unsupportedLocationType} is not supported. Supported location types are ${SUPPORTED_LOCATION_TYPES.join(
+          ', ',
+        )}`,
+      );
+    }
+  }
+
   get locationTypes() {
     return this.args.locationTypes ?? SUPPORTED_LOCATION_TYPES;
   }

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -28,7 +28,10 @@ import { replaceSelectionWithLocation } from '@lblod/ember-rdfa-editor-lblod-plu
 import { type LocationPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node';
 import { NodeContentsUtils } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node-contents';
 import Edit from './edit';
-import LocationMap, { type LocationType } from './map';
+import LocationMap, {
+  SUPPORTED_LOCATION_TYPES,
+  type LocationType,
+} from './map';
 
 export type CurrentLocation = Address | GlobalCoordinates | undefined;
 
@@ -55,6 +58,7 @@ interface Signature {
     config: LocationPluginConfig;
     defaultMunicipality?: string;
     templateMode?: boolean;
+    locationTypes?: LocationType[];
   };
   Element: HTMLLIElement;
 }
@@ -64,6 +68,10 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
   @tracked modalOpen = false;
   @tracked chosenPoint: GeoPos | undefined;
   @tracked isLoading = false;
+
+  get locationTypes() {
+    return this.args.locationTypes ?? SUPPORTED_LOCATION_TYPES;
+  }
 
   @trackedReset({
     memo: 'modalOpen',
@@ -99,11 +107,13 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
     update(component: LocationPluginInsertComponent) {
       return (
         updateFromNode(Place, () => 'place')(component) ??
-        updateFromNode(Area, () => 'area', 'address')(component)
+        updateFromNode(Area, () => 'area')(component) ??
+        updateFromNode(Address, () => 'address')(component) ??
+        component.locationTypes[0]
       );
     },
   })
-  locationType: LocationType = 'address';
+  declare locationType: LocationType;
 
   @trackedReset({
     memo: 'controller.activeEditorState',
@@ -284,6 +294,7 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
             <Edit
               @locationType={{this.locationType}}
               @setLocationType={{this.setLocationType}}
+              @locationTypes={{this.locationTypes}}
               @selectedLocationNode={{this.selectedLocationNode}}
               @setAddressToInsert={{this.setAddressToInsert}}
               @setIsLoading={{this.setIsLoading}}

--- a/addon/components/location-plugin/map.gts
+++ b/addon/components/location-plugin/map.gts
@@ -20,7 +20,8 @@ import {
   type GlobalCoordinates,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/utils/geo-helpers';
 
-export type LocationType = 'address' | 'place' | 'area';
+export const SUPPORTED_LOCATION_TYPES = ['address', 'place', 'area'] as const;
+export type LocationType = (typeof SUPPORTED_LOCATION_TYPES)[number];
 
 const MAP_TILE_ATTRIBUTION =
   '&copy; <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -119,6 +119,7 @@
                 <LocationPlugin::Insert
                   @controller={{this.controller}}
                   @config={{this.config.location}}
+                  @locationTypes={{array 'place' 'address' 'area'}}
                   @defaultMunicipality='Gent'
                 />
                 <VariablePlugin::Date::Insert @controller={{this.controller}} />


### PR DESCRIPTION
### Overview
This PR adds support for configuring the location types shown by the location plugin.
The location types may be configured through the `@locationTypes` argument of the `location-plugin/insert` component.

The `@locationTypes` argument expects an array of `LocationType` values.
Supported `LocationType` values are:
- 'address'
- 'place'
- 'area'
By default the value of `@locationTypes` is `['address', 'place', 'area']`

##### connected issues and PRs:
[GN-5468](https://binnenland.atlassian.net/browse/GN-5468)

### How to test/reproduce
- Start the dummy app
- Open the 'insert location' modal
- Notice that the order of the tabs has changed (in correspondence with the config inside the dummy app)
- If you adjust the `@locationTypes` argument, the modal should update accordingly
- Passing and unsupported location type causes an error. 

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
