### PR TITLE
GN-5570: roadsign-regulation-plugin - differentiate between verkeersbord and onderbord

### DIFF
--- a/.changeset/tiny-pots-float.md
+++ b/.changeset/tiny-pots-float.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Roadsign-regulation-plugin: differentiate between 'Verkeersbord' and 'Onderbord' signs

--- a/addon/components/roadsign-regulation-plugin/roadsigns-table.gts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-table.gts
@@ -19,6 +19,7 @@ import { eq } from 'ember-truth-helpers';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
+import { SIGN_CONCEPT_TYPES } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/constants';
 
 type Signature = {
   Args: {
@@ -44,8 +45,10 @@ export default class RoadSignsTable extends Component<Signature> {
   categories = (measureConcept: MobilityMeasureConcept) => {
     const categorySet: Set<string> = new Set();
     for (const signConcept of measureConcept.signConcepts) {
-      const categories = signConcept.classifications;
-      addAll(categorySet, ...categories);
+      if (signConcept.type === SIGN_CONCEPT_TYPES.ROAD_SIGN) {
+        const categoryLabels = signConcept.categories.map((cat) => cat.label);
+        addAll(categorySet, ...categoryLabels);
+      }
     }
     return [...categorySet].sort();
   };

--- a/addon/plugins/roadsign-regulation-plugin/actions/insert-measure.ts
+++ b/addon/plugins/roadsign-regulation-plugin/actions/insert-measure.ts
@@ -25,7 +25,8 @@ import { buildArticleStructure } from '../../decision-plugin/utils/build-article
 import { insertArticle } from '../../decision-plugin/actions/insert-article';
 import { SignConcept } from '../schemas/sign-concept';
 import {
-  SIGN_CONCEPT_TYPE_LABELS,
+  ROAD_SIGN_CATEGORIES,
+  SIGN_CONCEPT_TYPES,
   SIGN_TYPE_MAPPING,
   SIGN_TYPES,
   ZONALITY_OPTIONS,
@@ -190,9 +191,28 @@ function constructMeasureBody(
   return schema.nodes.paragraph.create({}, nodes);
 }
 
+function determineSignLabel(signConcept: SignConcept) {
+  switch (signConcept.type) {
+    case SIGN_CONCEPT_TYPES.TRAFFIC_LIGHT:
+      return 'Verkeerslicht';
+    case SIGN_CONCEPT_TYPES.ROAD_MARKING:
+      return 'Wegmarkering';
+    case SIGN_CONCEPT_TYPES.ROAD_SIGN:
+      if (
+        signConcept.categories
+          .map((cat) => cat.uri)
+          .includes(ROAD_SIGN_CATEGORIES.ONDERBORD)
+      ) {
+        return 'Onderbord';
+      } else {
+        return 'Verkeersbord';
+      }
+  }
+}
+
 function constructSignNode(signConcept: SignConcept, schema: Schema) {
   const signUri = `http://data.lblod.info/verkeerstekens/${uuid()}`;
-  const prefix = SIGN_CONCEPT_TYPE_LABELS[signConcept.type];
+  const prefix = determineSignLabel(signConcept);
   const node = schema.nodes.inline_rdfa.create(
     {
       rdfaNodeType: 'resource',

--- a/addon/plugins/roadsign-regulation-plugin/constants.ts
+++ b/addon/plugins/roadsign-regulation-plugin/constants.ts
@@ -29,9 +29,25 @@ export const SIGN_TYPE_MAPPING = {
   [SIGN_CONCEPT_TYPES.ROAD_MARKING]: SIGN_TYPES.ROAD_MARKING,
 } as const;
 
-export const SIGN_CONCEPT_TYPE_LABELS = {
-  [SIGN_CONCEPT_TYPES.TRAFFIC_SIGN]: 'Verkeersteken',
-  [SIGN_CONCEPT_TYPES.ROAD_SIGN]: 'Verkeersbord',
-  [SIGN_CONCEPT_TYPES.TRAFFIC_LIGHT]: 'Verkeerslicht',
-  [SIGN_CONCEPT_TYPES.ROAD_MARKING]: 'Wegmarkering',
-} as const;
+export const ROAD_SIGN_CATEGORIES = {
+  XXBORD:
+    'https://data.vlaanderen.be/id/concept/Verkeersbordcategorie/ae1b7231-1f31-492d-947a-25fc5d114492',
+  'XX-AWVBORD':
+    'https://data.vlaanderen.be/id/concept/Verkeersbordcategorie/8e302648-0eca-478b-8b48-67c3b0e39c0a',
+  GEVAARSBORD:
+    'http://data.vlaanderen.be/id/concept/Verkeersbordcategorie/2982567006d9e19f04063df73123f56f40e3a28941031a7ba6e6667f64740fa9',
+  STILSTAANPARKEERBORD:
+    'http://data.vlaanderen.be/id/concept/Verkeersbordcategorie/29ea3335e357e414d07229242607b352941c0c21e78760600cc0f5270f18c38b',
+  VOORRANGSBORD:
+    'http://data.vlaanderen.be/id/concept/Verkeersbordcategorie/737da5751bc7f311398a834f34df310dd95255a0b62afa2db2882c72d54b47d2',
+  ZONEBORD:
+    'http://data.vlaanderen.be/id/concept/Verkeersbordcategorie/86a67f3cba6512ae10c4b9b09ba35d8c80109189b44d37e848858af9efb37019',
+  VERBODSBORD:
+    'http://data.vlaanderen.be/id/concept/Verkeersbordcategorie/955a9adc73d076a2a424754cd540b73da8d15fb002ab6c9f115d080edddb57e8',
+  ONDERBORD:
+    'http://data.vlaanderen.be/id/concept/Verkeersbordcategorie/991b04b477b77bc7cf1414fb5d255cc4435dd9c1681e8de66f770710c1c83ad0',
+  GEBODSBORD:
+    'http://data.vlaanderen.be/id/concept/Verkeersbordcategorie/9d84069e70f192b7a474d02f07687bc3343ee324207ad9e093c0b2f5def647f8',
+  AANWIJSBORD:
+    'http://data.vlaanderen.be/id/concept/Verkeersbordcategorie/9ea8f8b421343370d20a8bd45d6226aadc48125bda8ddbbeeb53d99f181ee05a',
+};

--- a/addon/plugins/roadsign-regulation-plugin/queries/road-sign-category.ts
+++ b/addon/plugins/roadsign-regulation-plugin/queries/road-sign-category.ts
@@ -2,6 +2,7 @@ import {
   BindingObject,
   executeQuery,
   objectify,
+  sparqlEscapeUri,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/sparql-helpers';
 import {
   RoadSignCategory,
@@ -10,16 +11,18 @@ import {
 
 type QueryOptions = {
   abortSignal?: AbortSignal;
+  roadSignConceptUri?: string;
 };
 
 export default async function queryRoadSignCategories(
   endpoint: string,
   options: QueryOptions = {},
 ) {
-  const { abortSignal } = options;
+  const { abortSignal, roadSignConceptUri } = options;
   const query = /* sparql */ `
     PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    PREFIX dct: <http://purl.org/dc/terms/>
 
     SELECT DISTINCT
       ?uri
@@ -27,6 +30,8 @@ export default async function queryRoadSignCategories(
     WHERE {
       ?uri a mobiliteit:Verkeersbordcategorie;
            skos:prefLabel ?label.
+
+      ${roadSignConceptUri ? `${sparqlEscapeUri(roadSignConceptUri)} dct:type ?uri` : ''}
     }
   `;
   const queryResult = await executeQuery<BindingObject<RoadSignCategory>>({

--- a/addon/plugins/roadsign-regulation-plugin/schemas/sign-concept.ts
+++ b/addon/plugins/roadsign-regulation-plugin/schemas/sign-concept.ts
@@ -1,13 +1,27 @@
 import { z } from 'zod';
 import { SIGN_CONCEPT_TYPES, ZONALITY_OPTIONS } from '../constants';
+import { RoadSignCategorySchema } from './road-sign-category';
 
-export const SignConceptSchema = z.object({
-  uri: z.string(),
-  code: z.string(),
-  type: z.nativeEnum(SIGN_CONCEPT_TYPES),
-  image: z.string(),
-  classifications: z.array(z.string()).default([]),
-  zonality: z.nativeEnum(ZONALITY_OPTIONS).optional(),
-});
+export const SignConceptSchema = z
+  .object({
+    uri: z.string(),
+    code: z.string(),
+    image: z.string(),
+    zonality: z.nativeEnum(ZONALITY_OPTIONS).optional(),
+  })
+  .and(
+    z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal(SIGN_CONCEPT_TYPES.ROAD_SIGN),
+        categories: z.array(RoadSignCategorySchema).default([]),
+      }),
+      z.object({
+        type: z.enum([
+          SIGN_CONCEPT_TYPES.ROAD_MARKING,
+          SIGN_CONCEPT_TYPES.TRAFFIC_LIGHT,
+        ]),
+      }),
+    ]),
+  );
 
 export type SignConcept = z.infer<typeof SignConceptSchema>;

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -261,8 +261,8 @@ export default class BesluitSampleController extends Controller {
         defaultDecisionsGovernmentName: 'Edegem',
       },
       roadsignRegulation: {
-        endpoint: 'https://dev-vlag.roadsigns.lblod.info/sparql',
-        imageBaseUrl: 'https://dev-vlag.roadsigns.lblod.info',
+        endpoint: 'https://dev.roadsigns.lblod.info/sparql',
+        imageBaseUrl: 'https://dev.roadsigns.lblod.info',
       },
       besluitType: {
         endpoint: 'https://centrale-vindplaats.lblod.info/sparql',


### PR DESCRIPTION
### Overview
This PR ensures that the roadsign-regulation plugin now differentiates between a 'Verkeersbord' and 'Onderbord' when applicable. It affects how roadsigns are displayed in the document.
- If a sign is a 'Verkeersbord', but does not have the 'Onderbord' category => 'Verkeersbord <code>'
- If a sign is a 'Verkeerdbord', and has the 'Onderbord' category => 'Onderbord <code>'

This PR also adjusts the logic of fetching the categories a bit, to retrieve all needed information.

##### connected issues and PRs:
[GN-5570](https://binnenland.atlassian.net/browse/GN-5570)
Requires https://github.com/lblod/app-mow-registry/pull/129


### Setup
Set-up and configure https://github.com/lblod/app-mow-registry/pull/129 as the MOW backend

### How to test/reproduce
- Start the test-app and open the 'Besluit' page
- Open the 'Insert roadsign-regulation' modal
- Ensure the categories are still correctly displayed next to the measure options
- Select a measure which contains the 'Onderbord' category and insert it
- Ensure that the 'Onderbord' sign is displayed as 'Onderbord <code>'

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
