### PR TITLE
Fix traffic measure type filter

### DIFF
--- a/.changeset/fast-ladybugs-admire.md
+++ b/.changeset/fast-ladybugs-admire.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Fix filtering of traffic measures by type

--- a/.changeset/late-radios-joke.md
+++ b/.changeset/late-radios-joke.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Fix type selector in combination with sign code in traffic measure modal

--- a/addon/components/roadsign-regulation-plugin/roadsigns-modal.gts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-modal.gts
@@ -10,6 +10,7 @@ import { getCurrentBesluitRange } from '@lblod/ember-rdfa-editor-lblod-plugins/p
 import { RoadsignRegulationPluginOptions } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin';
 import {
   countMobilityMeasures,
+  MobilityMeasureQueryOptions,
   queryMobilityMeasures,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/queries/mobility-measure-concept';
 import queryRoadSignCategories from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/queries/road-sign-category';
@@ -237,11 +238,11 @@ export default class RoadsignsModal extends Component<Signature> {
     if (this.selectedCode) {
       codes.push(this.selectedCode);
     }
-    const queryOptions = {
+    const queryOptions: MobilityMeasureQueryOptions = {
       imageBaseUrl: this.imageBaseUrl,
       searchString: this.searchQuery,
       zonality: this.selectedZonality ? this.selectedZonality.uri : undefined,
-      signType: this.selectedType ? this.selectedType.uri : undefined,
+      trafficSignalType: this.selectedType ? this.selectedType.uri : undefined,
       codes: codes.length ? codes.map((code) => code.uri) : undefined,
       category: this.selectedCategory ? this.selectedCategory.uri : undefined,
       page: this.pageNumber,

--- a/addon/components/roadsign-regulation-plugin/roadsigns-modal.gts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-modal.gts
@@ -152,7 +152,7 @@ export default class RoadsignsModal extends Component<Signature> {
 
   searchCodes = restartableTask(async (term: string) => {
     const category = this.selectedCategory?.uri;
-    const type = this.selectedType?.label;
+    const type = this.selectedType?.uri;
     const types = type ? [type] : undefined;
     await timeout(DEBOUNCE_MS);
     const abortController = new AbortController();

--- a/addon/plugins/roadsign-regulation-plugin/queries/mobility-measure-concept.ts
+++ b/addon/plugins/roadsign-regulation-plugin/queries/mobility-measure-concept.ts
@@ -160,16 +160,21 @@ async function _queryMobilityMeasures<Count extends boolean>(
   }
 }
 
+export type MobilityMeasureQueryOptions = Omit<QueryOptions, 'count'>;
 export async function queryMobilityMeasures(
   endpoint: string,
-  options: Omit<QueryOptions, 'count'> = {},
+  options: MobilityMeasureQueryOptions = {},
 ) {
   return _queryMobilityMeasures(endpoint, { ...options, count: false });
 }
 
+export type MobilityMeasureCountOptions = Omit<
+  QueryOptions,
+  'count' | 'page' | 'pageSize'
+>;
 export function countMobilityMeasures(
   endpoint: string,
-  options: Omit<QueryOptions, 'count' | 'page' | 'pageSize'> = {},
+  options: MobilityMeasureCountOptions = {},
 ) {
   return _queryMobilityMeasures(endpoint, { ...options, count: true });
 }


### PR DESCRIPTION
### Overview
When fixing the categories I didn't notice that the types were also broken, they should be fixed now, I also tested all the parts of the modal and they are working. So please also test them so we don't miss anything :)

##### connected issues and PRs:
GN-5686


### Setup
None

### How to test/reproduce
Test that you can filter on type of traffic measure and then you get signs related to that type, also check that everything else works in the modal 

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
