### PR TITLE
GN-5739: order traffic signals based on position

### DIFF
--- a/.changeset/eight-tips-obey.md
+++ b/.changeset/eight-tips-obey.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Order traffic signals of a mobility measure based on their position

--- a/addon/plugins/roadsign-regulation-plugin/queries/mobility-measure-concept.ts
+++ b/addon/plugins/roadsign-regulation-plugin/queries/mobility-measure-concept.ts
@@ -142,13 +142,12 @@ async function _queryMobilityMeasures<Count extends boolean>(
     );
     const conceptsWithSigns = await Promise.all(
       concepts.map(async (concept) => {
-        const trafficSignalConcepts = await queryTrafficSignalConcepts(
-          endpoint,
-          {
+        const trafficSignalConcepts = (
+          await queryTrafficSignalConcepts(endpoint, {
             measureConceptUri: concept.uri,
             imageBaseUrl,
-          },
-        );
+          })
+        ).sort((a, b) => a.position - b.position);
         return {
           ...concept,
           trafficSignalConcepts,

--- a/addon/plugins/roadsign-regulation-plugin/schemas/traffic-signal-concept.ts
+++ b/addon/plugins/roadsign-regulation-plugin/schemas/traffic-signal-concept.ts
@@ -8,6 +8,7 @@ export const TrafficSignalConceptSchema = z
     code: z.string(),
     image: z.string(),
     zonality: z.nativeEnum(ZONALITY_OPTIONS).optional(),
+    position: z.coerce.number().default(-1),
   })
   .and(
     z.discriminatedUnion('type', [


### PR DESCRIPTION
### Overview
This PR adjusts the roadsign-regulation-plugin to ensure traffic signals belonging to a mobility measure are correctly ordered based on their position.

This PR also keeps the previous behaviour intact, in case the plugin is connected to a MOW backend which does not yet contain the new list-item/position data for the road signals.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-5739?atlOrigin=eyJpIjoiYWYzNjYxNTM2NTQwNDMzNDk5MDM3ODE0Njc0NzhhZmUiLCJwIjoiaiJ9

### Set-up
Connect to the `/raw-sparql` endpoint of the MOW registry you are using, to see changes in the order of signals be directly reflected.

### How to test/reproduce
Ideally, this PR should be tested with both a MOW backend containing the position-data, and one which doesn't contain any position-data.
- Create a regulation decision
- Open the traffic measure modal
- Ensure the traffic signals are ordered based on position in the table
- Insert a traffic measure containing 2+ signals, these should be correctly ordered in the document
- Adjust the order of the signals in the connected registry. This should be immediately reflected in the plugin.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
