### PR TITLE
Add eli:title properties to structure nodes

### DIFF
--- a/.changeset/dry-eggs-fly.md
+++ b/.changeset/dry-eggs-fly.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Add eli:title to structure titles

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -199,7 +199,7 @@ export const emberNodeConfig: (
       if (titleHTML) {
         headerSpec = [
           tag,
-          { 'data-say-structure-header': true },
+          { 'data-say-structure-header': true, property: ELI('title').full },
           ...(structureName
             ? [
                 [
@@ -225,6 +225,7 @@ export const emberNodeConfig: (
       } else {
         headerSpec = [
           tag,
+          { property: ELI('title').full },
           ...(structureName
             ? [
                 [


### PR DESCRIPTION
### Overview
Add the eli:title property back to the structures so the rdfa is correct

##### connected issues and PRs:
maybe CIT-27


### Setup
None

### How to test/reproduce
Add a structure node, check that the html exported contains the eli:title property and the content is correct

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
