### PR TITLE
Add actions to document validation plugin

### DIFF
--- a/.changeset/tender-actors-shout.md
+++ b/.changeset/tender-actors-shout.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add actions to document validation plugin

--- a/addon/components/document-validation-plugin/card.gts
+++ b/addon/components/document-validation-plugin/card.gts
@@ -41,7 +41,7 @@ export default class DocumentValidationPluginCard extends Component<Sig> {
     if (!propertiesWithErrors) return undefined;
     const documentValidationErrors = propertiesWithErrors.map((property) => {
       const action = actions.find(
-        (action) => property.shape === action.shaclRule,
+        (action) => property?.shape === action.shaclRule,
       );
       return {
         ...property,

--- a/addon/components/document-validation-plugin/card.gts
+++ b/addon/components/document-validation-plugin/card.gts
@@ -37,10 +37,18 @@ export default class DocumentValidationPluginCard extends Component<Sig> {
   }
   get documentValidationErrors() {
     if (!this.validationState) return [];
-    const { propertiesWithErrors } = this.validationState;
+    const { propertiesWithErrors, actions } = this.validationState;
     if (!propertiesWithErrors) return undefined;
-
-    return propertiesWithErrors;
+    const documentValidationErrors = propertiesWithErrors.map((property) => {
+      const action = actions.find(
+        (action) => property.shape === action.shaclRule,
+      );
+      return {
+        ...property,
+        action,
+      };
+    });
+    return documentValidationErrors;
   }
   get propertiesWithoutErrors() {
     if (!this.validationState) return [];
@@ -114,6 +122,15 @@ export default class DocumentValidationPluginCard extends Component<Sig> {
                 title={{error.subject}}
                 {{on 'click' (fn this.goToSubject error.subject)}}
               >{{t 'document-validation-plugin.see-related-node'}}</AuButton>
+              {{#if error.action}}
+                <AuButton
+                  class='au-u-padding-left-none au-u-padding-right-none'
+                  @icon={{ExternalLinkIcon}}
+                  @skin='link'
+                  title={{error.subject}}
+                  {{on 'click' (fn error.action.action this.controller)}}
+                >{{error.action.buttonTitle}}</AuButton>
+              {{/if}}
             </div>
           </div>
         {{/each}}

--- a/addon/plugins/document-validation-plugin/common-fixes.ts
+++ b/addon/plugins/document-validation-plugin/common-fixes.ts
@@ -1,0 +1,92 @@
+import { SayController } from '@lblod/ember-rdfa-editor';
+import { getCurrentBesluitRange } from '../besluit-topic-plugin/utils/helpers';
+import IntlService from 'ember-intl/services/intl';
+import {
+  insertMotivation,
+  insertArticleContainer,
+  insertDescription,
+  insertTitle,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/decision-plugin/commands';
+
+export function insertTitleAtCursor(
+  controller: SayController,
+  intl: IntlService,
+) {
+  const decisionNodeLocation = getDecisionNodeLocation(controller);
+  if (!decisionNodeLocation) return;
+  controller.doCommand(
+    insertTitle({
+      placeholderText: intl.t('besluit-plugin.placeholder.decision-title'),
+      decisionLocation: decisionNodeLocation,
+    }),
+    { view: controller.mainEditorView },
+  );
+  controller.focus();
+}
+
+export function insertDescriptionAtCursor(
+  controller: SayController,
+  intl: IntlService,
+) {
+  const decisionNodeLocation = getDecisionNodeLocation(controller);
+  if (!decisionNodeLocation) return;
+  controller.doCommand(
+    insertDescription({
+      placeholderText: intl.t(
+        'besluit-plugin.placeholder.decision-description',
+      ),
+      decisionLocation: decisionNodeLocation,
+    }),
+    {
+      view: controller.mainEditorView,
+    },
+  );
+  controller.focus();
+}
+
+export function insertMotivationAtCursor(
+  controller: SayController,
+  intl: IntlService,
+) {
+  const decisionNodeLocation = getDecisionNodeLocation(controller);
+  if (!decisionNodeLocation) return;
+  controller.doCommand(
+    insertMotivation({
+      intl: intl,
+      decisionLocation: decisionNodeLocation,
+    }),
+    {
+      view: controller.mainEditorView,
+    },
+  );
+  controller.focus();
+}
+
+export function insertArticleContainerAtCursor(
+  controller: SayController,
+  intl: IntlService,
+  articleUriGenerator?: () => string,
+) {
+  const decisionNodeLocation = getDecisionNodeLocation(controller);
+  if (!decisionNodeLocation) return;
+  controller.doCommand(
+    insertArticleContainer({
+      intl: intl,
+      decisionUri: decisionNodeLocation?.node.attrs.subject,
+      articleUriGenerator: articleUriGenerator,
+    }),
+    {
+      view: controller.mainEditorView,
+    },
+  );
+}
+
+function getDecisionNodeLocation(controller: SayController) {
+  const besluitRange = getCurrentBesluitRange(controller);
+  if (!besluitRange) return;
+  const decisionNodeLocation = {
+    pos: besluitRange.from,
+    node: besluitRange.node,
+  };
+  return decisionNodeLocation;
+}

--- a/addon/plugins/document-validation-plugin/index.ts
+++ b/addon/plugins/document-validation-plugin/index.ts
@@ -2,7 +2,12 @@ import factory from '@rdfjs/dataset';
 import SHACLValidator from 'rdf-validate-shacl';
 import { Parser as ParserN3 } from 'n3';
 import { RdfaParser } from 'rdfa-streaming-parser';
-import { ProsePlugin, PluginKey, EditorView } from '@lblod/ember-rdfa-editor';
+import {
+  ProsePlugin,
+  PluginKey,
+  EditorView,
+  SayController,
+} from '@lblod/ember-rdfa-editor';
 import removeQuotes from '@lblod/ember-rdfa-editor-lblod-plugins/utils/remove-quotes';
 import {
   BlankNode,
@@ -20,13 +25,11 @@ export const documentValidationPluginKey =
 
 interface DocumentValidationPluginArgs {
   documentShape: string;
-  actions: [
-    {
-      shaclRule: string;
-      action: () => void;
-      buttonTitle: string;
-    },
-  ];
+  actions: {
+    shaclRule: string;
+    action: (controller: SayController) => void;
+    buttonTitle: string;
+  }[];
 }
 
 export type ShaclValidationReport = ValidationReport.ValidationReport<
@@ -55,13 +58,11 @@ export interface DocumentValidationPluginState
   extends DocumentValidationResult {
   documentShape: string;
   validationCallback: typeof validationCallback;
-  actions: [
-    {
-      shaclRule: string;
-      action: () => void;
-      buttonTitle: string;
-    },
-  ];
+  actions: {
+    shaclRule: string;
+    action: (controller: SayController) => void;
+    buttonTitle: string;
+  }[];
 }
 
 export const documentValidationPlugin = (

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -140,11 +140,8 @@ import {
   documentValidationPlugin,
   documentValidationPluginKey,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-validation-plugin';
-import { getShapeOfDocumentType } from '@lblod/lib-decision-shapes';
 import { RdfaVisualizerConfig } from '@lblod/ember-rdfa-editor/plugins/rdfa-info';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
-import { getCurrentBesluitRange } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-topic-plugin/utils/helpers';
-import { insertTitle } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/decision-plugin/commands';
 import {
   insertArticleContainerAtCursor,
   insertDescriptionAtCursor,

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -143,6 +143,14 @@ import {
 import { getShapeOfDocumentType } from '@lblod/lib-decision-shapes';
 import { RdfaVisualizerConfig } from '@lblod/ember-rdfa-editor/plugins/rdfa-info';
 import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
+import { getCurrentBesluitRange } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/besluit-topic-plugin/utils/helpers';
+import { insertTitle } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/decision-plugin/commands';
+import {
+  insertArticleContainerAtCursor,
+  insertDescriptionAtCursor,
+  insertMotivationAtCursor,
+  insertTitleAtCursor,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-validation-plugin/common-fixes';
 
 export default class BesluitSampleController extends Controller {
   queryParams = ['editableNodes'];
@@ -355,7 +363,149 @@ export default class BesluitSampleController extends Controller {
         onlyArticleSpecialName: true,
       },
       documentValidation: {
-        documentShape: getShapeOfDocumentType('decision'),
+        actions: [
+          {
+            shaclRule:
+              'https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-title-validation',
+            action: (controller: SayController) =>
+              insertTitleAtCursor(controller, this.intl),
+            buttonTitle: 'Insert title',
+          },
+          {
+            shaclRule:
+              'https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-description-validation',
+            action: (controller: SayController) =>
+              insertDescriptionAtCursor(controller, this.intl),
+            buttonTitle: 'Insert description',
+          },
+          {
+            shaclRule:
+              'https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-motivering-validation',
+            action: (controller: SayController) =>
+              insertMotivationAtCursor(controller, this.intl),
+            buttonTitle: 'Insert motivation',
+          },
+          {
+            shaclRule:
+              'https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-article-container-validation',
+            action: (controller: SayController) =>
+              insertArticleContainerAtCursor(controller, this.intl),
+            buttonTitle: 'Insert article container',
+          },
+        ],
+        documentShape: `
+        @prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix qb:      <http://purl.org/linked-data/cube#> .
+@prefix lblodBesluit:	<http://lblod.data.gift/vocabularies/besluit/> .
+@prefix ext:	<http://mu.semte.ch/vocabularies/ext/> .
+<https://data.vlaanderen.be/shacl/besluit-publicatie#BesluitShape>
+	a sh:NodeShape ;
+	sh:targetClass <http://data.vlaanderen.be/ns/besluit#Besluit> ;
+	sh:property <https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-description-validation>;
+    sh:property <https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-article-container-validation>;
+	sh:property <https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-short-title-validation>;
+    sh:property <https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-title-validation>;
+	sh:property <https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-language-validation>;
+    sh:property <https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-article-validation>;
+    sh:property <https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-citation-validation>;
+    sh:property <https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-motivering-validation>;
+	sh:property <https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-publication-date-validation>;
+    sh:property <https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-date-no-longer-in-force-validation>;
+	sh:property <https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-first-date-entry-in-force-validation>;
+	sh:closed false .
+
+<https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-description-validation> sh:name "beschrijving" ;
+		sh:description "Een beknopte beschrijving van het besluit." ;
+		sh:path <http://data.europa.eu/eli/ontology#description> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+        sh:minCount 0 ;
+		sh:maxCount 1 ;
+        sh:resultMessage "Het besluit mag maximaal één beschrijving hebben.";
+    	ext:successMessage "Het besluit heeft een beschrijving.".
+
+<https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-article-container-validation> sh:name "inhoud" ;
+		sh:description "De beschrijving van de beoogde rechtsgevolgen, het zogenaamde beschikkend gedeelte." ;
+		sh:path <http://www.w3.org/ns/prov#value> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+        sh:resultMessage "Het besluit moet een artikelcontainer hebben.";
+        ext:successMessage "Het besluit heeft een artikelcontainer.".
+
+<https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-short-title-validation> sh:name "citeeropschrift" ;
+		sh:description "De beknopte titel of officiële korte naam van een decreet, wet, besluit... Deze wordt officieel vastgelegd. Deze benaming wordt in de praktijk gebruikt om naar de rechtsgrond te verwijzen." ;
+		sh:path <http://data.europa.eu/eli/ontology#title_short> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+        sh:minCount 0 ;
+		sh:maxCount 1 ;
+        sh:resultMessage "Het besluit mag niet meer dan één officiële titel hebben.";
+    	ext:successMessage "Het besluit heeft een officiële titel.".
+
+<https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-title-validation> sh:name "titel" ;
+		sh:description "Titel van de legale verschijningsvorm." ;
+		sh:path <http://data.europa.eu/eli/ontology#title> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+		sh:minCount 1 ;
+        sh:resultMessage "Het besluit moet minstens één titel hebben.";
+        ext:successMessage "De beslissing heeft een titel.".
+
+<https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-language-validation> sh:name "taal" ;
+		sh:description "De taal van de verschijningsvorm." ;
+		sh:path <http://data.europa.eu/eli/ontology#language> ;
+		sh:class <http://www.w3.org/2004/02/skos/core#Concept> ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+		qb:codeList <http://publications.europa.eu/mdr/authority/language/index.html> ;
+        sh:resultMessage "Het besluit moet een geldige taal hebben.";
+        ext:successMessage "Het besluit heeft een geldig taalgebruik.".
+
+<https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-article-validation> sh:name "heeftDeel" ;
+		sh:description "Duidt een artikel aan van dit besluit." ;
+		sh:path <http://data.europa.eu/eli/ontology#has_part> ;
+		sh:class <http://data.vlaanderen.be/ns/besluit#Artikel> ;
+		sh:minCount 0 ;
+        sh:resultMessage "Het artikel moet het juiste type hebben.";
+        ext:successMessage "Het artikel is correct getypt.".
+
+<https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-citation-validation> sh:name "citeert" ;
+		sh:description "Een citatie in de wettelijke tekst. Dit omvat zowel woordelijke citaten als citaten in verwijzingen." ;
+		sh:path <http://data.europa.eu/eli/ontology#cites> ;
+		sh:class <http://data.europa.eu/eli/ontology#LegalExpression> ;
+        sh:minCount 0 ;
+        sh:resultMessage "De citatie moet het juiste type hebben.";
+        ext:successMessage "De citatie is correct getypt.".
+
+<https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-motivering-validation> sh:name "motivering" ;
+		sh:description "Beschrijving van de juridische en feitelijke motivering achter de beslissing die wordt uitgedrukt in het besluit." ;
+		sh:path <http://data.vlaanderen.be/ns/besluit#motivering> ;
+		sh:datatype <http://www.w3.org/1999/02/22-rdf-syntax-ns#langString> ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+        sh:resultMessage "Het besluit moet één motivering hebben.";
+        ext:successMessage "Het besluit heeft een motivering.".
+
+<https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-publication-date-validation> sh:name "publicatiedatum" ;
+		sh:description "De officiële publicatiedatum van het besluit." ;
+		sh:path <http://data.europa.eu/eli/ontology#date_publication> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#date> ;
+        sh:minCount 0 ;
+		sh:maxCount 1 ;
+        sh:resultMessage "Het besluit mag niet meer dan één publicatiedatum hebben.";
+        ext:successMessage "Het besluit heeft niet meer dan één publicatiedatum.".
+
+<https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-date-no-longer-in-force-validation> sh:name "buitenwerkingtreding" ;
+		sh:description "De laatste dag waarop de regelgeving nog van kracht is." ;
+		sh:path <http://data.europa.eu/eli/ontology#date_no_longer_in_force> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#date> ;
+        sh:minCount 0 ;
+		sh:maxCount 1.
+
+<https://data.vlaanderen.be/shacl/besluit-publicatie#besluit-first-date-entry-in-force-validation> sh:name "inwerkingtreding" ;
+		sh:description "De datum waarop de regelgeving van kracht wordt." ;
+		sh:path <http://data.europa.eu/eli/ontology#first_date_entry_in_force> ;
+		sh:datatype <http://www.w3.org/2001/XMLSchema#date> ;
+		sh:minCount 0 ;
+		sh:maxCount 1.`,
       },
     };
   }


### PR DESCRIPTION
### Overview
 This PR allows the user to add a function to fix a shacl violation, like add a title if there isn't one. For this we have several changes:
 First I added uris to the shacl properties, I made this change in the validation shapes library but also copied it here as it's needed for this to work, when it gets merged there I will remove the shape from here and just import it.
Then I added a file on the plugin with common fixes like the ones we had in the decision plugin
And finally developed a new API to add these actions to the plugin config

##### connected issues and PRs:
GN-5660


### Setup
None
### How to test/reproduce
Check the added actions work, but most important check the API and see if it makes sense

### Challenges/uncertainties
I don't know what to do with the description, because the shacl rule we have in the model says that a besluit can have 0 descriptions and be completely valid, so the fix to add a description doesn't work, as a besluit with 0 description would be valid.
Maybe we can add warning shacl rules? so the besluit is valid with 0 description but it gives a warning, but this can be done in future tickets I think



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
