### PR TITLE
Solved bug with powerselect dropdown not displaying in place

### DIFF
--- a/.changeset/grumpy-clocks-jam.md
+++ b/.changeset/grumpy-clocks-jam.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Solves bug with powerselect dropdown not displaying in place

--- a/addon/components/variable-plugin/location/edit.hbs
+++ b/addon/components/variable-plugin/location/edit.hbs
@@ -27,6 +27,7 @@
           @options={{this.locationOptions.value.options}}
           @selected={{this.selectedLocationOption}}
           @onChange={{this.updateLocationOption}}
+          @verticalPosition="above"
           as |option|
         >
           {{option.label}}
@@ -34,12 +35,14 @@
       {{else}}
         <PowerSelect
           id='location-select'
+          @dropdownClass="location-select-dropdown"
           @allowClear={{false}}
           @searchEnabled={{true}}
           @searchField='label'
           @options={{this.locationOptions.value.options}}
           @selected={{this.selectedLocationOption}}
           @onChange={{this.updateLocationOption}}
+
           as |option|
         >
           {{option.label}}

--- a/addon/components/variable-plugin/location/edit.hbs
+++ b/addon/components/variable-plugin/location/edit.hbs
@@ -27,7 +27,6 @@
           @options={{this.locationOptions.value.options}}
           @selected={{this.selectedLocationOption}}
           @onChange={{this.updateLocationOption}}
-          @verticalPosition="above"
           as |option|
         >
           {{option.label}}
@@ -35,14 +34,13 @@
       {{else}}
         <PowerSelect
           id='location-select'
-          @dropdownClass="location-select-dropdown"
+          @dropdownClass='location-select-dropdown'
           @allowClear={{false}}
           @searchEnabled={{true}}
           @searchField='label'
           @options={{this.locationOptions.value.options}}
           @selected={{this.selectedLocationOption}}
           @onChange={{this.updateLocationOption}}
-
           as |option|
         >
           {{option.label}}

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -131,59 +131,33 @@
 }
 
 @media only screen and (min-width: 2500px) {
-  #location-select {
+  #location-select, .location-select-dropdown {
     width: 600px;
-    .ember-power-select-option {
-      width: 598px;
-    }
   }
-
-
 }
 
 @media only screen and (max-width: 2500px) {
-  #location-select {
+  #location-select, .location-select-dropdown {
     width: 500px;
-    .ember-power-select-option {
-      width: 498px;
-    }
   }
-
-
 }
 
 @media only screen and (max-width: 2000px) {
-  #location-select {
+  #location-select, .location-select-dropdown {
     width: 400px;
-    .ember-power-select-option {
-      width: 398px;
-    }
   }
-
-
 }
 
-@media only screen and (max-width: 1600px) {
-  #location-select {
+@media only screen and (max-width: 1700px) {
+  #location-select, .location-select-dropdown {
     width: 300px;
-    .ember-power-select-option {
-      width: 298px;
-    }
   }
-
-
 }
 
-@media only screen and (max-width: 1300px) {
-
-  #location-select {
+@media only screen and (max-width: 1400px) {
+  #location-select, .location-select-dropdown {
     width: 200px;
-    .ember-power-select-option {
-      width: 198px;
-    }
   }
-
-
 }
 
 

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -131,35 +131,36 @@
 }
 
 @media only screen and (min-width: 2500px) {
-  #location-select, .location-select-dropdown {
+  #location-select,
+  .location-select-dropdown {
     width: 600px;
   }
 }
 
 @media only screen and (max-width: 2500px) {
-  #location-select, .location-select-dropdown {
+  #location-select,
+  .location-select-dropdown {
     width: 500px;
   }
 }
 
 @media only screen and (max-width: 2000px) {
-  #location-select, .location-select-dropdown {
+  #location-select,
+  .location-select-dropdown {
     width: 400px;
   }
 }
 
 @media only screen and (max-width: 1700px) {
-  #location-select, .location-select-dropdown {
+  #location-select,
+  .location-select-dropdown {
     width: 300px;
   }
 }
 
 @media only screen and (max-width: 1400px) {
-  #location-select, .location-select-dropdown {
+  #location-select,
+  .location-select-dropdown {
     width: 200px;
   }
 }
-
-
-
-

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -129,3 +129,63 @@
     margin-top: 5px;
   }
 }
+
+@media only screen and (min-width: 2500px) {
+  #location-select {
+    width: 600px;
+    .ember-power-select-option {
+      width: 598px;
+    }
+  }
+
+
+}
+
+@media only screen and (max-width: 2500px) {
+  #location-select {
+    width: 500px;
+    .ember-power-select-option {
+      width: 498px;
+    }
+  }
+
+
+}
+
+@media only screen and (max-width: 2000px) {
+  #location-select {
+    width: 400px;
+    .ember-power-select-option {
+      width: 398px;
+    }
+  }
+
+
+}
+
+@media only screen and (max-width: 1600px) {
+  #location-select {
+    width: 300px;
+    .ember-power-select-option {
+      width: 298px;
+    }
+  }
+
+
+}
+
+@media only screen and (max-width: 1300px) {
+
+  #location-select {
+    width: 200px;
+    .ember-power-select-option {
+      width: 198px;
+    }
+  }
+
+
+}
+
+
+
+


### PR DESCRIPTION
### Overview
Long story short, the powerselect was miscalculating the position of the dropdown, and producing a bug where the option got selected on mouseup, this should solve the miscalculation by fixing the width of the dropdown even when it's not displayed

##### connected issues and PRs:
GN-5479


### Setup
None

### How to test/reproduce
Make your window small so the options of a location have to be displayed in 2 rows, then scroll the sidebar so the powerselect dropdown needs to be displayed above the powerselect, notice that the bug doesn't happen anymore and the dropdown is displayed in the correct position

### Challenges/uncertainties
Breakpoints are always kinda ugly but don't know a better solution



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
