### PR TITLE
Change number variable modal to clarify the upper number is also included in the range

### DIFF
--- a/.changeset/cold-stingrays-design.md
+++ b/.changeset/cold-stingrays-design.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Change number variable modal to clarify the upper number is also included in the range

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -219,7 +219,7 @@ variable-plugin:
     minimum-placeholder: minimum value
     maximum: Maximum
     maximum-placeholder: maximum value
-    to: to
+    to: to and including
   person:
     card-title: Insert person
     nodeview-placeholder: Person

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -223,7 +223,7 @@ variable-plugin:
     minimum-placeholder: minimumwaarde
     maximum: Maximum
     maximum-placeholder: maximumwaarde
-    to: tot
+    to: tot en met
   person:
     card-title: Persoon invoegen
     nodeview-placeholder: Persoon


### PR DESCRIPTION
### Overview
Changed the `to`to `to and including` in the number variable modal as the max number is also allowed

##### connected issues and PRs:
GN-5481


### Setup
None

### How to test/reproduce
Insert a number variable and notice the text is updated

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
