### PR TITLE
Ensure location plugin outputs WKT polygons with matching start and end

### DIFF
--- a/.changeset/sharp-turkeys-greet.md
+++ b/.changeset/sharp-turkeys-greet.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Fix location plugin to output correct WKT polygons (with matching start and end points) for area locations

--- a/addon/plugins/location-plugin/utils/geo-helpers.ts
+++ b/addon/plugins/location-plugin/utils/geo-helpers.ts
@@ -18,7 +18,13 @@ export class Polygon {
   declare uri: string;
   declare locations: GeoPos[];
   constructor(args: Omit<Polygon, 'constructor' | 'formatted'>) {
-    Object.assign(this, args);
+    this.uri = args.uri;
+    // The start and end points of a polygon should match
+    if (isSamePos(args.locations[0], args.locations.at(-1))) {
+      this.locations = args.locations;
+    } else {
+      this.locations = [...args.locations, args.locations[0]];
+    }
   }
 
   get formatted() {
@@ -108,6 +114,15 @@ export type GeoPos = {
   global?: GlobalCoordinates;
   lambert: Lambert72Coordinates;
 };
+
+export function isSamePos(
+  a: GeoPos | undefined,
+  b: GeoPos | undefined,
+): boolean {
+  return (
+    !!a && !!b && a.lambert.x === b.lambert.x && a.lambert.y === b.lambert.y
+  );
+}
 
 export function constructLambert72GMLString({ x, y }: Lambert72Coordinates) {
   return `<gml:Point srsName="http://www.opengis.net/def/crs/EPSG/0/31370" xmlns:gml="http://www.opengis.net/gml/3.2"><gml:pos>${x} ${y}</gml:pos></gml:Point>`;


### PR DESCRIPTION
### Overview
Needed for Virtuoso to accept area locations as valid when enabling geosparql support.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/CIT-61

### Setup
No set-up needed to test that the location plugin still works, but to check that harvesting works correctly, follow the instructions in [the plugins PR for changing to rdf:HTML datatype](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/579) for how to do this. Instead of using the app-lblod-harvester version pointed to in that PR, use the `feature/citerra` branch. A GN frontend using this PR is also needed: `32.1.0-dev.57d72b6f4f4d02524f5e6e7e1256c11f3ee026d4`.

### How to test/reproduce
Looking at plugin output directly:
- In the test app, insert an area location and look at the HTML output. The `asWKT` predicate should be pointing to a `wktLiteral` string, the `POLYGON` in this string should have matching first and last elements.
- The location plugin should work as before.
Looking at the harvester:
- After following the setup instructions, create a meeting containing an agendapoint which contains an area location.
- Publish this meeting and harvest the result (see the plugins PR in the setup instructions).
- The job should succeed.
- The new triples to publish should include the `wktLiteral` string.
- Virtuoso should include an `asWKT` predicate pointing to a string of datatype `http://www.openlinksw.com/schemas/virtrdf#Geometry`.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
