### PR TITLE
feat: add backward-compatible parserule to `roadsign_regulation`  nodespec

### DIFF
--- a/.changeset/rare-meals-jam.md
+++ b/.changeset/rare-meals-jam.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+`roadsign_regulation` node: introduce parse-rule which converts classic `roadsign_regulation` nodes to `block_rdfa` nodes

--- a/addon/plugins/roadsign-regulation-plugin/nodes.ts
+++ b/addon/plugins/roadsign-regulation-plugin/nodes.ts
@@ -6,16 +6,17 @@ import {
   PROV,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { hasRDFaAttribute } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 
 const CONTENT_SELECTOR = `div[property~='${
   DCT('description').full
 }'],div[property~='${DCT('description').prefixed}']`;
-const rdfaAware = false;
+
 export const roadsign_regulation: NodeSpec = {
   content: 'block+',
   group: 'block',
   attrs: {
-    ...rdfaAttrSpec({ rdfaAware }),
+    ...rdfaAttrSpec({ rdfaAware: false }),
     resourceUri: {},
     measureUri: {},
     zonality: {},
@@ -61,7 +62,12 @@ export const roadsign_regulation: NodeSpec = {
   parseDOM: [
     {
       tag: 'div',
+      node: 'block_rdfa',
       getAttrs(node: HTMLElement) {
+        const attrs = getRdfaAttrs(node, { rdfaAware: true });
+        if (!attrs || attrs.rdfaNodeType !== 'resource') {
+          return false;
+        }
         if (
           hasRDFaAttribute(
             node,
@@ -71,7 +77,7 @@ export const roadsign_regulation: NodeSpec = {
           node.querySelector(CONTENT_SELECTOR)
         ) {
           const resourceUri = node.getAttribute('resource');
-          const measureUri = node
+          const measureConceptUri = node
             .querySelector(
               `span[property~='${PROV('wasDerivedFrom').prefixed}'],
              span[property~='${PROV('wasDerivedFrom').full}']`,
@@ -83,21 +89,24 @@ export const roadsign_regulation: NodeSpec = {
            span[property~='${EXT('zonality').full}']`,
             )
             ?.getAttribute('resource');
-          if (!resourceUri || !measureUri || !zonality) {
+          if (!resourceUri || !measureConceptUri || !zonality) {
             return false;
           }
-          const temporal = node
-            .querySelector(
-              `span[property~='${EXT('temporal').prefixed}'],
-           span[property~='${EXT('temporal').full}']`,
-            )
-            ?.getAttribute('value');
+          const { rdfaNodeType, properties, backlinks, __rdfaId } = attrs;
+          // We need to ensure that a content-literal for the description is added
+          const propertiesFiltered = properties.filter(
+            (prop) => !DCT('description').matches(prop.predicate),
+          );
+          propertiesFiltered.push({
+            predicate: DCT('description').full,
+            object: sayDataFactory.contentLiteral(),
+          });
           return {
-            resourceUri,
-            measureUri,
-            zonality,
-            temporal,
-            ...getRdfaAttrs(node, { rdfaAware }),
+            rdfaNodeType,
+            __rdfaId,
+            properties: propertiesFiltered,
+            backlinks,
+            label: `Mobiliteitsmaatregel`,
           };
         }
         return false;

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@glint/template": "^1.5.0",
     "@graphy/content.ttl.write": "^4.3.7",
     "@graphy/memory.dataset.fast": "4.3.3",
-    "@lblod/ember-rdfa-editor": "11.0.0",
+    "@lblod/ember-rdfa-editor": "11.3.0",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^4.0.0",
     "@tsconfig/ember": "^3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,8 +187,8 @@ importers:
         specifier: 4.3.3
         version: 4.3.3
       '@lblod/ember-rdfa-editor':
-        specifier: 11.0.0
-        version: 11.0.0(nlq6pvqp7wukmbrtxngdh43tfm)
+        specifier: 11.3.0
+        version: 11.3.0(nlq6pvqp7wukmbrtxngdh43tfm)
       '@rdfjs/types':
         specifier: ^1.1.0
         version: 1.1.0
@@ -1717,8 +1717,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@lblod/ember-rdfa-editor@11.0.0':
-    resolution: {integrity: sha512-hHuzfxtIGDAPj1FxofPeUWkKqY/koqrSnba4BKM1fWLRtAo0eozqGSsgYti0hPI5YBzjPB3wLo4RnYMsH8h4WQ==}
+  '@lblod/ember-rdfa-editor@11.3.0':
+    resolution: {integrity: sha512-16tJ+HHqdTuLTV1EzhyJS3u/oJ3JoyJ3YfQlHkyymU49JmeNkqEjAWOJ+VpVLgzKtwOaRdIq78KKbJpVGpOmeg==}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.5.0
       '@ember/test-helpers': ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
@@ -12052,7 +12052,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@lblod/ember-rdfa-editor@11.0.0(nlq6pvqp7wukmbrtxngdh43tfm)':
+  '@lblod/ember-rdfa-editor@11.3.0(nlq6pvqp7wukmbrtxngdh43tfm)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.5.0(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@3.3.0)(webpack@5.97.1)
       '@codemirror/commands': 6.6.0
@@ -12065,7 +12065,7 @@ snapshots:
       '@ember/render-modifiers': 2.1.0(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))
       '@ember/test-helpers': 3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1)
       '@embroider/addon-shim': 1.9.0
-      '@embroider/macros': 1.16.10(@glint/template@1.5.1)
+      '@embroider/macros': 1.16.11(@glint/template@1.5.1)
       '@floating-ui/dom': 1.6.7
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
       '@glimmer/tracking': 1.1.2


### PR DESCRIPTION
### Overview
This PR adds a backward-compatible parserule to the `roadsign_regulation` nodespec which converts classic `roadsign_regulation` nodes to `block_rdfa` nodes in the best of its capabilities.

##### connected issues and PRs:
None

### How to test/reproduce
- Start the test-app and open the decision sample page
- Find an (older) 'reglement' decision on GN, which contains a classic `roadsign_regulation` node
- Copy the decision and paste it in the test-app
- Ensure the `roadsign_regulation` node has been converted to a `block_rdfa` node and contains the necessary RDFa properties and relationships.

### Challenges/uncertainties
- Adding the parserule to the `roadsign_regulation` spec itself is not ideal. I'd prefer using some kind of 'loose' parserule. It feels a bit silly to just add a nodespec just for its parserule...
- Unsure if we should mark this as breaking
- Hopefully the converted node contains all necessary RDFa



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
