### PR TITLE
Support drag-drop of structures and snippets

### DIFF
--- a/.changeset/early-badgers-sell.md
+++ b/.changeset/early-badgers-sell.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Move structure-plugin to use on-changed plugin to always keep RDFa and numbering up to date on changes

--- a/.changeset/plenty-rockets-tell.md
+++ b/.changeset/plenty-rockets-tell.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Move to @lblod/ember-rdfa-editor version with support for drag-and-drop ember-nodes and on-changed plugin

--- a/addon/components/snippet-plugin/nodes/snippet.gts
+++ b/addon/components/snippet-plugin/nodes/snippet.gts
@@ -220,7 +220,12 @@ export default class SnippetNode extends Component<Signature> {
       />
     {{else}}
       <div class='say-snippet-card'>
-        <div class='say-snippet-title'>
+        <div
+          class='say-snippet-title'
+          contenteditable='false'
+          {{! template-lint-disable no-invalid-interactive }}
+          {{on 'click' @selectNode}}
+        >
           <span class='au-c-badge au-c-badge--small say-snippet-title-icon'>
             <AuIcon @icon='plus-text' />
           </span>

--- a/addon/components/structure-plugin/_private/structure.gts
+++ b/addon/components/structure-plugin/_private/structure.gts
@@ -204,6 +204,15 @@ export default class Structure extends Component<Sig> {
   focusInner() {
     this.innerView?.focus();
   }
+  selectNode = (event: MouseEvent) => {
+    if (
+      !(event.target instanceof HTMLElement) ||
+      !event.target.classList.contains('say-structure__title')
+    ) {
+      // Only select the node if we're not trying to edit the title...
+      this.args.selectNode();
+    }
+  };
 
   <template>
     <div
@@ -215,7 +224,7 @@ export default class Structure extends Component<Sig> {
         class='say-structure__header'
         contenteditable='false'
         {{! template-lint-disable no-invalid-interactive }}
-        {{on 'click' @selectNode}}
+        {{on 'click' this.selectNode}}
       >
         {{#let (element this.headerTag) as |Tag|}}
           <Tag class='say-structure__header-element'><span

--- a/addon/components/structure-plugin/_private/structure.gts
+++ b/addon/components/structure-plugin/_private/structure.gts
@@ -204,14 +204,19 @@ export default class Structure extends Component<Sig> {
   focusInner() {
     this.innerView?.focus();
   }
+
   <template>
     <div
       class='say-structure'
       {{didUpdate this.onAttrsUpdate this.titleAttr}}
       {{on 'focus' this.focusInner}}
     >
-      <div class='say-structure__header' contenteditable='false'>
-
+      <div
+        class='say-structure__header'
+        contenteditable='false'
+        {{! template-lint-disable no-invalid-interactive }}
+        {{on 'click' @selectNode}}
+      >
         {{#let (element this.headerTag) as |Tag|}}
           <Tag class='say-structure__header-element'><span
               class='say-structure__name'

--- a/addon/plugins/snippet-plugin/nodes/snippet.ts
+++ b/addon/plugins/snippet-plugin/nodes/snippet.ts
@@ -161,6 +161,22 @@ const emberNodeConfig = (options: SnippetPluginConfig): EmberNodeConfig => ({
   selectable: true,
   editable: true,
   isolating: true,
+  stopEvent(event) {
+    // Prevent mousedown events from jumping focus inside the ember-node temporarily when
+    // selecting by clicking on the title
+    if (event.type === 'mousedown') {
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.className.includes('say-snippet-title')
+      ) {
+        event.preventDefault();
+        return true;
+      }
+    }
+    // Follow default stopEvent logic
+    return null;
+  },
   attrs: {
     ...rdfaAttrSpec({ rdfaAware: true }),
     properties: {

--- a/addon/plugins/structure-plugin/commands/insert-structure.ts
+++ b/addon/plugins/structure-plugin/commands/insert-structure.ts
@@ -1,12 +1,9 @@
 import { Command } from '@lblod/ember-rdfa-editor';
-import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
 import {
   type StructurePluginOptions,
   type StructureType,
 } from '../../structure-plugin/structure-types';
-import { recalculateNumbers } from '../monads/recalculate-structure-numbers';
 import { findHowToInsertStructure } from '../monads/insert-structure';
-import { regenerateRdfaLinks } from '../monads/regenerate-rdfa-links';
 import { closeHistory } from '@lblod/ember-rdfa-editor/plugins/history';
 
 export const insertStructure = (
@@ -14,14 +11,13 @@ export const insertStructure = (
   uriGenerator: Required<StructurePluginOptions>['uriGenerator'],
 ): Command => {
   return (state, dispatch) => {
-    const { result, transaction } = transactionCombinator(state)([
-      findHowToInsertStructure(structureType, uriGenerator),
-      // Prevent calculations that will not fail, if the command is just being tested
-      ...(dispatch ? [recalculateNumbers, regenerateRdfaLinks] : []),
-    ]);
+    const { result, transaction } = findHowToInsertStructure(
+      structureType,
+      uriGenerator,
+    )(state, { sayIsDryRun: !dispatch });
 
     transaction.scrollIntoView();
-    if (result.every((ok) => ok)) {
+    if (result) {
       if (dispatch) {
         // makes sure each structure insertion is undoable, even when quickly
         // creating a bunch of them

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -137,6 +137,29 @@ export const emberNodeConfig: (
     atom: false,
     editable: rdfaAware,
     tocEntry: buildTocEntry,
+    // This stopEvent would prevent the issue where a cursor jumps temporarily inside a structure
+    // when it is selected (unless it's inside one that is already selected).
+    // Unfortunately, this has the side-effect that if a structure title anywhere in the document
+    // is selected, when any structure name is clicked, the selection remains where it is instead
+    // of moving. Due to the complexity of detecting this situation it seems better to leave the
+    // weird visual bug in place.
+    // stopEvent(event) {
+    //   // Prevent mousedown events from jumping focus inside the ember-node temporarily when
+    //   // selecting by clicking on the title
+    //   if (event.type === 'mousedown') {
+    //     const target = event.target;
+    //     if (
+    //       target instanceof HTMLElement &&
+    //       (target.className.includes('say-structure__header') ||
+    //         target.className.includes('say-structure__name'))
+    //     ) {
+    //       event.preventDefault();
+    //       return true;
+    //     }
+    //   }
+    //   // Follow default stopEvent logic
+    //   return null;
+    // },
     attrs: {
       ...rdfaAttrSpec({ rdfaAware }),
 

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -42,8 +42,12 @@ import {
   Option,
   isSome,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { recalculateNumbers } from './monads/recalculate-structure-numbers';
+import { regenerateRdfaLinks } from './monads/regenerate-rdfa-links';
+import { NodeSpecOnChanged } from '@lblod/ember-rdfa-editor/plugins/on-changed/plugin';
 
 const rdfaAware = true;
+const parser = new DOMParser();
 
 const PARAGRAPH_SYMBOL = '§';
 
@@ -111,7 +115,13 @@ function buildTocEntry(node: PNode, state: EditorState) {
   }
 }
 
-const parser = new DOMParser();
+const onChanged: NodeSpecOnChanged = {
+  doOnce: true,
+  monadGenerator: () => {
+    return [recalculateNumbers, regenerateRdfaLinks];
+  },
+};
+
 export const emberNodeConfig: (
   config?: StructurePluginOptions,
 ) => EmberNodeConfig = (config) => {
@@ -165,6 +175,7 @@ export const emberNodeConfig: (
             : config?.onlyArticleSpecialName,
       },
     },
+    onChanged,
     serialize(node: PNode, state: EditorState) {
       const tag = node.attrs.headerTag;
       const structureType = node.attrs.structureType as StructureType;

--- a/addon/plugins/table-of-contents-plugin/index.ts
+++ b/addon/plugins/table-of-contents-plugin/index.ts
@@ -4,4 +4,4 @@ export type LegacyTableOfContentsConfig = {
 }[];
 export type TableOfContentsConfig =
   | LegacyTableOfContentsConfig
-  | { scrollContainer?: () => HTMLElement };
+  | { scrollContainer?: () => HTMLElement | undefined };

--- a/addon/plugins/variable-plugin/plugins/autofiller.ts
+++ b/addon/plugins/variable-plugin/plugins/autofiller.ts
@@ -71,7 +71,7 @@ export function variableAutofillerPlugin(config: AutofilledArgs): ProsePlugin {
         }
         return tr;
       }
-      return newState.tr;
+      return null;
     },
   });
 }

--- a/app/styles/snippet-plugin.scss
+++ b/app/styles/snippet-plugin.scss
@@ -97,6 +97,7 @@
     padding: 5px;
     border-bottom: 1px solid var(--au-blue-300);
     color: var(--au-blue-700);
+    cursor: pointer;
     .say-snippet-title-icon {
       background-color: var(--au-blue-300);
       color: black;
@@ -152,6 +153,18 @@
     }
   }
 }
+.ProseMirror-selectednode {
+  .say-snippet-content {
+    background-color: var(--au-blue-200);
+  }
+  .say-snippet-title {
+    background-color: var(--au-blue-300);
+  }
+  // Only grab if this exact snippet is selected
+  & > .say-snippet-card > .say-snippet-title {
+    cursor: grab;
+  }
+}
 
 .ember-node.say-active:has(> .say-snippet-card) {
   outline: none;
@@ -173,6 +186,7 @@
   background-color: var(--au-orange-300);
   border-radius: var(--au-radius);
   border: 0.1rem solid var(--au-orange-500);
+  cursor: pointer;
 
   .say-snippet-placeholder__icon {
     background-color: var(--au-orange-500);
@@ -204,6 +218,7 @@
 
 .ProseMirror-selectednode > .say-snippet-placeholder {
   background-color: var(--au-blue-200);
+  cursor: grab;
 }
 
 .say-snippet-placeholder-node {

--- a/app/styles/structure-plugin.scss
+++ b/app/styles/structure-plugin.scss
@@ -12,6 +12,7 @@
   padding-left: 0.7rem;
   border-bottom: 1px solid var(--au-gray-300);
   border-radius: 0.1em 0.1em 0 0;
+  cursor: pointer;
 
   .say-structure__header-element {
     margin: 0;
@@ -31,6 +32,7 @@
     .say-structure__title {
       flex: 1 1 100%;
 
+      cursor: text;
       border: none;
       flex-grow: 1;
       display: inline-block;
@@ -96,5 +98,22 @@
   > .say-structure__header {
     border-bottom-color: var(--au-blue-700);
     border-bottom-width: 0.2rem;
+  }
+}
+
+// Don't highlight the whole node as selected if we're editing the title
+.ember-node.ProseMirror-selectednode
+  > .say-structure:not(:has(.ProseMirror-focused)) {
+  background-color: var(--au-blue-200);
+
+  > .say-structure__header {
+    background-color: var(--au-blue-300);
+  }
+
+  > .say-structure__header {
+    cursor: grab;
+    .say-structure__header {
+      cursor: text;
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@glint/template": "^1.5.0",
     "@graphy/content.ttl.write": "^4.3.7",
     "@graphy/memory.dataset.fast": "4.3.3",
-    "@lblod/ember-rdfa-editor": "12.6.0",
+    "@lblod/ember-rdfa-editor": "12.6.1-dev.076e5d32e25c5038592643e60973755501d8bc35",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^4.0.0",
     "@tsconfig/ember": "^3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,8 +181,8 @@ importers:
         specifier: 4.3.3
         version: 4.3.3
       '@lblod/ember-rdfa-editor':
-        specifier: 12.6.0
-        version: 12.6.0(uyopq47zhjkpyroiqgd3grmn6i)
+        specifier: 12.6.1-dev.076e5d32e25c5038592643e60973755501d8bc35
+        version: 12.6.1-dev.076e5d32e25c5038592643e60973755501d8bc35(uyopq47zhjkpyroiqgd3grmn6i)
       '@rdfjs/types':
         specifier: ^1.1.0
         version: 1.1.0
@@ -1708,8 +1708,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@lblod/ember-rdfa-editor@12.6.0':
-    resolution: {integrity: sha512-LrdXe7lk++zYin5IzP+Bele0d2gkA6ZpgoG9HlPb2fcuiei1pxnWOcWwbN2WxAGgd3igNlUPTihDFTE6w68/NQ==}
+  '@lblod/ember-rdfa-editor@12.6.1-dev.076e5d32e25c5038592643e60973755501d8bc35':
+    resolution: {integrity: sha512-9CmI6R9kVBVsddWMoj+xjM9EtqObDVD1fjkCpUNhLQ8U0trp4KmE9HgP/7TLzUiX0lS2Y5uHAfIO66t73QPmxQ==}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.5.0
       '@ember/test-helpers': ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
@@ -11928,7 +11928,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@lblod/ember-rdfa-editor@12.6.0(uyopq47zhjkpyroiqgd3grmn6i)':
+  '@lblod/ember-rdfa-editor@12.6.1-dev.076e5d32e25c5038592643e60973755501d8bc35(uyopq47zhjkpyroiqgd3grmn6i)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.5.0(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@3.3.0)(webpack@5.97.1)
       '@codemirror/commands': 6.6.0
@@ -12480,27 +12480,6 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
-  '@types/ember@4.0.11':
-    dependencies:
-      '@types/ember__application': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__array': 4.0.10(@babel/core@7.26.0)
-      '@types/ember__component': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__controller': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__debug': 4.0.8(@babel/core@7.26.0)
-      '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__error': 4.0.6
-      '@types/ember__object': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__polyfills': 4.0.6
-      '@types/ember__routing': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__runloop': 4.0.10
-      '@types/ember__service': 4.0.9(@babel/core@7.26.0)
-      '@types/ember__string': 3.16.3
-      '@types/ember__template': 4.0.7
-      '@types/ember__test': 4.0.6(@babel/core@7.26.0)
-      '@types/ember__utils': 4.0.7
-      '@types/rsvp': 4.0.9
-    optional: true
-
   '@types/ember@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@types/ember__application': 4.0.11(@babel/core@7.26.0)
@@ -12528,7 +12507,7 @@ snapshots:
   '@types/ember__application@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
-      '@types/ember': 4.0.11
+      '@types/ember': 4.0.11(@babel/core@7.26.0)
       '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
       '@types/ember__object': 4.0.12(@babel/core@7.26.0)
       '@types/ember__owner': 4.0.9
@@ -12630,11 +12609,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@types/ember__runloop@4.0.10':
-    dependencies:
-      '@types/ember': 4.0.11
-    optional: true
-
   '@types/ember__runloop@4.0.10(@babel/core@7.26.0)':
     dependencies:
       '@types/ember': 4.0.11(@babel/core@7.26.0)
@@ -12665,11 +12639,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    optional: true
-
-  '@types/ember__utils@4.0.7':
-    dependencies:
-      '@types/ember': 4.0.11
     optional: true
 
   '@types/ember__utils@4.0.7(@babel/core@7.26.0)':

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -7,7 +7,13 @@ import { tracked } from 'tracked-built-ins';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 
-import { Plugin, PNode, SayController, Schema } from '@lblod/ember-rdfa-editor';
+import {
+  NodeViewConstructor,
+  Plugin,
+  PNode,
+  SayController,
+  Schema,
+} from '@lblod/ember-rdfa-editor';
 import {
   em,
   strikethrough,
@@ -97,7 +103,6 @@ import {
   structureWithConfig,
   structureViewWithConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/structure-plugin/node';
-import { SayNodeViewConstructor } from '@lblod/ember-rdfa-editor/utils/ember-node';
 
 import InsertArticleComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/decision-plugin/insert-article';
 import StructureControlCardComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/structure-plugin/control-card';
@@ -338,7 +343,7 @@ export default class BesluitSampleController extends Controller {
   @tracked rdfaEditor?: SayController;
   @tracked nodeViews: (
     controller: SayController,
-  ) => Record<string, SayNodeViewConstructor> = (controller) => {
+  ) => Record<string, NodeViewConstructor> = (controller) => {
     return {
       text_variable: textVariableView(controller),
       person_variable: personVariableView(controller),
@@ -356,8 +361,9 @@ export default class BesluitSampleController extends Controller {
         controller,
       ),
       snippet: snippetView(this.config.snippet)(controller),
-      block_rdfa: (node) => new BlockRDFaView(node),
-    } satisfies Record<string, SayNodeViewConstructor>;
+      block_rdfa: (...args: Parameters<NodeViewConstructor>) =>
+        new BlockRDFaView(args, controller),
+    } satisfies Record<string, NodeViewConstructor>;
   };
   @tracked plugins: Plugin[] = [
     firefoxCursorFix(),

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -367,7 +367,8 @@ export default class RegulatoryStatementSampleController extends Controller {
       ),
       snippet: snippetView(this.config.snippet)(controller),
       autofilled_variable: autofilledVariableView(controller),
-      block_rdfa: (node) => new BlockRDFaView(node),
+      block_rdfa: (...args: Parameters<NodeViewConstructor>) =>
+        new BlockRDFaView(args, controller),
     };
   };
   @tracked plugins: Plugin[] = [

--- a/tests/dummy/app/controllers/snippet-edit-sample.ts
+++ b/tests/dummy/app/controllers/snippet-edit-sample.ts
@@ -333,7 +333,8 @@ export default class SnippetEditController extends Controller {
         controller,
       ),
       snippet: snippetView(this.config.snippet)(controller),
-      block_rdfa: (node) => new BlockRDFaView(node),
+      block_rdfa: (...args: Parameters<NodeViewConstructor>) =>
+        new BlockRDFaView(args, controller),
       // This is the only addition needed to move away from article-structure-plugin without other
       // configuration changes
       structure: structureViewWithConfig()(controller),


### PR DESCRIPTION
### Overview
Styling and behavour changes to support selecting and drag-drop of structures and snippets. Similar to rdfa blocks, they can be selected by clicking on the title. This is made more complex by the nested prosemirror in structure titles.

The on-changed plugin is used to make sure structure numbers and links are kept up to date whenever they are moved.

There is still one weird behaviour with selecting structures, which is in many cases (it depends what's currently selected), when selecting a structure, the cursor jumps inside the structure, before selecting the node itself. This can be fixed with a `preventDefault()` in the structure's `stopEvent()`, similar to the one for snippets, but this has the unfortunate side-effect that if a structure title anywhere in the document is selected, when any structure name is clicked, the selection remains where it is instead of moving. Due to the complexity of detecting this situation it seems better to leave the weird visual bug in place.

##### connected issues and PRs:
Part of [binnenland.atlassian.net/browse/GN-5579](https://binnenland.atlassian.net/browse/GN-5579)
Editor PR: https://github.com/lblod/ember-rdfa-editor/pull/1321

### Setup
Already has the relevant editor version included.

### How to test/reproduce
Move structures, snippets and RDFa blocks around by dragging and dropping. Care should be taken to test different combinations of nesting and where the selection is before the process starts.
Verify that structures are kept up to date in terms of numbering and RDFa links.
All existing interactive functionalities of snippets, structures and RDFa blocks should remain intact.

### Challenges/uncertainties
This was way more fiddly than expected. There seems to be a lot competing for any events...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
