### PR TITLE
Change structure-plugin node body to rdf:HTML datatype

### DIFF
--- a/.changeset/chatty-beers-do.md
+++ b/.changeset/chatty-beers-do.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Change structure-plugin to output say:body with datatype rdf:HTML instead of rdf:XMLLiteral as it is more correct

--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -273,7 +273,7 @@ export const emberNodeConfig: (
           headerSpec,
           [
             'div',
-            { property: SAY('body').full, datatype: RDF('XMLLiteral').full },
+            { property: SAY('body').full, datatype: RDF('HTML').full },
             0,
           ],
         ],


### PR DESCRIPTION
### Overview
The body isn't (necessarily) valid XML, so use the more correct rdf:HTML datatype. This prevents problems with parsers failing if they try to parse invalid XML, such as unclosed self-closing elements, which are valid HTML.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5623

### Setup
Test setup is a little tricky to actually parse the documents, I'll add some PRs with additional docs on how to set up publisher and harvester locally...

### How to test/reproduce
Create a document with structures (a besluit or a RS) and export the HTML. Put the HTML into an RDFa parser, such as rdfa.org/play and verify that the `say:body` has the `rdf:HTML` datatype.

### Challenges/uncertainties
Getting the test setup working...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
