### PR TITLE
Use correct rdf:value instead of ext:content when serializing

### DIFF
--- a/.changeset/itchy-coats-nail.md
+++ b/.changeset/itchy-coats-nail.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Use the correct predicate for serializing variables

--- a/addon/plugins/variable-plugin/variables/number.ts
+++ b/addon/plugins/variable-plugin/variables/number.ts
@@ -166,7 +166,7 @@ const serialize = (node: PNode, state: EditorState): DOMOutputSpec => {
   const t = getTranslationFunction(state);
   const docLang = state.doc.attrs.lang as string;
   const { writtenNumber, minimumValue, maximumValue } = node.attrs;
-  const value = getOutgoingTriple(node.attrs, EXT('content'))?.object.value;
+  const value = getOutgoingTriple(node.attrs, RDF('value'))?.object.value;
 
   let humanReadableContent: string;
 


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->

[GN-5539](https://binnenland.atlassian.net/browse/GN-5539)
### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->

Not 100% sure all old variables will get parsed into a state where they use rdf:value
I checked the parserules and it seems so, though the "modern" one just takes the rdfa attributes verbatim so there's a slight chance it could get it wrong, but I don't think so

### Checks PR readiness

- [x] changelog
- [x] npm lint
- [x] no new deprecations
