### PR TITLE
Rework ToC to be compatible with new structure nodes

### DIFF
--- a/.changeset/breezy-dodos-press.md
+++ b/.changeset/breezy-dodos-press.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': major
+---
+
+Bump peerdeps to be compatible with editor v11

--- a/.changeset/chilly-hounds-jog.md
+++ b/.changeset/chilly-hounds-jog.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Make ToC compatible with new structure nodes

--- a/addon/components/table-of-contents-plugin/ember-nodes/outline.hbs
+++ b/addon/components/table-of-contents-plugin/ember-nodes/outline.hbs
@@ -6,7 +6,7 @@
         {{! template-lint-disable no-capital-arguments }}
         @block={{true}}
         @skin='link-secondary'
-        onclick={{fn @onEntryClick outlineEntry.pos}}
+        {{on 'click' (fn @onEntryClick outlineEntry.pos)}}
       >
         {{outlineEntry.content}}
       </AuButton>

--- a/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.hbs
+++ b/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.hbs
@@ -1,5 +1,8 @@
 {{! @glint-nocheck: not typesafe yet }}
-<div class='au-u-background-gray-100 au-u-padding-tiny table-of-contents'>
+<div
+  class='au-u-background-gray-100 au-u-padding-tiny table-of-contents'
+  contenteditable='false'
+>
   <h3>{{this.title}}</h3>
   {{#if this.outline}}
     <TableOfContentsPlugin::EmberNodes::Outline

--- a/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
+++ b/addon/components/table-of-contents-plugin/ember-nodes/table-of-contents.ts
@@ -8,8 +8,8 @@ import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 export default class TableOfContentsComponent extends Component<EmberNodeArgs> {
   @service declare intl: IntlService;
-  get config() {
-    return this.args.node.attrs['config'] as TableOfContentsConfig;
+  get config(): TableOfContentsConfig | undefined {
+    return this.args.node.attrs['config'] as TableOfContentsConfig | undefined;
   }
 
   get documentLanguage() {
@@ -49,9 +49,14 @@ export default class TableOfContentsComponent extends Component<EmberNodeArgs> {
         const coords = this.controller.mainEditorView.coordsAtPos(
           selection.from,
         );
-        const config = this.config[0];
+        let config;
+        if (Array.isArray(this.config)) {
+          config = this.config[0];
+        } else {
+          config = this.config;
+        }
         let scrollContainer: HTMLElement | undefined;
-        if (config.scrollContainer) {
+        if (config?.scrollContainer) {
           scrollContainer = config.scrollContainer();
         } else {
           scrollContainer = this.getScrollContainer();

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -39,11 +39,9 @@ import {
 } from './structure-types';
 import { parseBooleanDatasetAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/dom-utils';
 import {
-  isSome,
   Option,
   optionMapOr,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
-import { unwrapOr } from '@lblod/ember-rdfa-editor/utils/_private/option';
 
 const rdfaAware = true;
 
@@ -162,7 +160,6 @@ export const emberNodeConfig: (
       },
     },
     serialize(node: PNode, state: EditorState) {
-      const parser = new DOMParser();
       const tag = node.attrs.headerTag;
       const structureType = node.attrs.structureType as StructureType;
       const number = node.attrs.number as number;

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -82,6 +82,9 @@ export const emberNodeConfig: (
     isolating: true,
     atom: false,
     editable: rdfaAware,
+    tocEntry: (node: PNode) => {
+      return `${node.attrs.number}. ${node.attrs.title}`;
+    },
 
     attrs: {
       ...rdfaAttrSpec({ rdfaAware }),

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -40,7 +40,6 @@ import {
 import { parseBooleanDatasetAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/dom-utils';
 import {
   Option,
-  optionMapOr,
   isSome,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 

--- a/addon/plugins/table-of-contents-plugin/index.ts
+++ b/addon/plugins/table-of-contents-plugin/index.ts
@@ -1,4 +1,6 @@
-export type TableOfContentsConfig = {
-  nodeHierarchy: string[];
-  scrollContainer?: () => HTMLElement;
-}[];
+export type TableOfContentsConfig =
+  | {
+      nodeHierarchy: string[];
+      scrollContainer?: () => HTMLElement;
+    }[]
+  | { scrollContainer?: () => HTMLElement };

--- a/addon/plugins/table-of-contents-plugin/index.ts
+++ b/addon/plugins/table-of-contents-plugin/index.ts
@@ -1,6 +1,7 @@
+export type LegacyTableOfContentsConfig = {
+  nodeHierarchy: string[];
+  scrollContainer?: () => HTMLElement;
+}[];
 export type TableOfContentsConfig =
-  | {
-      nodeHierarchy: string[];
-      scrollContainer?: () => HTMLElement;
-    }[]
+  | LegacyTableOfContentsConfig
   | { scrollContainer?: () => HTMLElement };

--- a/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
+++ b/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
@@ -31,7 +31,6 @@ export const emberNodeConfig: (
       const t = getTranslationFunction(state);
 
       const { config: configToSerialize } = node.attrs;
-      console.log('configToSerialize', configToSerialize);
       const entries = extractOutline({
         node: unwrap(state).doc,
         pos: -1,

--- a/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
+++ b/addon/plugins/table-of-contents-plugin/nodes/table-of-contents.ts
@@ -14,7 +14,7 @@ import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/u
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 
 export const emberNodeConfig: (
-  config: TableOfContentsConfig,
+  config?: TableOfContentsConfig,
 ) => EmberNodeConfig = (config) => {
   return {
     name: 'table-of-contents',
@@ -31,10 +31,11 @@ export const emberNodeConfig: (
       const t = getTranslationFunction(state);
 
       const { config: configToSerialize } = node.attrs;
+      console.log('configToSerialize', configToSerialize);
       const entries = extractOutline({
         node: unwrap(state).doc,
         pos: -1,
-        config: configToSerialize as TableOfContentsConfig,
+        config: configToSerialize,
         state: unwrap(state),
       });
 
@@ -67,7 +68,7 @@ export const emberNodeConfig: (
   };
 };
 
-export const table_of_contents = (config: TableOfContentsConfig) =>
+export const table_of_contents = (config?: TableOfContentsConfig) =>
   createEmberNodeSpec(emberNodeConfig(config));
-export const tableOfContentsView = (config: TableOfContentsConfig) =>
+export const tableOfContentsView = (config?: TableOfContentsConfig) =>
   createEmberNodeView(emberNodeConfig(config));

--- a/addon/plugins/table-of-contents-plugin/utils/index.ts
+++ b/addon/plugins/table-of-contents-plugin/utils/index.ts
@@ -44,7 +44,9 @@ export function createTableOfContents(entries: OutlineEntry[]) {
 }
 
 type LegacyConfig = { nodeHierarchy: string[] }[];
-type NewConfig = Record<string, never>;
+// the scrollcontainer config isn't used here, so we can use the unknown type
+// cause we don't need any config
+type NewConfig = unknown;
 
 export function extractOutline(args: {
   node: PNode;

--- a/addon/plugins/table-of-contents-plugin/utils/index.ts
+++ b/addon/plugins/table-of-contents-plugin/utils/index.ts
@@ -1,5 +1,5 @@
-import { DOMOutputSpec, EditorState, PNode } from '@lblod/ember-rdfa-editor';
 import { NodeWithPos } from '@curvenote/prosemirror-utils';
+import { DOMOutputSpec, EditorState, PNode } from '@lblod/ember-rdfa-editor';
 
 export type OutlineEntry = {
   content: string;
@@ -45,7 +45,51 @@ export function createTableOfContents(entries: OutlineEntry[]) {
 
 type Config = { nodeHierarchy: string[] }[];
 
-export function extractOutline({
+export function extractOutline(args: {
+  node: PNode;
+  pos: number;
+  /** @deprecated */
+  config?: Config;
+  state: EditorState;
+}): OutlineEntry[] {
+  const { node, pos, config, state } = args;
+  if (config) {
+    return extractOutlineLegacy({ ...args, config });
+  }
+  let result: OutlineEntry[] = [];
+  let parent: OutlineEntry | undefined;
+  const tocEntry = node.type.spec.tocEntry as
+    | ((node: PNode, state: EditorState) => string)
+    | string
+    | undefined;
+  if (tocEntry) {
+    let entry: string;
+    if (typeof tocEntry === 'function') {
+      entry = tocEntry(node, state);
+    } else {
+      entry = tocEntry;
+    }
+    parent = {
+      pos,
+      content: entry,
+    };
+  }
+  const subResults: OutlineEntry[] = [];
+  node.forEach((child, offset) => {
+    subResults.push(
+      ...extractOutline({ node: child, pos: pos + 1 + offset, config, state }),
+    );
+  });
+  if (parent) {
+    parent.children = subResults;
+    result = [parent];
+  } else {
+    result = subResults;
+  }
+  return result;
+}
+
+function extractOutlineLegacy({
   node,
   pos,
   config,

--- a/addon/plugins/table-of-contents-plugin/utils/index.ts
+++ b/addon/plugins/table-of-contents-plugin/utils/index.ts
@@ -1,5 +1,6 @@
 import { NodeWithPos } from '@curvenote/prosemirror-utils';
-import { DOMOutputSpec, EditorState, PNode } from '@lblod/ember-rdfa-editor';
+import { LegacyTableOfContentsConfig, TableOfContentsConfig } from '..';
+import { DOMOutputSpec, PNode, EditorState } from '@lblod/ember-rdfa-editor';
 
 export type OutlineEntry = {
   content: string;
@@ -43,16 +44,11 @@ export function createTableOfContents(entries: OutlineEntry[]) {
   return tableOfContents;
 }
 
-type LegacyConfig = { nodeHierarchy: string[] }[];
-// the scrollcontainer config isn't used here, so we can use the unknown type
-// cause we don't need any config
-type NewConfig = unknown;
-
 export function extractOutline(args: {
   node: PNode;
   pos: number;
   /** @deprecated */
-  config?: LegacyConfig | NewConfig;
+  config?: TableOfContentsConfig;
   state: EditorState;
 }): OutlineEntry[] {
   const { node, pos, config, state } = args;
@@ -100,7 +96,7 @@ function extractOutlineLegacy({
 }: {
   node: PNode;
   pos: number;
-  config: LegacyConfig;
+  config: LegacyTableOfContentsConfig;
   state: EditorState;
 }): OutlineEntry[] {
   let result: OutlineEntry[] = [];

--- a/addon/plugins/table-of-contents-plugin/utils/index.ts
+++ b/addon/plugins/table-of-contents-plugin/utils/index.ts
@@ -43,17 +43,18 @@ export function createTableOfContents(entries: OutlineEntry[]) {
   return tableOfContents;
 }
 
-type Config = { nodeHierarchy: string[] }[];
+type LegacyConfig = { nodeHierarchy: string[] }[];
+type NewConfig = Record<string, never>;
 
 export function extractOutline(args: {
   node: PNode;
   pos: number;
   /** @deprecated */
-  config?: Config;
+  config?: LegacyConfig | NewConfig;
   state: EditorState;
 }): OutlineEntry[] {
   const { node, pos, config, state } = args;
-  if (config) {
+  if (config && Array.isArray(config)) {
     return extractOutlineLegacy({ ...args, config });
   }
   let result: OutlineEntry[] = [];
@@ -97,7 +98,7 @@ function extractOutlineLegacy({
 }: {
   node: PNode;
   pos: number;
-  config: Config;
+  config: LegacyConfig;
   state: EditorState;
 }): OutlineEntry[] {
   let result: OutlineEntry[] = [];

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-version-checker": "^5.1.2",
-    "ember-concurrency": "^3.1.1",
     "ember-mu-transform-helpers": "^2.1.2",
     "ember-resources": "^7.0.2",
     "ember-template-imports": "^4.1.1",
@@ -91,7 +90,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "~3.4.2",
+    "@appuniversum/ember-appuniversum": "~3.5.0",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.7",
     "@ember/optional-features": "^2.1.0",
@@ -143,6 +142,7 @@
     "ember-leaflet": "^5.1.3",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "~4.1.0",
+    "ember-concurrency": "^4.0.2",
     "ember-page-title": "^8.2.3",
     "ember-power-select": "~7.1.0",
     "ember-qunit": "^8.1.0",
@@ -174,11 +174,11 @@
     "webpack": "^5.95.0"
   },
   "peerDependencies": {
-    "@appuniversum/ember-appuniversum": "^3.4.1",
+    "@appuniversum/ember-appuniversum": "^3.5.0",
     "@ember/string": "3.x",
     "@glint/template": "^1.4.0",
     "@lblod/ember-rdfa-editor": "^11.0.0",
-    "ember-concurrency": "^3.1.0 || ^4.0.2",
+    "ember-concurrency": "^4.0.2",
     "ember-element-helper": "^0.8.6",
     "ember-intl": "^7.0.0",
     "ember-leaflet": "^5.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       ember-cli-version-checker:
         specifier: ^5.1.2
         version: 5.1.2
-      ember-concurrency:
-        specifier: ^3.1.1
-        version: 3.1.1(@babel/core@7.26.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))
       ember-mu-transform-helpers:
         specifier: ^2.1.2
         version: 2.1.2
@@ -127,8 +124,8 @@ importers:
         version: 3.24.1
     devDependencies:
       '@appuniversum/ember-appuniversum':
-        specifier: ~3.4.2
-        version: 3.4.2(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@3.3.0)(webpack@5.97.1)
+        specifier: ~3.5.0
+        version: 3.5.0(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@3.3.0)(webpack@5.97.1)
       '@changesets/changelog-github':
         specifier: ^0.5.0
         version: 0.5.0
@@ -152,7 +149,7 @@ importers:
         version: 4.0.0
       '@gavant/glint-template-types':
         specifier: ^0.4.0
-        version: 0.4.0(ggto6bo63gd4ko3j6i5ajjgjhe)
+        version: 0.4.0(6sslik2cgbgfbiasnzshv2k6mi)
       '@glimmer/component':
         specifier: ^1.1.2
         version: 1.1.2(@babel/core@7.26.0)
@@ -179,7 +176,7 @@ importers:
         version: 4.3.3
       '@lblod/ember-rdfa-editor':
         specifier: 11.0.0
-        version: 11.0.0(qdg7y7b7gxkkzgodsywhdplbsy)
+        version: 11.0.0(nlq6pvqp7wukmbrtxngdh43tfm)
       '@rdfjs/types':
         specifier: ^1.1.0
         version: 1.1.0
@@ -261,6 +258,9 @@ importers:
       ember-cli-terser:
         specifier: ^4.0.2
         version: 4.0.2
+      ember-concurrency:
+        specifier: ^4.0.2
+        version: 4.0.3(@babel/core@7.26.0)(@glimmer/tracking@1.1.2)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))
       ember-disable-prototype-extensions:
         specifier: ^1.1.3
         version: 1.1.3
@@ -376,8 +376,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@appuniversum/ember-appuniversum@3.4.2':
-    resolution: {integrity: sha512-GsMbEhk5KucUwiLLTY8dP7q++7kE8vKSWvqVkrz9FilBuPTGUn6vAkfx9904eyGRKYfmutVRbVUZQQOn4nagrA==}
+  '@appuniversum/ember-appuniversum@3.5.0':
+    resolution: {integrity: sha512-vhDWMLcWvBZmUziXjow/w+vfEW3XTrvhDjS4cQtKjGGHWa6Os6F0e49E8CchgwBCYC9XNCgfqrBWee29dDj1Tg==}
     engines: {node: '>= 18'}
     peerDependencies:
       ember-source: ^4.12.0 || ^5.0.0
@@ -507,16 +507,8 @@ packages:
     resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.24.7':
-    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.24.7':
-    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.25.9':
@@ -1050,10 +1042,6 @@ packages:
 
   '@babel/traverse@7.26.5':
     resolution: {integrity: sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.24.7':
-    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.26.5':
@@ -3215,7 +3203,6 @@ packages:
 
   chokidar@2.1.8:
     resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
-    deprecated: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -4184,6 +4171,17 @@ packages:
     engines: {node: 16.* || >= 18}
     peerDependencies:
       ember-source: ^3.28.0 || ^4.0.0 || >=5.0.0
+
+  ember-concurrency@4.0.3:
+    resolution: {integrity: sha512-deDJiB5OBYtYYOiVSt2qe5YBC8/vj1HwXPXtcw2SHijjMVL3i8ZBUmnHcaFr4RGsZJkGUr7Fg0zM45P9yUqKmQ==}
+    engines: {node: 16.* || >= 18}
+    peerDependencies:
+      '@glimmer/tracking': ^1.1.2
+      '@glint/template': '>= 1.0.0'
+      ember-source: ^3.28.0 || ^4.0.0 || >=5.0.0
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
 
   ember-data-table@2.1.0:
     resolution: {integrity: sha512-h/rI5K9woEafshFAjTfMVhfXK91aEjsXJO1zsYsY6aXZBfiNXWbCfrrnMk8W5Q3c8uPeNPyZ12W0//i/wQmGTg==}
@@ -8455,10 +8453,6 @@ packages:
     resolution: {integrity: sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==}
     engines: {node: '>=0.10.0'}
 
-  to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
-
   to-object-path@0.3.0:
     resolution: {integrity: sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==}
     engines: {node: '>=0.10.0'}
@@ -9070,11 +9064,11 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@appuniversum/ember-appuniversum@3.4.2(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@3.3.0)(webpack@5.97.1)':
+  '@appuniversum/ember-appuniversum@3.5.0(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@3.3.0)(webpack@5.97.1)':
     dependencies:
       '@babel/core': 7.26.0
       '@duetds/date-picker': 1.4.0
-      '@embroider/macros': 1.16.5(@glint/template@1.5.1)
+      '@embroider/macros': 1.16.10(@glint/template@1.5.1)
       '@floating-ui/dom': 1.6.7
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
       '@glimmer/tracking': 1.1.2
@@ -9302,11 +9296,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.5
 
-  '@babel/helper-string-parser@7.24.7': {}
-
   '@babel/helper-string-parser@7.25.9': {}
-
-  '@babel/helper-validator-identifier@7.24.7': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
 
@@ -9985,12 +9975,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.24.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
-
   '@babel/types@7.26.5':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
@@ -10549,12 +10533,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.7.3
 
-  '@gavant/glint-template-types@0.4.0(ggto6bo63gd4ko3j6i5ajjgjhe)':
+  '@gavant/glint-template-types@0.4.0(6sslik2cgbgfbiasnzshv2k6mi)':
     dependencies:
       ember-source: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1)
     optionalDependencies:
       ember-basic-dropdown: 8.5.0(@babel/core@7.26.0)(@ember/string@3.1.1)(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))
-      ember-concurrency: 3.1.1(@babel/core@7.26.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))
+      ember-concurrency: 4.0.3(@babel/core@7.26.0)(@glimmer/tracking@1.1.2)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))
       ember-intl: 7.0.3(@glint/template@1.5.1)(typescript@5.7.3)(webpack@5.97.1)
       ember-modifier: 4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))
       ember-power-select: 7.1.2(@babel/core@7.26.0)(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1)
@@ -10903,9 +10887,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@lblod/ember-rdfa-editor@11.0.0(qdg7y7b7gxkkzgodsywhdplbsy)':
+  '@lblod/ember-rdfa-editor@11.0.0(nlq6pvqp7wukmbrtxngdh43tfm)':
     dependencies:
-      '@appuniversum/ember-appuniversum': 3.4.2(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@3.3.0)(webpack@5.97.1)
+      '@appuniversum/ember-appuniversum': 3.5.0(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@3.3.0)(webpack@5.97.1)
       '@codemirror/commands': 6.6.0
       '@codemirror/lang-html': 6.4.9
       '@codemirror/lang-xml': 6.1.0
@@ -10935,7 +10919,7 @@ snapshots:
       ember-changeset: 4.1.2(@glint/template@1.5.1)(webpack@5.97.1)
       ember-cli-babel: 8.2.0(@babel/core@7.26.0)
       ember-cli-htmlbars: 6.3.0
-      ember-concurrency: 3.1.1(@babel/core@7.26.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))
+      ember-concurrency: 4.0.3(@babel/core@7.26.0)(@glimmer/tracking@1.1.2)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))
       ember-focus-trap: 1.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))
       ember-intl: 7.0.3(@glint/template@1.5.1)(typescript@5.7.3)(webpack@5.97.1)
       ember-modifier: 4.2.0(@babel/core@7.26.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))
@@ -11462,7 +11446,7 @@ snapshots:
       '@types/ember__object': 4.0.12(@babel/core@7.26.0)
       '@types/ember__polyfills': 4.0.6
       '@types/ember__routing': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__runloop': 4.0.10
+      '@types/ember__runloop': 4.0.10(@babel/core@7.26.0)
       '@types/ember__service': 4.0.9(@babel/core@7.26.0)
       '@types/ember__string': 3.16.3
       '@types/ember__template': 4.0.7
@@ -11598,11 +11582,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    optional: true
-
-  '@types/ember__runloop@4.0.10':
-    dependencies:
-      '@types/ember': 4.0.11
     optional: true
 
   '@types/ember__runloop@4.0.10(@babel/core@7.26.0)':
@@ -14728,13 +14707,28 @@ snapshots:
   ember-concurrency@3.1.1(@babel/core@7.26.0)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1)):
     dependencies:
       '@babel/helper-plugin-utils': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/types': 7.26.5
       '@glimmer/tracking': 1.1.2
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
       ember-cli-htmlbars: 6.3.0
       ember-compatibility-helpers: 1.2.7(@babel/core@7.26.0)
       ember-source: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  ember-concurrency@4.0.3(@babel/core@7.26.0)(@glimmer/tracking@1.1.2)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1)):
+    dependencies:
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/types': 7.26.5
+      '@embroider/addon-shim': 1.9.0
+      '@glimmer/tracking': 1.1.2
+      decorator-transforms: 1.2.1(@babel/core@7.26.0)
+      ember-source: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1)
+    optionalDependencies:
+      '@glint/template': 1.5.1
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -14784,8 +14778,8 @@ snapshots:
     dependencies:
       '@ember/test-helpers': 3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1)
       '@ember/test-waiters': 3.1.0
-      '@embroider/addon-shim': 1.8.9
-      '@embroider/macros': 1.16.5(@glint/template@1.5.1)
+      '@embroider/addon-shim': 1.9.0
+      '@embroider/macros': 1.16.10(@glint/template@1.5.1)
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
       '@glimmer/tracking': 1.1.2
       ember-auto-import: 2.10.0(@glint/template@1.5.1)(webpack@5.97.1)
@@ -17938,7 +17932,7 @@ snapshots:
       buffer: 4.9.2
       console-browserify: 1.2.0
       constants-browserify: 1.0.0
-      crypto-browserify: 3.12.0
+      crypto-browserify: 3.12.1
       domain-browser: 1.2.0
       events: 3.3.0
       https-browserify: 1.0.0
@@ -19860,7 +19854,7 @@ snapshots:
 
   terser@4.8.1:
     dependencies:
-      acorn: 8.12.1
+      acorn: 8.14.0
       commander: 2.20.3
       source-map: 0.6.1
       source-map-support: 0.5.21
@@ -20015,8 +20009,6 @@ snapshots:
   to-arraybuffer@1.0.1: {}
 
   to-fast-properties@1.0.3: {}
-
-  to-fast-properties@2.0.0: {}
 
   to-object-path@0.3.0:
     dependencies:

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -359,9 +359,7 @@ export default class RegulatoryStatementSampleController extends Controller {
     controller: SayController,
   ) => Record<string, NodeViewConstructor> = (controller) => {
     return {
-      table_of_contents: tableOfContentsView(this.config.tableOfContents)(
-        controller,
-      ),
+      table_of_contents: tableOfContentsView()(controller),
       link: linkView(this.config.link)(controller),
       date: dateView(this.dateOptions)(controller),
       number: numberView(controller),

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -201,7 +201,7 @@ export default class RegulatoryStatementSampleController extends Controller {
 
       hard_break,
       block_rdfa: blockRdfaWithConfig({ rdfaAware: true }),
-      table_of_contents: table_of_contents(this.config.tableOfContents),
+      table_of_contents: table_of_contents(),
       invisible_rdfa: invisibleRdfaWithConfig({ rdfaAware: true }),
       inline_rdfa: inlineRdfaWithConfig({ rdfaAware: true }),
       link: link(this.config.link),
@@ -293,18 +293,6 @@ export default class RegulatoryStatementSampleController extends Controller {
 
   get config() {
     return {
-      tableOfContents: [
-        {
-          nodeHierarchy: [
-            'title|chapter|section|subsection|article',
-            'structure_header|article_header',
-          ],
-          scrollContainer: () =>
-            document.getElementsByClassName(
-              'say-container__main',
-            )[0] as HTMLElement,
-        },
-      ],
       templateVariable: {
         endpoint: 'https://dev.roadsigns.lblod.info/sparql',
         zonalLocationCodelistUri:


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

BREAKING: this bumps the peerdeps of ember-appuniversum and ember-concurrency to the ranges the editor needs. 

- the config is no longer required. Instead, the ToC looks at the `tocEntry` property of a nodeSpec. This makes the ToC logic way simpler and decouples it from the implementation of hierarchies and other complexities
- Passing in the legacy config, an array, will active the legacy mode. So the behavior will not change until you change the config.
- passing in an object (not an array) with a `scrollContainer` callback is now also supported, but it is entirely optional as the plugin will try to find its scrollcontainer on its own.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->
https://binnenland.atlassian.net/browse/GN-5387

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->
go to the regulatory statement sample page, add some structures, add the ToC.
Observe it automatically updates when you make changes to the structures. (including editing their titles)

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->

Known issue: you have to click twice on the TOC entry to jump to the position in the document. I don't think that's a regression from this PR, judging by this ticket: https://binnenland.atlassian.net/browse/GN-4419 
It's a tricky one to solve, so I'd rather unblock the plugin as a whole first and pick up that minor ux inconvenience later.

### Checks PR readiness

- [x] changelog
- [x] npm lint
- [x] no new deprecations
