### PR TITLE
GN-5590 - a11y(irgn): increase measure preview font-size

### DIFF
--- a/.changeset/smart-sheep-hope.md
+++ b/.changeset/smart-sheep-hope.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+IRGN: increase font size of measure preview"

--- a/addon/components/roadsign-regulation-plugin/roadsigns-table.gts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-table.gts
@@ -106,7 +106,11 @@ export default class RoadSignsTable extends Component<Signature> {
                     </div>
                   </td>
                   <td>
-                    <AuHelpText skin='secondary' class='au-u-margin-none'>
+                    <AuHelpText
+                      @size='large'
+                      skin='secondary'
+                      class='au-u-margin-none'
+                    >
                       <MeasurePreview
                         @concept={{measureConcept}}
                         @limitText={{true}}

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -261,8 +261,8 @@ export default class BesluitSampleController extends Controller {
         defaultDecisionsGovernmentName: 'Edegem',
       },
       roadsignRegulation: {
-        endpoint: 'https://dev-vlag.roadsigns.lblod.info/sparql',
-        imageBaseUrl: 'https://dev-vlag.roadsigns.lblod.info',
+        endpoint: 'https://dev.roadsigns.lblod.info/sparql',
+        imageBaseUrl: 'https://dev.roadsigns.lblod.info',
       },
       besluitType: {
         endpoint: 'https://centrale-vindplaats.lblod.info/sparql',


### PR DESCRIPTION
### Overview
The font-size of the measure preview is a bit small, so this PR increases it.

### How to test/reproduce
- Start the test-app
- Insert a 'reglement' decision
- Open the mobility measure modal
- Ensure the font-size of the preview is a bit larger

