### PR TITLE
CIT-41: configure new versions of rdfa-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@glint/template": "^1.5.0",
     "@graphy/content.ttl.write": "^4.3.7",
     "@graphy/memory.dataset.fast": "4.3.3",
-    "@lblod/ember-rdfa-editor": "12.6.0",
+    "@lblod/ember-rdfa-editor": "12.6.1-dev.c4b8e9755e928959f8a22a78bf7ac47a6a7694bf",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^4.0.0",
     "@tsconfig/ember": "^3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,8 +181,8 @@ importers:
         specifier: 4.3.3
         version: 4.3.3
       '@lblod/ember-rdfa-editor':
-        specifier: 12.6.0
-        version: 12.6.0(uyopq47zhjkpyroiqgd3grmn6i)
+        specifier: 12.6.1-dev.c4b8e9755e928959f8a22a78bf7ac47a6a7694bf
+        version: 12.6.1-dev.c4b8e9755e928959f8a22a78bf7ac47a6a7694bf(uyopq47zhjkpyroiqgd3grmn6i)
       '@rdfjs/types':
         specifier: ^1.1.0
         version: 1.1.0
@@ -1708,8 +1708,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@lblod/ember-rdfa-editor@12.6.0':
-    resolution: {integrity: sha512-LrdXe7lk++zYin5IzP+Bele0d2gkA6ZpgoG9HlPb2fcuiei1pxnWOcWwbN2WxAGgd3igNlUPTihDFTE6w68/NQ==}
+  '@lblod/ember-rdfa-editor@12.6.1-dev.c4b8e9755e928959f8a22a78bf7ac47a6a7694bf':
+    resolution: {integrity: sha512-rMR1PSthbWZW6oUEljRiYHHcccurpcxL9gMNRnkVNPzIfDc/yWc5h2MqFhIMq8yeIum2U6xORyW9SaoGo+/9Dw==}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.5.0
       '@ember/test-helpers': ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
@@ -11928,7 +11928,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@lblod/ember-rdfa-editor@12.6.0(uyopq47zhjkpyroiqgd3grmn6i)':
+  '@lblod/ember-rdfa-editor@12.6.1-dev.c4b8e9755e928959f8a22a78bf7ac47a6a7694bf(uyopq47zhjkpyroiqgd3grmn6i)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.5.0(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@3.3.0)(webpack@5.97.1)
       '@codemirror/commands': 6.6.0
@@ -12480,27 +12480,6 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
-  '@types/ember@4.0.11':
-    dependencies:
-      '@types/ember__application': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__array': 4.0.10(@babel/core@7.26.0)
-      '@types/ember__component': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__controller': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__debug': 4.0.8(@babel/core@7.26.0)
-      '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__error': 4.0.6
-      '@types/ember__object': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__polyfills': 4.0.6
-      '@types/ember__routing': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__runloop': 4.0.10
-      '@types/ember__service': 4.0.9(@babel/core@7.26.0)
-      '@types/ember__string': 3.16.3
-      '@types/ember__template': 4.0.7
-      '@types/ember__test': 4.0.6(@babel/core@7.26.0)
-      '@types/ember__utils': 4.0.7
-      '@types/rsvp': 4.0.9
-    optional: true
-
   '@types/ember@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@types/ember__application': 4.0.11(@babel/core@7.26.0)
@@ -12528,7 +12507,7 @@ snapshots:
   '@types/ember__application@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
-      '@types/ember': 4.0.11
+      '@types/ember': 4.0.11(@babel/core@7.26.0)
       '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
       '@types/ember__object': 4.0.12(@babel/core@7.26.0)
       '@types/ember__owner': 4.0.9
@@ -12630,11 +12609,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@types/ember__runloop@4.0.10':
-    dependencies:
-      '@types/ember': 4.0.11
-    optional: true
-
   '@types/ember__runloop@4.0.10(@babel/core@7.26.0)':
     dependencies:
       '@types/ember': 4.0.11(@babel/core@7.26.0)
