### PR TITLE
Only auto-focus variables if they contain only a placeholder

### DIFF
--- a/.changeset/clever-beers-rule.md
+++ b/.changeset/clever-beers-rule.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Do not auto-focus variables unless they only contain a placeholder

--- a/addon/components/variable-plugin/variable/nodeview.ts
+++ b/addon/components/variable-plugin/variable/nodeview.ts
@@ -28,8 +28,6 @@ export default class VariableNodeViewComponent extends Component<EmberNodeArgs> 
             this.innerView?.dispatch(tr);
           }
         });
-      } else {
-        this.innerView.focus();
       }
     }
   }


### PR DESCRIPTION
### Overview
The auto-focus behaviour causes problems when a variable has nested nodeviews, e.g. an inline_rdfa inside a variable. This seems to occur in roadsign regulations.

Instead of always focusing the inner editor, only do so for placeholders. All of the variables seem to function correctly after this change.

##### connected issues and PRs:
Gent raising the issue of editing these values: https://binnenland.atlassian.net/browse/GN-5718

### Setup
N/A

### How to test/reproduce
- Insert a variable which contains free text, such as a 'location' (not an oslo_location).
- Click somewhere outside the variable and insert some variables to test.
- Copy-paste the test variables into the location variable.
- Check that editing the text and the variables work as expected.

### Challenges/uncertainties
It's hard to know if there's some other edge-case that is broken by this...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
