### PR TITLE
Fix parsing of oslo_locations to remove false positives

### DIFF
--- a/.changeset/weak-ties-enjoy.md
+++ b/.changeset/weak-ties-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Fix parsing of oslo locations to no longer incorrectly catch non-locations

--- a/addon/plugins/location-plugin/node.ts
+++ b/addon/plugins/location-plugin/node.ts
@@ -109,13 +109,15 @@ const parseDOM = (config: LocationPluginConfig): TagParseRule[] => {
             nodeContentsUtils.address.parse(contentContainer.children[0]) ||
             nodeContentsUtils.place.parse(contentContainer.children[0]) ||
             nodeContentsUtils.area.parse(contentContainer.children[0]);
-          // Ignore the properties for now, we handle these ourselves
-          const properties: OutgoingTriple[] = [];
-          return {
-            ...attrs,
-            properties,
-            value: location,
-          };
+          if (location) {
+            // Ignore the properties for now, we handle these ourselves
+            const properties: OutgoingTriple[] = [];
+            return {
+              ...attrs,
+              properties,
+              value: location,
+            };
+          }
         }
         return false;
       },


### PR DESCRIPTION
### Overview
Only match as a location if a location can be parsed. Tested with location placeholders, but not with older address variable placeholders.

##### connected issues and PRs:
Discovered when looking at https://binnenland.atlassian.net/browse/GN-5710

### Setup
N/A

### How to test/reproduce
- In the test app, insert a traffic measure
- Refresh the page
- Any signs as part of the measure should remain as inline_rdfa nodes with the correct annotations, rather than being turned into oslo_location nodes

### Challenges/uncertainties
It's not clear if we need to support address variable placeholders.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
