### PR TITLE
GN-5639 - roadsign-regulation-plugin: order signs by code alphabetically

### DIFF
--- a/.changeset/wicked-adults-draw.md
+++ b/.changeset/wicked-adults-draw.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+roadsign-regulation plugin: order sign-concepts by code

--- a/addon/plugins/roadsign-regulation-plugin/queries/mobility-measure-concept.ts
+++ b/addon/plugins/roadsign-regulation-plugin/queries/mobility-measure-concept.ts
@@ -140,6 +140,7 @@ async function _queryMobilityMeasures<Count extends boolean>(
         const signConcepts = await querySignConcepts(endpoint, {
           measureConceptUri: concept.uri,
           imageBaseUrl,
+          orderBy: 'code',
         });
         return {
           ...concept,

--- a/addon/plugins/roadsign-regulation-plugin/queries/sign-concept.ts
+++ b/addon/plugins/roadsign-regulation-plugin/queries/sign-concept.ts
@@ -13,13 +13,14 @@ type QueryOptions = {
   imageBaseUrl?: string;
   measureConceptUri?: string;
   abortSignal?: AbortSignal;
+  orderBy?: 'code';
 };
 
 export async function querySignConcepts(
   endpoint: string,
   options: QueryOptions = {},
 ) {
-  const { imageBaseUrl, measureConceptUri, abortSignal } = options;
+  const { imageBaseUrl, measureConceptUri, abortSignal, orderBy } = options;
   const query = /* sparql */ `
     PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
@@ -54,6 +55,8 @@ export async function querySignConcepts(
 
       ${measureConceptUri ? `?uri mobiliteit:heeftMaatregelconcept ${sparqlEscapeUri(measureConceptUri)}` : ''}
     }
+    ${orderBy ? `ORDER BY ASC(UCASE(?${orderBy}))` : ''}
+
   `;
   const queryResult = await executeQuery<BindingObject<SignConcept>>({
     query,


### PR DESCRIPTION
### Overview
This PR ensures that the signs of a measure are ordered alphabetically (in both the preview of a measure and the inserted measure).

##### connected issues and PRs:
Possible solution to [GN-5639](https://binnenland.atlassian.net/browse/GN-5639?atlOrigin=eyJpIjoiMTMzNTg1MGQ4MjE0NDBiNzhhODNmMGVjMTVjMmMzNTQiLCJwIjoiaiJ9)


### Setup
Use MOW QA as an endpoint (this endpoint has several measure-concepts with 2+ sign-concepts)

### How to test/reproduce
- Start the test-app
- Open the roadsign regulation insertion modal
- Search for measure-concepts with 2+ sign-concepts
- Ensure, that in the measure previews, the sign-concepts are ordered alphabetically
- Insert a measure
- Ensure the signs in the inserted measure are ordered alphabetically

### Challenges/uncertainties
Based on the tickets description, it seems that the desired ordering is indeed alphabetical, but not a 100% sure about that.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
