### PR TITLE
Category filter was not working on roadsign regulation plugin

### DIFF
--- a/.changeset/early-jobs-joke.md
+++ b/.changeset/early-jobs-joke.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Fix bug in roadsign regulation plugin where you couldn't search a sign if you had selected a category

--- a/addon/components/roadsign-regulation-plugin/roadsigns-modal.gts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-modal.gts
@@ -151,7 +151,7 @@ export default class RoadsignsModal extends Component<Signature> {
   }
 
   searchCodes = restartableTask(async (term: string) => {
-    const category = this.selectedCategory?.label;
+    const category = this.selectedCategory?.uri;
     const type = this.selectedType?.label;
     const types = type ? [type] : undefined;
     await timeout(DEBOUNCE_MS);


### PR DESCRIPTION
### Overview
The function for searching the sign by code in the roadsign regulation plugin was sending the label of the category instead of the uri so the filter was failing

##### connected issues and PRs:
GN-5640


### Setup
None

### How to test/reproduce
Open the roadsign regulation plugin and check that you can now filter by a category and then search for signs in that category

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
