### PR TITLE
Add support for async content in PreviewList previews

### DIFF
--- a/.changeset/metal-glasses-reply.md
+++ b/.changeset/metal-glasses-reply.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Change preview list to asynchronously load previews

--- a/addon/components/common/documents/preview.gts
+++ b/addon/components/common/documents/preview.gts
@@ -68,7 +68,7 @@ export default class DocumentPreview<
       <div class='snippet-preview__header'>
         <div
           role='button'
-          title={{t 'snippet-plugin.modal.preview-button.title'}}
+          title={{t 'common.preview-list.preview-button.title'}}
           {{on 'click' this.togglePreview}}
           {{! template-lint-disable require-presentational-children}}
         >
@@ -100,12 +100,12 @@ export default class DocumentPreview<
         </div>
         <div
           role='button'
-          title={{t 'snippet-plugin.modal.select-button.title'}}
+          title={{t 'common.preview-list.select-button.title'}}
           {{on 'click' this.onInsert}}
           {{! template-lint-disable require-presentational-children}}
         >
           <AuButton class='snippet-preview__insert-button' @skin='naked'>
-            {{t 'snippet-plugin.modal.select-button.label'}}
+            {{t 'common.preview-list.select-button.label'}}
           </AuButton>
         </div>
 
@@ -121,7 +121,7 @@ export default class DocumentPreview<
               {{t 'common.search.loading'}}
             </AuLoader>
           {{else}}
-            <p class='au-u-italic'>{{t 'snippet-plugin.modal.no-content'}}</p>
+            <p class='au-u-italic'>{{t 'common.preview-list.no-content'}}</p>
           {{/if}}
         </div>
       {{/if}}

