### PR TITLE
Feat/make lpdc endpoint more configurable

### DIFF
--- a/.changeset/gorgeous-rocks-cheer.md
+++ b/.changeset/gorgeous-rocks-cheer.md
@@ -1,0 +1,26 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': major
+---
+
+BREAKING: changed the endpoint config on lpdc plugin so you can specify if you want instances or concepts.
+The config of the lpdc plugin should go from: 
+```
+lpdc: {
+  endpoint: '/lpdc-service',
+},
+```
+ to
+
+```
+lpdc: {
+  endpoint: '/lpdc-service/doc/instantie',
+},
+```
+To maintain the same functionality or 
+
+```
+lpdc: {
+  endpoint: '/lpdc-service/doc/concept',
+},
+```
+To fetch the concepts instead of the instances

--- a/addon/plugins/lpdc-plugin/api.ts
+++ b/addon/plugins/lpdc-plugin/api.ts
@@ -60,7 +60,7 @@ export const fetchLpdcs = async ({
     };
   };
 }> => {
-  const endpoint = `${config?.endpoint}/doc/instantie`;
+  const endpoint = `${config?.endpoint}`;
 
   const url = endpoint.startsWith('/')
     ? new URL(endpoint, window.location.origin)

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -290,7 +290,7 @@ export default class BesluitSampleController extends Controller {
       },
       lpdc: {
         // Needs to be exposed locally without authentication as otherwise calls fail
-        endpoint: 'http://localhost/lpdc-service',
+        endpoint: 'http://localhost/lpdc-service/doc/instantie',
       },
       location: {
         defaultPointUriRoot:


### PR DESCRIPTION
### Overview
Made the ldpc endpoint more configurable so we can fetch the concepts in any app if needed to

##### connected issues and PRs:
CIT-27


### Setup
None

### How to test/reproduce
Check that the lpdc plugin still works as before

### Challenges/uncertainties
Tried to do this non-breaking and support old configs, but it was more of a headache than it was worth, we will need to communicate with the people using the plugin if any



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
