### PR TITLE
Improve sorting of code filters on roadsigns modal

### DIFF
--- a/.changeset/unlucky-camels-fail.md
+++ b/.changeset/unlucky-camels-fail.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Improve sorting of label filters on 'insert traffic measure' modal

--- a/addon/components/roadsign-regulation-plugin/roadsigns-modal.gts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-modal.gts
@@ -18,7 +18,9 @@ import { MobilityMeasureConcept } from '@lblod/ember-rdfa-editor-lblod-plugins/p
 import { pagination } from '@lblod/ember-rdfa-editor-lblod-plugins/helpers/pagination';
 import { restartableTask, task, timeout } from 'ember-concurrency';
 import t from 'ember-intl/helpers/t';
-import PowerSelect from 'ember-power-select/components/power-select';
+import PowerSelect, {
+  Select,
+} from 'ember-power-select/components/power-select';
 import PowerSelectMultiple from 'ember-power-select/components/power-select-multiple';
 import { TaskInstance, trackedTask } from 'reactiveweb/ember-concurrency';
 import { trackedFunction } from 'reactiveweb/function';
@@ -150,6 +152,18 @@ export default class RoadsignsModal extends Component<Signature> {
     this.args.closeModal();
   }
 
+  @action
+  doFirstCodeSearch(select: Select) {
+    if (
+      this.searchCodes.isIdle &&
+      !select.searchText &&
+      // @ts-expect-error not part of the public API... (tested on PS 7 and 8)
+      this.searchCodes.lastSuccessful?.args?.[0] !== ''
+    ) {
+      this.searchCodes.perform('');
+    }
+    return true;
+  }
   searchCodes = restartableTask(async (term: string) => {
     const category = this.selectedCategory?.uri;
     const type = this.selectedType?.label;
@@ -401,9 +415,11 @@ export default class RoadsignsModal extends Component<Signature> {
                   @verticalPosition='below'
                   @searchEnabled={{true}}
                   @search={{this.searchCodes.perform}}
+                  @options={{or this.searchCodes.last.value undefined}}
                   @selected={{this.selectedCode}}
                   @allowClear={{true}}
                   @onChange={{this.changeCode}}
+                  @onOpen={{this.doFirstCodeSearch}}
                   as |option|
                 >
                   {{option.label}}

--- a/addon/plugins/roadsign-regulation-plugin/queries/traffic-signal-codes.ts
+++ b/addon/plugins/roadsign-regulation-plugin/queries/traffic-signal-codes.ts
@@ -77,6 +77,9 @@ export default async function queryTrafficSignalCodes(
   const { abortSignal } = options;
   const filterStatement = buildFilters(options);
 
+  // The sorting here is a little weird. This is to handle labels which are normally of the form
+  // 'A1.3b', where the 1.3 should be sorted as a number. There is no enforcement of this format, so
+  // we try to handle cases such as 'weird1.2.3LABEL' in a way that is not too broken.
   const query = /* sparql */ `
     PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
@@ -92,8 +95,11 @@ export default async function queryTrafficSignalCodes(
               skos:prefLabel ?label;
               ext:valid ${sparqlEscapeBool(true)}.
       ${filterStatement}
+      BIND(REPLACE(?label, "^(\\\\D+).*", "$1", "i") AS ?firstLetters)
+      BIND(xsd:decimal(REPLACE(?label, "^\\\\D+(\\\\d*\\\\.?\\\\d*).*", "$1", "i")) AS ?number)
+      BIND(REPLACE(?label, "^\\\\D+\\\\d*\\\\.?\\\\d*(.*)", "$1", "i") AS ?secondLetters)
     }
-    ORDER BY ASC(?label)
+    ORDER BY ASC(UCASE(?firstLetters)) ASC(?number) ASC(LCASE(?secondLetters))
   `;
   const queryResult = await executeQuery({ endpoint, query, abortSignal });
   const bindings = queryResult.results.bindings;


### PR DESCRIPTION
### Overview
Also add a slightly hacky version of actually populating the filters before doing any searching. Since this uses a non-public API, I tested it in GN on Power Select 8, where the test app here is on v7.

The sorting in the list itself is weird as it is based on the string length of the code. It seems to have always been like this (without digging into the old repo). We should maybe change this to match the ordering for the codes in the filter.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5680

### Setup
N/A

### How to test/reproduce
When inserting a traffic measure, the code and 'combine with code' filters should display options in the expected order (sorted by the first letters alphabetically, the following number (numerically) then anything left alphabetically. 

### Challenges/uncertainties
The possible codes are weird and unconstrained, so leads to weird regex patterns to handle them...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