--- a/addon/components/common/documents/types.ts
+++ b/addon/components/common/documents/types.ts
@@ -1,19 +1,4 @@
-import { htmlSafe } from '@ember/template';
-
-import { optionMapOr } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
-import { SafeString } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/types';
-
-interface PreviewableDocumentArgs {
+export interface PreviewableDocument {
   title: string | null;
-  content: string | null;
-}
-
-export class PreviewableDocument {
-  content: SafeString | null;
-  title: string | null;
-
-  constructor({ title, content }: PreviewableDocumentArgs) {
-    this.content = optionMapOr(null, htmlSafe, content);
-    this.title = title;
-  }
+  content: string | Promise<string | null> | null;
 }

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -197,7 +197,7 @@ export default class SnippetNode extends Component<Signature> {
     }
     this.controller.doCommand(
       insertSnippet({
-        content: snippet.content?.toHTML() ?? '',
+        content: snippet.content ?? '',
         title: snippet.title ?? '',
         listProperties: {
           placeholderId: this.node.attrs.placeholderId,

--- a/addon/components/snippet-plugin/snippet-insert.gts
+++ b/addon/components/snippet-plugin/snippet-insert.gts
@@ -64,7 +64,7 @@ export default class SnippetInsertComponent extends Component<Sig> {
     if (this.args.listProperties) {
       this.controller.doCommand(
         insertSnippet({
-          content: snippet.content?.toHTML() ?? '',
+          content: snippet.content ?? '',
           title: snippet.title ?? '',
           listProperties: this.args.listProperties,
           allowMultipleSnippets: this.args.allowMultipleSnippets,

--- a/addon/plugins/snippet-plugin/index.ts
+++ b/addon/plugins/snippet-plugin/index.ts
@@ -1,11 +1,6 @@
-import { htmlSafe } from '@ember/template';
-
-import {
-  type Option,
-  optionMapOr,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { PreviewableDocument } from '@lblod/ember-rdfa-editor-lblod-plugins/components/common/documents/types';
+import { type Option } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 import { dateValue } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/strings';
-import { SafeString } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/types';
 
 export const DEFAULT_CONTENT_STRING = 'block+';
 
@@ -21,13 +16,13 @@ interface SnippetArgs {
   content: string | null;
 }
 
-export class Snippet {
-  content: SafeString | null;
+export class Snippet implements PreviewableDocument {
+  content: string | null;
   createdOn: string | null;
   title: string | null;
 
   constructor({ title, createdOn, content }: SnippetArgs) {
-    this.content = optionMapOr(null, htmlSafe, content);
+    this.content = content;
     this.createdOn = dateValue(createdOn ?? undefined);
     this.title = title;
   }

--- a/addon/plugins/snippet-plugin/utils/collate-imported-resources.ts
+++ b/addon/plugins/snippet-plugin/utils/collate-imported-resources.ts
@@ -1,14 +1,17 @@
 import { IMPORTED_RESOURCES_ATTR } from '@lblod/ember-rdfa-editor/plugins/imported-resources';
 import { jsonParse } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/strings';
 import { type Snippet } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/snippet-plugin';
+import { optionMap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 
 export function collateImportedResources(snippets: Snippet[]): string[] {
   const domParser = new DOMParser();
   return [
     ...new Set(
       snippets.flatMap(({ content }) => {
-        const htmlNode =
-          content && domParser.parseFromString(content.toString(), 'text/html');
+        const htmlNode = optionMap(
+          (some) => domParser.parseFromString(some, 'text/html'),
+          content,
+        );
         const imports = jsonParse(
           htmlNode
             ?.querySelector('[data-say-document]')

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -12,6 +12,13 @@ common:
     asc: Sort ascending
     desc: Sort descending
   not-applicable: 'N/A'
+  preview-list:
+    preview-button:
+      title: Show preview
+    select-button:
+      label: Select
+      title: Insert
+    no-content: Does not contain any content
 
 structure-plugin:
   move-up: 'Move {structureName} up'
@@ -255,16 +262,10 @@ snippet-plugin:
     active-lists: 'Active lists:'
   modal:
     title: Choose a snippet from {snippetListNames}
-    preview-button:
-      title: Show snippet preview
-    select-button:
-      label: Select
-      title: Insert snippet
     search:
       title: Filter on
       label: Snippet name
       placeholder: Type something...
-    no-content: Snippet does not contain any content
   snippet-list:
     open-modal: Manage snippet lists
     modal:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -12,6 +12,13 @@ common:
     asc: Oplopend sorteren
     desc: Aflopend sorteren
   not-applicable: 'n.v.t.'
+  preview-list:
+    preview-button:
+      title: Preview tonen
+    select-button:
+      label: Selecteer
+      title: Invoegen
+    no-content: Bevat geen inhoud
 
 structure-plugin:
   move-up: '{structureName} naar boven verplaatsen'
@@ -254,16 +261,10 @@ snippet-plugin:
     active-lists: 'Actieve lijsten:'
   modal:
     title: Kies een fragment uit {snippetListNames}
-    preview-button:
-      title: Preview van fragment tonen
-    select-button:
-      label: Selecteer
-      title: Fragment invoegen
     search:
       title: Filter op
       label: Fragmentnaam
       placeholder: Typ iets...
-    no-content: Fragment bevat geen inhoud
   snippet-list:
     open-modal: Fragmentlijsten beheren
     modal:


### PR DESCRIPTION
### Overview
I managed to forget that I was hacking around the async nature of the template previews, so the version I'd put in a PR for didn't actually work for what I needed. I also missed some translations referring to snippets the first time around.

##### connected issues and PRs:
Part of https://binnenland.atlassian.net/browse/GN-5418

### Setup
N/A

### How to test/reproduce
Snippets should just work, but they don't use the async behaviour. To test async, you can replace the implementation of `Snippet` in `plugins/snippet-plugin/index.ts` with:
```
export class Snippet implements PreviewableDocument {
  _content: string | null;
  createdOn: string | null;
  title: string | null;

  constructor({ title, createdOn, content }: SnippetArgs) {
    this._content = content;
    this.createdOn = dateValue(createdOn ?? undefined);
    this.title = title;
  }

  get content() {
    console.log(
      'Getting content. This should not be called more than once per preview',
    );
    return new Promise<string | null>((res) =>
      setTimeout(() => res(this._content), 500),
    );
  }
}
```

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
