### PR TITLE
Fix inserted text to include traffic signals without images

### DIFF
--- a/.changeset/nervous-baboons-call.md
+++ b/.changeset/nervous-baboons-call.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Fix inserted text for traffic signals that do not have images

--- a/addon/components/roadsign-regulation-plugin/roadsigns-table.gts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-table.gts
@@ -99,14 +99,24 @@ export default class RoadSignsTable extends Component<Signature> {
                         as |signalConcept|
                       }}
                         <div class='au-o-grid__item au-u-1-3'>
-                          <img
-                            src={{signalConcept.image}}
-                            alt={{t
-                              'editor-plugins.roadsign-regulation.table.content.image.alt'
-                              code=signalConcept.code
-                            }}
-                            class='au-c-data-table__image'
-                          />
+                          {{#if signalConcept.image}}
+                            <img
+                              src={{signalConcept.image}}
+                              alt={{t
+                                'editor-plugins.roadsign-regulation.table.content.image.alt'
+                                code=signalConcept.code
+                              }}
+                              class='au-c-data-table__image'
+                            />
+                          {{else}}
+                            <AuPill
+                              @skin='border'
+                              @size='small'
+                              @draft={{true}}
+                            >
+                              {{signalConcept.code}}
+                            </AuPill>
+                          {{/if}}
                         </div>
                       {{/each}}
                     </div>


### PR DESCRIPTION
### Overview
Move the image part of the query into an optional and handle the resulting undefined images. In order to display something to the user, I put just the code of the sign in a pill.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5681

### Setup
Works well if pointing to QA as it avoids the need to produce your own (broken) test data.

### How to test/reproduce
Inserting signs with no images (such as `WM72.2` on QA, generates the correct text mentioning the signs as well as the template (see ticket).

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
