### PR TITLE
Add text indicating zonality to newly inserted zonal measures

### DIFF
--- a/.changeset/old-squids-flash.md
+++ b/.changeset/old-squids-flash.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add text to roadsigns indicating zonality to newly inserted zonal measures

--- a/addon/components/roadsign-regulation-plugin/expanded-measure.gts
+++ b/addon/components/roadsign-regulation-plugin/expanded-measure.gts
@@ -10,17 +10,16 @@ import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
 import { MobilityMeasureConcept } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/schemas/mobility-measure-concept';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
-import { ZONALITY_OPTIONS } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/constants';
+import {
+  ZONALITY_OPTIONS,
+  ZonalOrNot,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/constants';
 import { Task } from 'ember-concurrency';
 import { isSome } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 
 export type InsertMobilityMeasureTask = Task<
   void,
-  [
-    MobilityMeasureConcept,
-    typeof ZONALITY_OPTIONS.ZONAL | typeof ZONALITY_OPTIONS.NON_ZONAL,
-    boolean,
-  ]
+  [MobilityMeasureConcept, ZonalOrNot, boolean]
 >;
 type Signature = {
   Args: {
@@ -32,9 +31,7 @@ type Signature = {
 };
 
 export default class ExpandedMeasure extends Component<Signature> {
-  @tracked zonalityValue?:
-    | typeof ZONALITY_OPTIONS.ZONAL
-    | typeof ZONALITY_OPTIONS.NON_ZONAL;
+  @tracked zonalityValue?: ZonalOrNot;
   @tracked temporalValue?: boolean;
 
   get isPotentiallyZonal() {
@@ -49,9 +46,7 @@ export default class ExpandedMeasure extends Component<Signature> {
   }
 
   @action
-  changeZonality(
-    zonality: typeof ZONALITY_OPTIONS.ZONAL | typeof ZONALITY_OPTIONS.NON_ZONAL,
-  ) {
+  changeZonality(zonality: ZonalOrNot) {
     this.zonalityValue = zonality;
   }
 
@@ -65,9 +60,7 @@ export default class ExpandedMeasure extends Component<Signature> {
     this.args.insert.perform(
       this.args.concept,
       // POTENTIALLY_ZONAL option is filtered out by requiring a zonalityValue to submit
-      (this.zonalityValue ?? this.args.concept.zonality) as
-        | typeof ZONALITY_OPTIONS.ZONAL
-        | typeof ZONALITY_OPTIONS.NON_ZONAL,
+      (this.zonalityValue ?? this.args.concept.zonality) as ZonalOrNot,
       this.temporalValue ?? false,
     );
   }

--- a/addon/components/roadsign-regulation-plugin/expanded-measure.gts
+++ b/addon/components/roadsign-regulation-plugin/expanded-measure.gts
@@ -64,6 +64,7 @@ export default class ExpandedMeasure extends Component<Signature> {
   insert() {
     this.args.insert.perform(
       this.args.concept,
+      // POTENTIALLY_ZONAL option is filtered out by requiring a zonalityValue to submit
       (this.zonalityValue ?? this.args.concept.zonality) as
         | typeof ZONALITY_OPTIONS.ZONAL
         | typeof ZONALITY_OPTIONS.NON_ZONAL,

--- a/addon/components/roadsign-regulation-plugin/roadsigns-modal.gts
+++ b/addon/components/roadsign-regulation-plugin/roadsigns-modal.gts
@@ -32,6 +32,7 @@ import { on } from '@ember/modifier';
 import {
   TRAFFIC_SIGNAL_CONCEPT_TYPES,
   ZONALITY_OPTIONS,
+  type ZonalOrNot,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/constants';
 import { resolveTemplate } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/actions/resolve-template';
 import { queryMobilityTemplates } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/queries/mobility-template';
@@ -309,9 +310,7 @@ export default class RoadsignsModal extends Component<Signature> {
   insertMeasure = task(
     async (
       concept: MobilityMeasureConcept,
-      zonality:
-        | typeof ZONALITY_OPTIONS.ZONAL
-        | typeof ZONALITY_OPTIONS.NON_ZONAL,
+      zonality: ZonalOrNot,
       temporal: boolean,
     ) => {
       if (!this.decisionLocation) {

--- a/addon/plugins/roadsign-regulation-plugin/constants.ts
+++ b/addon/plugins/roadsign-regulation-plugin/constants.ts
@@ -1,4 +1,5 @@
 import { MOBILITEIT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { ValuesOf } from '@lblod/ember-rdfa-editor/utils/_private/types';
 
 export const ZONALITY_OPTIONS = {
   POTENTIALLY_ZONAL:
@@ -7,6 +8,11 @@ export const ZONALITY_OPTIONS = {
   NON_ZONAL:
     'http://lblod.data.gift/concepts/b651931b-923c-477c-8da9-fc7dd841fdcc',
 } as const;
+export type ZonalityOption = ValuesOf<typeof ZONALITY_OPTIONS>;
+export type ZonalOrNot = Exclude<
+  ZonalityOption,
+  typeof ZONALITY_OPTIONS.POTENTIALLY_ZONAL
+>;
 
 export const TRAFFIC_SIGNAL_CONCEPT_TYPES = {
   TRAFFIC_SIGNAL: MOBILITEIT('Verkeerstekenconcept').full,


### PR DESCRIPTION
### Overview
Updates the text content to reflect whether the measure is zonal (and so if those signs are being applied to that zone).

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5722

### Setup
N/A

### How to test/reproduce
- Insert a zonal measure and note the extra text after signs and sub-signs
- Insert a non-zonal measure and note there is no additional text
- Repeat the same with a potentially-zonal measure and selecting zonal or not

### Challenges/uncertainties
Understanding what Zonal means...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
