### PR TITLE
Rename "citeeropschrift" to "citaat"

### DIFF
--- a/.changeset/pretty-turkeys-vanish.md
+++ b/.changeset/pretty-turkeys-vanish.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Rename "citeeropschrift" to "citaat"

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -43,10 +43,10 @@ structure-plugin:
 
 citaten-plugin:
   card:
-    title: Voeg citeeropschrift toe
+    title: Voeg citaat toe
     suggestions: Suggesties
   insert:
-    title: Citeeropschrift invoegen
+    title: Citaat invoegen
   search:
     term: Zoekterm
     government-search: Filter op bestuursorgaan
@@ -70,7 +70,7 @@ citaten-plugin:
     previous: Vorige pagina
     of: van
   references:
-    insert: Citeeropschrift invoegen
+    insert: Citaat invoegen
     details: Details
     refer-whole: Verwijs naar volledig document
     refer-article: Verwijs naar artikel


### PR DESCRIPTION
### Overview
As title says :)

##### connected issues and PRs:
GN-4785


### Setup
None

### How to test/reproduce
Launch the editor in dutch, notice it now says citaat where it should

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
