### PR TITLE
fix(citation-plugin): remove usage of unsupported `keyboardInstruction` argument

### DIFF
--- a/.changeset/rotten-trainers-allow.md
+++ b/.changeset/rotten-trainers-allow.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Remove unsupported `keyboardInstruction` property from `AuDatePicker` `localization` argument

--- a/addon/components/citation-plugin/citations/search-modal.ts
+++ b/addon/components/citation-plugin/citations/search-modal.ts
@@ -85,7 +85,6 @@ export default class EditorPluginsCitationsSearchModalComponent extends Componen
       monthSelectLabel: this.intl.t('au-date-picker.month-select-label'),
       yearSelectLabel: this.intl.t('au-date-picker.year-select-label'),
       closeLabel: this.intl.t('au-date-picker.close-label'),
-      keyboardInstruction: this.intl.t('au-date-picker.keyboard-instruction'),
       calendarHeading: this.intl.t('au-date-picker.calendar-heading'),
       dayNames: getLocalizedDays(this.intl),
       monthNames: getLocalizedMonths(this.intl),


### PR DESCRIPTION
### Overview
Removes the unsupported `keyboardInstruction` property from `AuDatePicker` `localization` argument

### How to test/reproduce
- Start the test-app
- Open an 'Insert citation' modal instance
- Ensure no error pops-up in the console on the unsupported `keyboardInstruction` property