### PR TITLE
HOTFIX (28.x): Instantiate template uris in standard template plugin

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,4 +3,5 @@
 module.exports = {
   plugins: ['prettier-plugin-ember-template-tag'],
   singleQuote: true,
+  htmlWhitespaceSensitivity: 'strict',
 };

--- a/addon/components/standard-template-plugin/template-provider.ts
+++ b/addon/components/standard-template-plugin/template-provider.ts
@@ -13,6 +13,7 @@ import {
   hasOutgoingNamedNodeTriple,
   Resource,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import templateUuidInstantiator from '@lblod/template-uuid-instantiator';
 
 type Args = {
   controller: SayController;
@@ -120,7 +121,10 @@ export default class TemplateProviderComponent extends Component<Args> {
     }
     this.controller.doCommand(
       insertHtml(
-        instantiateUuids(template.body),
+        // TODO: we run both UUID regenerators for safety, but we should
+        // deprecate and remove the instantiateUuids function after we check
+        // there are no more templates that use that syntax.
+        instantiateUuids(templateUuidInstantiator(template.body)),
         insertRange.from,
         insertRange.to,
         undefined,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11446,7 +11446,7 @@ snapshots:
       '@types/ember__object': 4.0.12(@babel/core@7.26.0)
       '@types/ember__polyfills': 4.0.6
       '@types/ember__routing': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__runloop': 4.0.10(@babel/core@7.26.0)
+      '@types/ember__runloop': 4.0.10
       '@types/ember__service': 4.0.9(@babel/core@7.26.0)
       '@types/ember__string': 3.16.3
       '@types/ember__template': 4.0.7
@@ -11582,6 +11582,11 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    optional: true
+
+  '@types/ember__runloop@4.0.10':
+    dependencies:
+      '@types/ember': 4.0.11
     optional: true
 
   '@types/ember__runloop@4.0.10(@babel/core@7.26.0)':

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -1,3 +1,6 @@
+// there is some irregular whitespace in one of the templates from the GN
+// database we copied here verbatim
+/* eslint-disable no-irregular-whitespace */
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from 'tracked-built-ins';
@@ -416,7 +419,12 @@ export default class BesluitSampleController extends Controller {
           'http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt',
         ],
         disabledInContexts: [],
-        body: '<p><span class="mark-highlight-manual">Vrije tekst voor bijvoorbeeld vraag, antwoord, amendement, mededeling of tussenkomst.</span></p>',
+        body: /* HTML */ `<p
+          ><span class="mark-highlight-manual"
+            >Vrije tekst voor bijvoorbeeld vraag, antwoord, amendement,
+            mededeling of tussenkomst.</span
+          ></p
+        >`,
       },
       {
         id: 'b04fc03e-e8ff-496a-9343-1f07b4f55551',
@@ -428,15 +436,109 @@ export default class BesluitSampleController extends Controller {
           'http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt',
         ],
         disabledInContexts: ['http://data.vlaanderen.be/ns/besluit#Besluit'],
-        body: `
-          <div property="prov:generated" resource="http://data.lblod.info/id/besluiten/\${generateUuid()}" typeof="besluit:Besluit ext:BesluitNieuweStijl">
-            <p>Openbare titel besluit:</p>
-            <h4 class="h4" property="eli:title" datatype="xsd:string"><span class="mark-highlight-manual">Geef titel besluit op</span></h4>
-            <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
-            <br>
-            <p>Korte openbare beschrijving:</p>
-            <p property="eli:description" datatype="xsd:string"><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
+        body: /* HTML */ `
+          "
+          <div
+            property="prov:generated"
+            resource="http://data.lblod.info/id/besluiten/--ref-uuid4-c10209c0-dfba-46fb-80c7-1c6aedf656e9"
+            typeof="besluit:Besluit ext:BesluitNieuweStijl"
+            data-label="Besluit"
+          >
+            <div style="display: none" data-rdfa-container="true">
+              <span
+                property="eli:language"
+                resource="http://publications.europa.eu/resource/authority/language/NLD"
+              />
+            </div>
+            <div data-content-container="true">
+              <div
+                property="eli:title"
+                datatype="xsd:string"
+                data-label="Openbare titel besluit"
+              >
+                <h4
+                  ><span class="mark-highlight-manual"
+                    >Geef titel besluit op</span
+                  ></h4
+                >
+              </div>
+              <div
+                property="eli:description"
+                datatype="xsd:string"
+                data-label="Korte openbare beschrijving"
+              >
+                <p
+                  ><span class="mark-highlight-manual"
+                    >Geef korte beschrijving op</span
+                  ></p
+                >
+              </div>
+              <div
+                property="besluit:motivering"
+                lang="nl"
+                data-label="Motivering"
+              >
+                <p
+                  ><span class="mark-highlight-manual"
+                    >geef bestuursorgaan op</span
+                  >,</p
+                >
+                <br />
+                <h5>Bevoegdheid</h5>
+                <ul class="bullet-list">
+                  <li
+                    ><span class="mark-highlight-manual"
+                      >Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span
+                    ></li
+                  >
+                </ul>
+                <br />
+                <h5>Juridische context</h5>
+                <ul class="bullet-list">
+                  <li
+                    ><span class="mark-highlight-manual"
+                      >Voeg juridische context in</span
+                    ></li
+                  >
+                </ul>
+                <br />
+                <h5>Feitelijke context en argumentatie</h5>
+                <ul class="bullet-list">
+                  <li
+                    ><span class="mark-highlight-manual"
+                      >Voeg context en argumentatie in</span
+                    ></li
+                  >
+                </ul>
+              </div>
+              <br />
+              <br />
+              <h5>Beslissing</h5>
+              <div
+                property="prov:value"
+                datatype="xsd:string"
+                data-label="Artikels"
+              >
+                <div
+                  property="eli:has_part"
+                  resource="http://data.lblod.info/artikels/--ref-uuid4-7a0552ff-4fb1-4e42-98d6-dd88faf60f0c"
+                  typeof="besluit:Artikel"
+                  data-say-is-only-article="true"
+                >
+                  <div
+                    >Artikel
+                    <span property="eli:number" datatype="xsd:string"
+                      >1</span
+                    ></div
+                  >
+                  <div property="prov:value" datatype="xsd:string">
+                    <span class="mark-highlight-manual">Voer inhoud in</span>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
+          "
         `,
       },
       {
@@ -449,64 +551,193 @@ export default class BesluitSampleController extends Controller {
           'http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt',
         ],
         disabledInContexts: ['http://data.vlaanderen.be/ns/besluit#Besluit'],
-        body: `
-          <div property="prov:generated" resource="http://data.lblod.info/id/besluiten/\${generateUuid()}" typeof="besluit:Besluit https://data.vlaanderen.be/id/concept/BesluitType/67378dd0-5413-474b-8996-d992ef81637a ext:BesluitNieuweStijl">
-            <p>Openbare titel besluit:</p>
-            <h4 class="h4" property="eli:title" datatype="xsd:string"><span class="mark-highlight-manual">Geef titel besluit op</span></h4>
-            <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
-            <p>Korte openbare beschrijving:</p>
-            <p property="eli:description" datatype="xsd:string"><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
-            <br>
-
-            <div property="besluit:motivering" lang="nl">
-              <p>
-                <span class="mark-highlight-manual">geef bestuursorgaan op</span>,
+        body: /* HTML */ `<div
+          property="prov:generated"
+          resource="http://data.lblod.info/id/besluiten/--ref-uuid4-c10209c0-dfba-46fb-80c7-1c6aedf656e9"
+          typeof="besluit:Besluit https://data.vlaanderen.be/id/concept/BesluitType/67378dd0-5413-474b-8996-d992ef81637a ext:BesluitNieuweStijl"
+          data-label="Besluit"
+        >
+          <div style="display: none" data-rdfa-container="true">
+            <span
+              property="eli:language"
+              resource="http://publications.europa.eu/resource/authority/language/NLD"
+            />
+          </div>
+          <div data-content-container="true">
+            <div
+              property="eli:title"
+              datatype="xsd:string"
+              data-label="Openbare titel besluit"
+            >
+              <h4
+                ><span class="mark-highlight-manual"
+                  >Geef titel besluit op</span
+                ></h4
+              >
+            </div>
+            <div
+              property="eli:description"
+              datatype="xsd:string"
+              data-label="Korte openbare beschrijving"
+            >
+              <p
+                ><span class="mark-highlight-manual"
+                  >Geef korte beschrijving op</span
+                ></p
+              >
+            </div>
+            <br />
+            <div
+              property="besluit:motivering"
+              lang="nl"
+              data-label="Motivering"
+            >
+              <p
+                ><span class="mark-highlight-manual"
+                  >geef bestuursorgaan op</span
+                >,
               </p>
-              <br>
-
+              <br />
               <h5>Bevoegdheid</h5>
               <ul class="bullet-list">
-                <li><span class="mark-highlight-manual">Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span></li>
+                <li
+                  ><span class="mark-highlight-manual"
+                    >Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span
+                  ></li
+                >
               </ul>
-              <br>
-
+              <br />
               <h5>Juridische context</h5>
               <ul class="bullet-list">
-                <li><a class="annotation" property="eli:cites" typeof="eli:LegalExpression" href="https://codex.vlaanderen.be/doc/document/1009730">Nieuwe gemeentewet</a>&nbsp;(KB 24/06/1988)</li>
-                <li>decreet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1029017" property="eli:cites" typeof="eli:LegalExpression">over het lokaal bestuur</a> van 22/12/2017</li>
-                <li>wet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1009628" property="eli:cites" typeof="eli:LegalExpression">betreffende de politie over het wegverkeer (wegverkeerswet - Wet van 16 maart 1968)</a></li>
-                <li>wegcode - Koninklijk Besluit <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1036242" property="eli:cites" typeof="eli:LegalExpression">van 1 december 1975 houdende algemeen reglement op de politie van het wegverkeer en van het gebruik van de openbare weg.</a></li>
-                <li>code van de wegbeheerder - <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1035575" property="eli:cites" typeof="eli:LegalExpression">ministerieel besluit van 11 oktober 1976 houdende de minimumafmetingen en de bijzondere plaatsingsvoorwaarden van de verkeerstekens</a></li>
+                <li
+                  ><a
+                    class="annotation"
+                    property="eli:cites"
+                    typeof="eli:LegalExpression"
+                    href="https://codex.vlaanderen.be/doc/document/1009730"
+                    >Nieuwe gemeentewet</a
+                  >&nbsp;(KB 24/06/1988)</li
+                >
+                <li
+                  >decreet
+                  <a
+                    class="annotation"
+                    href="https://codex.vlaanderen.be/doc/document/1029017"
+                    property="eli:cites"
+                    typeof="eli:LegalExpression"
+                    >over het lokaal bestuur</a
+                  >
+                  van 22/12/2017</li
+                >
+                <li
+                  >wet
+                  <a
+                    class="annotation"
+                    href="https://codex.vlaanderen.be/doc/document/1009628"
+                    property="eli:cites"
+                    typeof="eli:LegalExpression"
+                    >betreffende de politie over het wegverkeer (wegverkeerswet
+                    - Wet van 16 maart 1968)</a
+                  ></li
+                >
+                <li
+                  >wegcode - Koninklijk Besluit
+                  <a
+                    class="annotation"
+                    href="https://codex.vlaanderen.be/doc/document/1036242"
+                    property="eli:cites"
+                    typeof="eli:LegalExpression"
+                    >van 1 december 1975 houdende algemeen reglement op de
+                    politie van het wegverkeer en van het gebruik van de
+                    openbare weg.</a
+                  ></li
+                >
+                <li
+                  >code van de wegbeheerder -
+                  <a
+                    class="annotation"
+                    href="https://codex.vlaanderen.be/doc/document/1035575"
+                    property="eli:cites"
+                    typeof="eli:LegalExpression"
+                    >ministerieel besluit van 11 oktober 1976 houdende de
+                    minimumafmetingen en de bijzondere plaatsingsvoorwaarden van
+                    de verkeerstekens</a
+                  ></li
+                >
               </ul>
-              <br>
-              <em>specifiek voor aanvullende reglementen op het wegverkeer  (= politieverordeningen m.b.t. het wegverkeer voor wat betreft permanente of periodieke verkeerssituaties)</em>
+              <br />
+              <em
+                >specifiek voor aanvullende reglementen op het wegverkeer (=
+                politieverordeningen m.b.t. het wegverkeer voor wat betreft
+                permanente of periodieke verkeerssituaties)</em
+              >
               <ul class="bullet-list">
-                <li>decreet <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1016816" property="eli:cites" typeof="eli:LegalExpression">betreffende de aanvullende reglementen op het wegverkeer en de plaatsing en bekostiging van de verkeerstekens </a>(16 mei 2008)</li>
-                <li>Besluit van de Vlaamse Regering <a class="annotation" href="https://codex.vlaanderen.be/doc/document/1017729" property="eli:cites" typeof="eli:LegalExpression">betreffende de aanvullende reglementen en de plaatsing en bekostiging van verkeerstekens</a> van 23 januari 2009</li>
-                    <li><a href="https://codex.vlaanderen.be/doc/document/1035938" property="eli:cites" typeof="eli:LegalExpression">Omzendbrief MOB/2009/01 van 3 april 2009 gemeentelijke aanvullende reglementen op de politie over het wegverkeer</a></li>
+                <li
+                  >decreet
+                  <a
+                    class="annotation"
+                    href="https://codex.vlaanderen.be/doc/document/1016816"
+                    property="eli:cites"
+                    typeof="eli:LegalExpression"
+                    >betreffende de aanvullende reglementen op het wegverkeer en
+                    de plaatsing en bekostiging van de verkeerstekens </a
+                  >(16 mei 2008)</li
+                >
+                <li
+                  >Besluit van de Vlaamse Regering
+                  <a
+                    class="annotation"
+                    href="https://codex.vlaanderen.be/doc/document/1017729"
+                    property="eli:cites"
+                    typeof="eli:LegalExpression"
+                    >betreffende de aanvullende reglementen en de plaatsing en
+                    bekostiging van verkeerstekens</a
+                  >​ van 23 januari 2009</li
+                >
+                <li
+                  ><a
+                    href="https://codex.vlaanderen.be/doc/document/1035938"
+                    property="eli:cites"
+                    typeof="eli:LegalExpression"
+                    >Omzendbrief MOB/2009/01 van 3 april 2009 gemeentelijke
+                    aanvullende reglementen op de politie over het wegverkeer</a
+                  ></li
+                >
               </ul>
-
               <h5>Feitelijke context en argumentatie</h5>
               <ul class="bullet-list">
-                <li><span class="mark-highlight-manual">Voeg context en argumentatie in</span></li>
+                <li
+                  ><span class="mark-highlight-manual"
+                    >Voeg context en argumentatie in</span
+                  ></li
+                >
               </ul>
             </div>
-            <br>
-            <br>
-
+            <br />
+            <br />
             <h5>Beslissing</h5>
-
-            <div property="prov:value" datatype="xsd:string">
-              <div property="eli:has_part" resource="http://data.lblod.info/artikels/\${generateUuid()}" typeof="besluit:Artikel" data-say-is-only-article="true">
-                <div>Artikel <span property="eli:number" datatype="xsd:string">1</span></div>
-                <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
+            <div
+              property="prov:value"
+              datatype="xsd:string"
+              data-label="Artikels"
+            >
+              <div
+                property="eli:has_part"
+                resource="http://data.lblod.info/artikels/--ref-uuid4-68c56ef4-8843-4b7f-a72a-9d0038ff723f"
+                typeof="besluit:Artikel"
+                data-say-is-only-article="true"
+              >
+                <div>
+                  Artikel
+                  <span property="eli:number" datatype="xsd:string">1</span>
+                </div>
                 <div property="prov:value" datatype="xsd:string">
                   <span class="mark-highlight-manual">Voer inhoud in</span>
                 </div>
               </div>
             </div>
           </div>
-        `,
+        </div>`,
       },
       {
         id: '39c31a7e-2ba9-11e9-88cf-83ebfda837dc',
@@ -514,49 +745,98 @@ export default class BesluitSampleController extends Controller {
         matches: [],
         contexts: [],
         disabledInContexts: ['http://data.vlaanderen.be/ns/besluit#Besluit'],
-        body: `
-          <div property="prov:generated" resource="http://data.lblod.info/id/besluiten/\${generateUuid()}" typeof="besluit:Besluit ext:BesluitKlassiekeStijl">
-            <p>Openbare titel besluit:</p>
-            <h5 class="h4" property="eli:title" datatype="xsd:string"><span class="mark-highlight-manual">Geef openbare titel besluit op</span></h5>
-            <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
-            <br>
-            <p>Korte openbare beschrijving:</p>
-            <p property="eli:description" datatype="xsd:string"><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
-            <br>
-
-
-            <div property="besluit:motivering" lang="nl">
-              <p>
-                <span class="mark-highlight-manual">geef bestuursorgaan op</span>,
-              </p>
-              <br>
-
+        body: /* HTML */ `<div
+          property="prov:generated"
+          resource="http://data.lblod.info/id/besluiten/--ref-uuid4-5ab24a9b-4760-4607-81c1-38dd53c13dff"
+          typeof="besluit:Besluit ext:BesluitKlassiekeStijl"
+          data-label="Besluit"
+        >
+          <div style="display: none" data-rdfa-container="true">
+            <span
+              property="eli:language"
+              resource="http://publications.europa.eu/resource/authority/language/NLD"
+            />
+          </div>
+          <div data-content-container="true">
+            <div
+              property="eli:title"
+              datatype="xsd:string"
+              data-label="Openbare titel besluit"
+            >
+              <h5
+                ><span class="mark-highlight-manual"
+                  >Geef titel besluit op</span
+                ></h5
+              >
+            </div>
+            <div
+              property="eli:description"
+              datatype="xsd:string"
+              data-label="Korte openbare beschrijving"
+            >
+              <p
+                ><span class="mark-highlight-manual"
+                  >Geef korte beschrijving op</span
+                ></p
+              >
+            </div>
+            <div
+              property="besluit:motivering"
+              lang="nl"
+              data-label="Motivering"
+            >
+              <p
+                ><span class="mark-highlight-manual"
+                  >geef bestuursorgaan op</span
+                >,</p
+              >
+              <br />
               <div>
                 <ul class="bullet-list">
-                  <li>Gelet op <span class="mark-highlight-manual">Voeg juridische grond in</span>;</li>
+                  <li
+                    >Gelet op
+                    <span class="mark-highlight-manual"
+                      >Voeg juridische grond in</span
+                    >;</li
+                  >
                 </ul>
               </div>
-
-              <br>
+              <br />
               <div>
                 <ul class="bullet-list">
-                  <li>Overwegende dat <span class="mark-highlight-manual">Voeg motivering in</span>;</li>
+                  <li
+                    >Overwegende dat
+                    <span class="mark-highlight-manual">Voeg motivering in</span
+                    >;</li
+                  >
                 </ul>
               </div>
             </div>
-            <br>
-            <br>
-
+            <br />
+            <br />
             <p class="u-spacer--small">Beslist,</p>
-            <div property="prov:value" datatype="xsd:string">
-              <div property="eli:has_part" resource="http://data.lblod.info/artikels/\${generateUuid()}" typeof="besluit:Artikel" data-say-is-only-article="true">
-                <div>Artikel <span property="eli:number" datatype="xsd:string">1</span></div>
-                <span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
-                <div property="prov:value" datatype="xsd:string"><span class="mark-highlight-manual">Voer inhoud in</span></div>
+            <div
+              property="prov:value"
+              datatype="xsd:string"
+              data-label="Artikels"
+            >
+              <div
+                property="eli:has_part"
+                resource="http://data.lblod.info/artikels/--ref-uuid4-69ba01d6-db79-4b36-8ed4-d824269724df"
+                typeof="besluit:Artikel"
+                data-say-is-only-article="true"
+              >
+                <div>
+                  Artikel
+                  <span property="eli:number" datatype="xsd:string">1</span>
+                </div>
+                <div property="prov:value" datatype="xsd:string">
+                  <span class="mark-highlight-manual">Voer inhoud in</span>
+                </div>
               </div>
             </div>
           </div>
-        `,
+        </div>`,
       },
       {
         id: '6933312e-2bac-11e9-af69-3baeff70b1a8',
@@ -564,44 +844,106 @@ export default class BesluitSampleController extends Controller {
         matches: [],
         contexts: [],
         disabledInContexts: ['http://data.vlaanderen.be/ns/besluit#Besluit'],
-        body: `
-          <div property="prov:generated" resource="http://data.lblod.info/id/besluiten/\${generateUuid()}" typeof="besluit:Besluit ext:BesluitNieuweStijl">
-          <p>Openbare titel besluit:</p>
-          <h4 class="h4" property="eli:title" datatype="xsd:string"><span class="mark-highlight-manual">Geef titel besluit op</span></h4>
-          <span style="display: none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span> <br />
-          <p>Korte openbare beschrijving:</p>
-          <p property="eli:description" datatype="xsd:string"><span class="mark-highlight-manual">Geef korte beschrijving op</span></p>
-          <br />
-          <div property="besluit:motivering" lang="nl">
-            <p><span class="mark-highlight-manual">geef bestuursorgaan op</span>,</p>
-            <br />
-            <h5>Bevoegdheid</h5>
-            <ul class="bullet-list">
-              <li><span class="mark-highlight-manual">Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span></li>
-            </ul>
-            <br />
-            <h5>Juridische context</h5>
-            <ul class="bullet-list">
-              <li><span class="mark-highlight-manual">Voeg juridische context in</span></li>
-            </ul>
-            <br />
-            <h5>Feitelijke context en argumentatie</h5>
-            <ul class="bullet-list">
-              <li><span class="mark-highlight-manual">Voeg context en argumentatie in</span></li>
-            </ul>
+        body: /* HTML */ `<div
+          property="prov:generated"
+          resource="http://data.lblod.info/id/besluiten/--ref-uuid4-c10209c0-dfba-46fb-80c7-1c6aedf656e9"
+          typeof="besluit:Besluit ext:BesluitNieuweStijl"
+          data-label="Besluit"
+        >
+          <div style="display: none" data-rdfa-container="true">
+            <span
+              property="eli:language"
+              resource="http://publications.europa.eu/resource/authority/language/NLD"
+            />
           </div>
-          <br />
-          <br />
-          <h5>Beslissing</h5>
-          <div property="prov:value" datatype="xsd:string">
-            <div property="eli:has_part" resource="http://data.lblod.info/artikels/\${generateUuid()}" typeof="besluit:Artikel" data-say-is-only-article="true">
-              <div>Artikel <span property="eli:number" datatype="xsd:string">1</span></div>
-              <span style="display: none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept">&nbsp;</span>
-              <div property="prov:value" datatype="xsd:string"><span class="mark-highlight-manual">Voer inhoud in</span></div>
+          <div data-content-container="true">
+            <div
+              property="eli:title"
+              datatype="xsd:string"
+              data-label="Openbare titel besluit"
+            >
+              <h4
+                ><span class="mark-highlight-manual"
+                  >Geef titel besluit op</span
+                ></h4
+              >
+            </div>
+            <div
+              property="eli:description"
+              datatype="xsd:string"
+              data-label="Korte openbare beschrijving"
+            >
+              <p
+                ><span class="mark-highlight-manual"
+                  >Geef korte beschrijving op</span
+                ></p
+              >
+            </div>
+            <div
+              property="besluit:motivering"
+              lang="nl"
+              data-label="Motivering"
+            >
+              <p
+                ><span class="mark-highlight-manual"
+                  >geef bestuursorgaan op</span
+                >,</p
+              >
+              <br />
+              <h5>Bevoegdheid</h5>
+              <ul class="bullet-list">
+                <li
+                  ><span class="mark-highlight-manual"
+                    >Rechtsgrond die bepaalt dat dit orgaan bevoegd is.</span
+                  ></li
+                >
+              </ul>
+              <br />
+              <h5>Juridische context</h5>
+              <ul class="bullet-list">
+                <li
+                  ><span class="mark-highlight-manual"
+                    >Voeg juridische context in</span
+                  ></li
+                >
+              </ul>
+              <br />
+              <h5>Feitelijke context en argumentatie</h5>
+              <ul class="bullet-list">
+                <li
+                  ><span class="mark-highlight-manual"
+                    >Voeg context en argumentatie in</span
+                  ></li
+                >
+              </ul>
+            </div>
+            <br />
+            <br />
+            <h5>Beslissing</h5>
+            <div
+              property="prov:value"
+              datatype="xsd:string"
+              data-label="Artikels"
+            >
+              <div
+                property="eli:has_part"
+                resource="http://data.lblod.info/artikels/--ref-uuid4-7a0552ff-4fb1-4e42-98d6-dd88faf60f0c"
+                typeof="besluit:Artikel"
+                data-say-is-only-article="true"
+              >
+                <div
+                  >Artikel
+                  <span property="eli:number" datatype="xsd:string"
+                    >1</span
+                  ></div
+                >
+                <div property="prov:value" datatype="xsd:string">
+                  <span class="mark-highlight-manual">Voer inhoud in</span>
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-        `,
+        </div>`,
       },
     ];
   }


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

A single forgotten function call which caused a huge mess in terms of bad publications...


- replaces the templates used in the dummy app with the current ones in the GN database (this was probably one of the reasons we didn't notice the problem)
- runs the template-uuid-instantiator when inserting a template with the standard-template-plugin

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->

https://binnenland.atlassian.net/browse/GN-5572

### Setup
<!-- PR dependencies -->
<!-- override snippets -->



### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

commit ab6935c2dbc94ffd8b5c5a319e082bd005100eab reproduces the bug in the dummy app by using the current GN templates instead of the old ones we still had
(insert a decision template using one of the sidebar buttons, notice the decision still has a `--ref-uuid4` uri)

commit d8bc81ff631e5a62f77e217c2ffcce0a656cd863 fixes the bug by running the template-uuid-instantiator.

Alternatively, hook up to gn and test creating an agendapoint from the meeting screen (which doesn't use the new template selector)


### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