@@ -12665,11 +12639,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    optional: true
-
-  '@types/ember__utils@4.0.7':
-    dependencies:
-      '@types/ember': 4.0.11
     optional: true
 
   '@types/ember__utils@4.0.7(@babel/core@7.26.0)':

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -90,9 +90,16 @@ import {
   editableNodePlugin,
   getActiveEditableNode,
 } from '@lblod/ember-rdfa-editor/plugins/editable-node';
+
+import VisualiserCard from '@lblod/ember-rdfa-editor/components/_private/rdfa-visualiser/visualiser-card';
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
-import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
+import NodeControlsCard from '@lblod/ember-rdfa-editor/components/_private/node-controls/card';
+import DocImportedResourceEditorCard from '@lblod/ember-rdfa-editor/components/_private/doc-imported-resource-editor/card';
+import ImportedResourceLinkerCard from '@lblod/ember-rdfa-editor/components/_private/imported-resource-linker/card';
+import ExternalTripleEditorCard from '@lblod/ember-rdfa-editor/components/_private/external-triple-editor/card';
+import RelationshipEditorCard from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/card';
+import { documentConfig } from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/configs';
 import {
   structureWithConfig,
   structureViewWithConfig,
@@ -121,14 +128,21 @@ import { BlockRDFaView } from '@lblod/ember-rdfa-editor/nodes/block-rdfa';
 import { isRdfaAttrs } from '@lblod/ember-rdfa-editor/core/schema';
 import { BESLUIT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import recreateUuidsOnPaste from '@lblod/ember-rdfa-editor/plugins/recreateUuidsOnPaste';
+
 import { getOwner } from '@ember/owner';
 
 export default class BesluitSampleController extends Controller {
   queryParams = ['editableNodes'];
 
+  VisualiserCard = VisualiserCard;
   DebugInfo = DebugInfo;
   AttributeEditor = AttributeEditor;
-  RdfaEditor = RdfaEditor;
+  NodeControlsCard = NodeControlsCard;
+  DocImportedResourceEditorCard = DocImportedResourceEditorCard;
+  ImportedResourceLinkerCard = ImportedResourceLinkerCard;
+  ExternalTripleEditorCard = ExternalTripleEditorCard;
+  RelationshipEditorCard = RelationshipEditorCard;
+
   InsertArticle = InsertArticleComponent;
   StructureControlCard = StructureControlCardComponent;
 
@@ -405,6 +419,10 @@ export default class BesluitSampleController extends Controller {
     controller.initialize(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);
+  }
+
+  get optionGeneratorConfig() {
+    return this.controller && documentConfig(this.controller);
   }
 
   get standardTemplates() {

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -103,9 +103,16 @@ import {
   inlineRdfaWithConfig,
   inlineRdfaWithConfigView,
 } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
+
+import VisualiserCard from '@lblod/ember-rdfa-editor/components/_private/rdfa-visualiser/visualiser-card';
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
-import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
+import NodeControlsCard from '@lblod/ember-rdfa-editor/components/_private/node-controls/card';
+import DocImportedResourceEditorCard from '@lblod/ember-rdfa-editor/components/_private/doc-imported-resource-editor/card';
+import ImportedResourceLinkerCard from '@lblod/ember-rdfa-editor/components/_private/imported-resource-linker/card';
+import ExternalTripleEditorCard from '@lblod/ember-rdfa-editor/components/_private/external-triple-editor/card';
+import RelationshipEditorCard from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/card';
+import { documentConfig } from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/configs';
 import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
 import SnippetListSelect from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-list-select';
 import {
@@ -133,11 +140,17 @@ import { type StructurePluginOptions } from '@lblod/ember-rdfa-editor-lblod-plug
 export default class RegulatoryStatementSampleController extends Controller {
   queryParams = ['editableNodes'];
 
-  SnippetInsert = SnippetInsertRdfaComponent;
-  SnippetListSelect = SnippetListSelect;
+  VisualiserCard = VisualiserCard;
   DebugInfo = DebugInfo;
   AttributeEditor = AttributeEditor;
-  RdfaEditor = RdfaEditor;
+  NodeControlsCard = NodeControlsCard;
+  DocImportedResourceEditorCard = DocImportedResourceEditorCard;
+  ImportedResourceLinkerCard = ImportedResourceLinkerCard;
+  ExternalTripleEditorCard = ExternalTripleEditorCard;
+  RelationshipEditorCard = RelationshipEditorCard;
+
+  SnippetInsert = SnippetInsertRdfaComponent;
+  SnippetListSelect = SnippetListSelect;
   StructureControlCard = StructureControlCardComponent;
   @tracked editableNodes = false;
 
@@ -416,5 +429,9 @@ export default class RegulatoryStatementSampleController extends Controller {
     controller.initialize(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);
+  }
+
+  get optionGeneratorConfig() {
+    return this.controller && documentConfig(this.controller);
   }
 }

--- a/tests/dummy/app/controllers/snippet-edit-sample.ts
+++ b/tests/dummy/app/controllers/snippet-edit-sample.ts
@@ -86,9 +86,16 @@ import {
   inlineRdfaWithConfig,
   inlineRdfaWithConfigView,
 } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
+
+import VisualiserCard from '@lblod/ember-rdfa-editor/components/_private/rdfa-visualiser/visualiser-card';
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
-import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
+import NodeControlsCard from '@lblod/ember-rdfa-editor/components/_private/node-controls/card';
+import DocImportedResourceEditorCard from '@lblod/ember-rdfa-editor/components/_private/doc-imported-resource-editor/card';
+import ImportedResourceLinkerCard from '@lblod/ember-rdfa-editor/components/_private/imported-resource-linker/card';
+import ExternalTripleEditorCard from '@lblod/ember-rdfa-editor/components/_private/external-triple-editor/card';
+import RelationshipEditorCard from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/card';
+import { documentConfig } from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/configs';
 import SnippetListSelect from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-list-select';
 import {
   CitationPluginConfig,
@@ -114,10 +121,16 @@ import { structureViewWithConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/
 export default class SnippetEditController extends Controller {
   queryParams = ['editableNodes'];
 
-  SnippetListSelect = SnippetListSelect;
+  VisualiserCard = VisualiserCard;
   DebugInfo = DebugInfo;
   AttributeEditor = AttributeEditor;
-  RdfaEditor = RdfaEditor;
+  SnippetListSelect = SnippetListSelect;
+  NodeControlsCard = NodeControlsCard;
+  DocImportedResourceEditorCard = DocImportedResourceEditorCard;
+  ImportedResourceLinkerCard = ImportedResourceLinkerCard;
+  ExternalTripleEditorCard = ExternalTripleEditorCard;
+  RelationshipEditorCard = RelationshipEditorCard;
+
   @tracked editableNodes = true;
 
   @action
@@ -371,5 +384,9 @@ export default class SnippetEditController extends Controller {
     controller.initialize(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);
+  }
+
+  get optionGeneratorConfig() {
+    return this.controller && documentConfig(this.controller);
   }
 }

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -140,46 +140,70 @@
                   @config={{this.config.lpdc}}
                 />
               </Sidebar.Collapsible>
-              <this.StructureControlCard @controller={{this.controller}} />
-              <DecisionPlugin::DecisionPluginCard
-                @controller={{this.controller}}
-              />
-              <CitationPlugin::CitationCard
-                @controller={{this.controller}}
-                @config={{this.config.citation}}
-              />
-              <ImportSnippetPlugin::Card @controller={{this.controller}} />
-              <MandateeTablePlugin::Configure
-                @controller={{this.controller}}
-                @supportedTags={{this.config.mandateeTable.tags}}
-              />
-              <VariablePlugin::Codelist::Edit
-                @controller={{this.controller}}
-                @options={{this.codelistOptions}}
-              />
-              <VariablePlugin::Date::Edit
-                @controller={{this.controller}}
-                @options={{this.dateOptions}}
-              />
-              <VariablePlugin::Location::Edit
-                @controller={{this.controller}}
-                @options={{this.locationOptions}}
-              />
-              <VariablePlugin::Person::Edit
-                @controller={{this.controller}}
-                @config={{this.config.lmb}}
-              />
-              <this.RdfaEditor
-                @node={{this.activeNode}}
-                @controller={{this.controller}}
-              />
-              {{#if this.activeNode}}
-                <this.DebugInfo @node={{this.activeNode}} />
-              {{/if}}
-              <this.AttributeEditor
-                @node={{this.activeNode}}
-                @controller={{this.controller}}
-              />
+              <div class='au-u-flex au-u-flex--column au-u-flex--spaced-tiny'>
+                <this.StructureControlCard @controller={{this.controller}} />
+                <DecisionPlugin::DecisionPluginCard
+                  @controller={{this.controller}}
+                />
+                <CitationPlugin::CitationCard
+                  @controller={{this.controller}}
+                  @config={{this.config.citation}}
+                />
+                <ImportSnippetPlugin::Card @controller={{this.controller}} />
+                <MandateeTablePlugin::Configure
+                  @controller={{this.controller}}
+                  @supportedTags={{this.config.mandateeTable.tags}}
+                />
+                <VariablePlugin::Codelist::Edit
+                  @controller={{this.controller}}
+                  @options={{this.codelistOptions}}
+                />
+                <VariablePlugin::Date::Edit
+                  @controller={{this.controller}}
+                  @options={{this.dateOptions}}
+                />
+                <VariablePlugin::Location::Edit
+                  @controller={{this.controller}}
+                  @options={{this.locationOptions}}
+                />
+                <VariablePlugin::Person::Edit
+                  @controller={{this.controller}}
+                  @config={{this.config.lmb}}
+                />
+                {{#if this.editableNodes}}
+                  <this.VisualiserCard
+                    @controller={{this.controller}}
+                  />
+                  <this.NodeControlsCard
+                    @node={{this.activeNode}}
+                    @controller={{this.controller}}
+                  />
+                  {{#if this.activeNode}}
+                    <this.RelationshipEditorCard
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                      @optionGeneratorConfig={{this.optionGeneratorConfig}}
+                    />
+                    <this.DocImportedResourceEditorCard
+                      @controller={{this.controller}}
+                      @optionGeneratorConfig={{this.optionGeneratorConfig}}
+                    />
+                    <this.ImportedResourceLinkerCard
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                    />
+                    <this.ExternalTripleEditorCard
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                    />
+                    <this.DebugInfo @node={{this.activeNode}} />
+                    <this.AttributeEditor
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                    />
+                  {{/if}}
+                {{/if}}
+              </div>
             </Sidebar>
           {{/if}}
         </:aside>

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -118,57 +118,82 @@
                   @config={{this.config.location}}
                 />
               </Sidebar.Collapsible>
-              <VariablePlugin::InsertVariableCard
-                @controller={{this.controller}}
-                @variableTypes={{this.variableTypes}}
-                @templateMode={{true}}
-              />
-              <this.StructureControlCard @controller={{this.controller}} />
-              <VariablePlugin::Address::Edit
-                @controller={{this.controller}}
-                @defaultMunicipality='Gent'
-              />
-              <VariablePlugin::Codelist::Edit
-                @controller={{this.controller}}
-                @options={{this.codelistOptions}}
-              />
-              <VariablePlugin::Date::Edit
-                @controller={{this.controller}}
-                @options={{this.dateOptions}}
-              />
-              <VariablePlugin::Location::Edit
-                @controller={{this.controller}}
-                @options={{this.locationOptions}}
-              />
-              <VariablePlugin::Person::Edit
-                @controller={{this.controller}}
-                @config={{this.config.lmb}}
-              />
-              <VariablePlugin::Autofilled::Edit
-                @controller={{this.controller}}
-              />
-              <TemplateCommentsPlugin::EditCard
-                @controller={{this.controller}}
-              />
-              <AuHr />
-              {{#if this.activeNode}}
-                <this.SnippetListSelect
-                  @node={{this.activeNode}}
+              <div class='au-u-flex au-u-flex--column au-u-flex--spaced-tiny'>
+                <VariablePlugin::InsertVariableCard
                   @controller={{this.controller}}
-                  @config={{this.config.snippet}}
+                  @variableTypes={{this.variableTypes}}
+                  @templateMode={{true}}
                 />
-                {{#if this.editableNodes}}
-                  <this.RdfaEditor
+                <this.StructureControlCard @controller={{this.controller}} />
+                <VariablePlugin::Address::Edit
+                  @controller={{this.controller}}
+                  @defaultMunicipality='Gent'
+                />
+                <VariablePlugin::Codelist::Edit
+                  @controller={{this.controller}}
+                  @options={{this.codelistOptions}}
+                />
+                <VariablePlugin::Date::Edit
+                  @controller={{this.controller}}
+                  @options={{this.dateOptions}}
+                />
+                <VariablePlugin::Location::Edit
+                  @controller={{this.controller}}
+                  @options={{this.locationOptions}}
+                />
+                <VariablePlugin::Person::Edit
+                  @controller={{this.controller}}
+                  @config={{this.config.lmb}}
+                />
+                <VariablePlugin::Autofilled::Edit
+                  @controller={{this.controller}}
+                />
+                <TemplateCommentsPlugin::EditCard
+                  @controller={{this.controller}}
+                />
+                <AuHr />
+                {{#if this.activeNode}}
+                  <this.SnippetListSelect
                     @node={{this.activeNode}}
                     @controller={{this.controller}}
-                  />
-                  <this.DebugInfo @node={{this.activeNode}} />
-                  <this.AttributeEditor
-                    @node={{this.activeNode}}
-                    @controller={{this.controller}}
+                    @config={{this.config.snippet}}
                   />
                 {{/if}}
-              {{/if}}
+                {{#if this.editableNodes}}
+                  <this.VisualiserCard
+                    @controller={{this.controller}}
+                    @config={{this.rdfa.visualizerConfig}}
+                  />
+                  <this.NodeControlsCard
+                    @node={{this.activeNode}}
+                    @controller={{this.controller}}
+                  />
+                  {{#if this.activeNode}}
+                    <this.RelationshipEditorCard
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                      @optionGeneratorConfig={{this.optionGeneratorConfig}}
+                    />
+                    <this.DocImportedResourceEditorCard
+                      @controller={{this.controller}}
+                      @optionGeneratorConfig={{this.optionGeneratorConfig}}
+                    />
+                    <this.ImportedResourceLinkerCard
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                    />
+                    <this.ExternalTripleEditorCard
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                    />
+                    <this.DebugInfo @node={{this.activeNode}} />
+                    <this.AttributeEditor
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                    />
+                  {{/if}}
+                {{/if}}
+              </div>
             </Sidebar>
           {{/if}}
         </:aside>

--- a/tests/dummy/app/templates/snippet-edit-sample.hbs
+++ b/tests/dummy/app/templates/snippet-edit-sample.hbs
@@ -135,56 +135,78 @@
                   @config={{this.config.snippet}}
                 />
               </Sidebar.Collapsible>
-              <VariablePlugin::InsertVariableCard
-                @controller={{this.controller}}
-                @variableTypes={{this.variableTypes}}
-              />
-              <VariablePlugin::Address::Edit
-                @controller={{this.controller}}
-                @defaultMunicipality='Gent'
-              />
-              <ArticleStructurePlugin::StructureCard
-                @controller={{this.controller}}
-                @options={{this.config.structures}}
-              />
-              <CitationPlugin::CitationCard
-                @controller={{this.controller}}
-                @plugin={{this.citationPlugin}}
-                @config={{this.config.citation}}
-              />
-              <VariablePlugin::Date::Edit
-                @controller={{this.controller}}
-                @options={{this.dateOptions}}
-              />
-              <VariablePlugin::Person::Edit
-                @controller={{this.controller}}
-                @config={{this.config.lmb}}
-              />
-              <TemplateCommentsPlugin::EditCard
-                @controller={{this.controller}}
-              />
-              <AuHr />
-              {{#if this.activeNode}}
-                <this.SnippetListSelect
-                  @node={{this.activeNode}}
+              <div class='au-u-flex au-u-flex--column au-u-flex--spaced-tiny'>
+                <VariablePlugin::InsertVariableCard
                   @controller={{this.controller}}
-                  @config={{this.config.snippet}}
+                  @variableTypes={{this.variableTypes}}
                 />
-                {{#if this.editableNodes}}
-                  <this.RdfaEditor
+                <VariablePlugin::Address::Edit
+                  @controller={{this.controller}}
+                  @defaultMunicipality='Gent'
+                />
+                <ArticleStructurePlugin::StructureCard
+                  @controller={{this.controller}}
+                  @options={{this.config.structures}}
+                />
+                <CitationPlugin::CitationCard
+                  @controller={{this.controller}}
+                  @plugin={{this.citationPlugin}}
+                  @config={{this.config.citation}}
+                />
+                <VariablePlugin::Date::Edit
+                  @controller={{this.controller}}
+                  @options={{this.dateOptions}}
+                />
+                <VariablePlugin::Person::Edit
+                  @controller={{this.controller}}
+                  @config={{this.config.lmb}}
+                />
+                <TemplateCommentsPlugin::EditCard
+                  @controller={{this.controller}}
+                />
+                <AuHr />
+                {{#if this.activeNode}}
+                  <this.SnippetListSelect
                     @node={{this.activeNode}}
                     @controller={{this.controller}}
-                    @additionalImportedResources={{array
-                      'http://example.org/this-is-an-example'
-                    }}
-                  />
-                  <this.DebugInfo @node={{this.activeNode}} />
-                  <this.AttributeEditor
-                    @node={{this.activeNode}}
-                    @controller={{this.controller}}
+                    @config={{this.config.snippet}}
                   />
                 {{/if}}
-              {{/if}}
+                {{#if this.editableNodes}}
+                  <this.VisualiserCard
+                    @controller={{this.controller}}
+                    @config={{this.rdfa.visualizerConfig}}
+                  />
+                  <this.NodeControlsCard
+                    @node={{this.activeNode}}
+                    @controller={{this.controller}}
+                  />
+                  {{#if this.activeNode}}
+                    <this.RelationshipEditorCard
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                      @optionGeneratorConfig={{this.optionGeneratorConfig}}
+                    />
+                    <this.DocImportedResourceEditorCard
+                      @controller={{this.controller}}
+                      @optionGeneratorConfig={{this.optionGeneratorConfig}}
+                    />
+                    <this.ImportedResourceLinkerCard
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                    />
+                    <this.ExternalTripleEditorCard
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                    />
+                    <this.DebugInfo @node={{this.activeNode}} />
+                    <this.AttributeEditor
+                      @node={{this.activeNode}}
+                      @controller={{this.controller}}
+                    />
+                  {{/if}}
+                {{/if}}
+              </div>
             </Sidebar>
           {{/if}}
         </:aside>


### PR DESCRIPTION
### Overview
This PR configures the new versions of the rdfa-tools (implemented in https://github.com/lblod/ember-rdfa-editor/pull/1310).
This PR can be used to e.g. test the imported-resource linker tool (which cannot be easily tested in the editor test-app)

##### connected issues and PRs:
[CIT-41](https://binnenland.atlassian.net/browse/CIT-41?atlOrigin=eyJpIjoiZDUzZmZhNGJhZTczNDVlMmJlODI3Y2Y0NzQ0ZjY4ZjIiLCJwIjoiaiJ9)
https://github.com/lblod/ember-rdfa-editor/pull/1310

### How to test/reproduce
- Start the test-app
- Ensure the rdfa-tools display correctly on all 3 sample pages
- Open the RB page, insert a snippet placeholder referencing imported resources
- Ensure you can link the imported resources to resources in the document

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
