### PR TITLE
GN-5646: roadsign-regulation-plugin - fix variable signage feature

### DIFF
--- a/.changeset/hip-steaks-dance.md
+++ b/.changeset/hip-steaks-dance.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+roadsign-regulation plugin: fix issue where measure could not be inserted as being variable/dynamic

--- a/addon/components/roadsign-regulation-plugin/expanded-measure.gts
+++ b/addon/components/roadsign-regulation-plugin/expanded-measure.gts
@@ -12,6 +12,7 @@ import { action } from '@ember/object';
 import { on } from '@ember/modifier';
 import { ZONALITY_OPTIONS } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/constants';
 import { Task } from 'ember-concurrency';
+import { isSome } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 
 export type InsertMobilityMeasureTask = Task<
   void,
@@ -41,7 +42,10 @@ export default class ExpandedMeasure extends Component<Signature> {
   }
 
   get insertButtonDisabled() {
-    return this.isPotentiallyZonal && !this.zonalityValue;
+    return (
+      (this.isPotentiallyZonal && !this.zonalityValue) ||
+      (this.args.concept.variableSignage && !isSome(this.temporalValue))
+    );
   }
 
   @action

--- a/addon/plugins/roadsign-regulation-plugin/queries/mobility-measure-concept.ts
+++ b/addon/plugins/roadsign-regulation-plugin/queries/mobility-measure-concept.ts
@@ -131,7 +131,9 @@ async function _queryMobilityMeasures<Count extends boolean>(
         const objectified = objectify(binding);
         return {
           ...objectified,
-          variableSignage: objectified.variableSignage === 'true',
+          variableSignage:
+            objectified.variableSignage === '1' ||
+            objectified.variableSignage === 'true',
         };
       }),
     );


### PR DESCRIPTION
### Overview
This PR fixes the issue where it was not possible to mark measure as having variable/dynamic signalization before inserting them in the document.

##### connected issues and PRs:
[GN-5646](https://binnenland.atlassian.net/browse/GN-5646?atlOrigin=eyJpIjoiNzllOWE3OWViNzllNGRmOWI5NTI0ZmM0MDIyOWVmYmYiLCJwIjoiaiJ9)

### Setup
Connect the roadsign-regulation-plugin to MOW QA

### How to test/reproduce
- Start the test-app
- Insert a regulation and open the insert-measure modal
- Search for a measure which supports variable signalization
- Ensure you can now select between a 'variable'/'non-variable' option


### Challenges/uncertainties
Whether or not the masure is temporal is not encoded in RDFa, but only in text 'Deze signalisatie is dynamish'. We might also want to encode the selected value in RDFa?



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
