### PR TITLE
Update roadsigns plugin to use unhyphenated signal subclass names

### DIFF
--- a/.changeset/silver-pumas-play.md
+++ b/.changeset/silver-pumas-play.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Update data model used for roadsigns to us correct classnames for different subclasses of traffic signal

--- a/addon/plugins/roadsign-regulation-plugin/constants.ts
+++ b/addon/plugins/roadsign-regulation-plugin/constants.ts
@@ -23,9 +23,9 @@ export const TRAFFIC_SIGNAL_CONCEPT_TYPES = {
 
 export const TRAFFIC_SIGNAL_TYPES = {
   TRAFFIC_SIGNAL: MOBILITEIT('Verkeersteken').full,
-  ROAD_SIGN: MOBILITEIT('Verkeersbord').full,
-  TRAFFIC_LIGHT: MOBILITEIT('Verkeerslicht').full,
-  ROAD_MARKING: MOBILITEIT('Wegmarkering').full,
+  ROAD_SIGN: MOBILITEIT('VerkeersbordVerkeersteken').full,
+  TRAFFIC_LIGHT: MOBILITEIT('VerkeerslichtVerkeersteken').full,
+  ROAD_MARKING: MOBILITEIT('WegmarkeringVerkeersteken').full,
 } as const;
 
 export const TRAFFIC_SIGNAL_TYPE_MAPPING = {

--- a/addon/plugins/roadsign-regulation-plugin/nodes.ts
+++ b/addon/plugins/roadsign-regulation-plugin/nodes.ts
@@ -141,20 +141,12 @@ export const roadsign_regulation: NodeSpec = {
 };
 
 const replacements = [
-  [
-    MOBILITEIT('Verkeersbord-Verkeersteken'),
-    MOBILITEIT('VerkeersbordVerkeersteken').full,
-    // Switch to this once we've made the unhyphenated form the default (and similar for other entries
-    // TRAFFIC_SIGNAL_TYPES.ROAD_SIGN,
-  ],
+  [MOBILITEIT('Verkeersbord-Verkeersteken'), TRAFFIC_SIGNAL_TYPES.ROAD_SIGN],
   [
     MOBILITEIT('Verkeerslicht-Verkeersteken'),
-    MOBILITEIT('VerkeerslichtVerkeersteken').full,
+    TRAFFIC_SIGNAL_TYPES.TRAFFIC_LIGHT,
   ],
-  [
-    MOBILITEIT('Wegmarkering-Verkeersteken'),
-    MOBILITEIT('WegmarkeringVerkeersteken').full,
-  ],
+  [MOBILITEIT('Wegmarkering-Verkeersteken'), TRAFFIC_SIGNAL_TYPES.ROAD_MARKING],
 ] as const;
 /**
  * Migrates documents from a data model featuring multiple nested inline_rdfa nodes to one that uses

--- a/addon/services/import-rdfa-snippet.ts
+++ b/addon/services/import-rdfa-snippet.ts
@@ -135,11 +135,7 @@ export default class ImportRdfaSnippet extends Service {
       .filter((triple) => triple.predicate === 'a')
       .map((triple) => triple.object)
       .filter((v, i, a) => a.indexOf(v) === i); //This filters only unique values
-    if (
-      types.includes(
-        'https://data.vlaanderen.be/ns/mobiliteit#Verkeersbord-Verkeersteken',
-      )
-    ) {
+    if (types.includes('Verkeersteken')) {
       return 'roadsign';
     } else {
       return 'generic';

--- a/tests/helpers/test-documents.ts
+++ b/tests/helpers/test-documents.ts
@@ -168,7 +168,12 @@ export const mobilityRegulationWithSignals = (
                 ><span
                   about="http://data.lblod.info/verkeerstekens/2a3451ca-e601-44e7-be89-f37aa33ac191"
                   property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-                  resource="https://data.vlaanderen.be/ns/mobiliteit#Verkeersbord-Verkeersteken"
+                  resource="https://data.vlaanderen.be/ns/mobiliteit#Verkeersteken"
+                ></span
+                ><span
+                  about="http://data.lblod.info/verkeerstekens/2a3451ca-e601-44e7-be89-f37aa33ac191"
+                  property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+                  resource="https://data.vlaanderen.be/ns/mobiliteit#VerkeersbordVerkeersteken"
                 ></span
                 ><span
                   rev="https://data.vlaanderen.be/ns/mobiliteit#wordtAangeduidDoor"
@@ -189,7 +194,7 @@ export const mobilityRegulationWithSignals = (
                       resource="https://data.vlaanderen.be/ns/mobiliteit#Verkeersbordconcept"
                     ></span
                     ><span
-                      rev="https://data.vlaanderen.be/ns/mobiliteit#heeftVerkeersbordconcept"
+                      rev="http://www.w3.org/ns/prov#wasDerivedFrom"
                       resource="http://data.lblod.info/verkeerstekens/2a3451ca-e601-44e7-be89-f37aa33ac191"
                     ></span></span
                   ><span data-content-container="true"
@@ -228,7 +233,12 @@ export const mobilityRegulationWithSignals = (
                 ><span
                   about="http://data.lblod.info/verkeerstekens/e770b0d3-6883-49d8-a9b6-c508d41a51c7"
                   property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-                  resource="https://data.vlaanderen.be/ns/mobiliteit#Verkeersbord-Verkeersteken"
+                  resource="https://data.vlaanderen.be/ns/mobiliteit#VerkeersbordVerkeersteken"
+                ></span
+                ><span
+                  about="http://data.lblod.info/verkeerstekens/e770b0d3-6883-49d8-a9b6-c508d41a51c7"
+                  property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+                  resource="https://data.vlaanderen.be/ns/mobiliteit#Verkeersteken"
                 ></span
                 ><span
                   rev="https://data.vlaanderen.be/ns/mobiliteit#wordtAangeduidDoor"
@@ -249,7 +259,7 @@ export const mobilityRegulationWithSignals = (
                       resource="https://data.vlaanderen.be/ns/mobiliteit#Verkeersbordconcept"
                     ></span
                     ><span
-                      rev="https://data.vlaanderen.be/ns/mobiliteit#heeftVerkeersbordconcept"
+                      rev="http://www.w3.org/ns/prov#wasDerivedFrom"
                       resource="http://data.lblod.info/verkeerstekens/e770b0d3-6883-49d8-a9b6-c508d41a51c7"
                     ></span></span
                   ><span data-content-container="true"

--- a/tests/integration/plugin/variable-plugin-test.ts
+++ b/tests/integration/plugin/variable-plugin-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { PNode } from '@lblod/ember-rdfa-editor';
 import {
-  getOutgoingTriple,
+  getOutgoingTripleList,
   hasOutgoingNamedNodeTriple,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 import {
@@ -362,18 +362,27 @@ module('plugin | variable plugin', function () {
       2,
       'measure should have 2 linked signals',
     );
-    const signalTypes = [...linkedSignals.values()].map(([sigNode]) =>
-      getOutgoingTriple(sigNode.attrs, RDF('type')),
+    const signalTypes = [...linkedSignals.values()].map(
+      ([sigNode]) =>
+        new Set(
+          getOutgoingTripleList(sigNode.attrs, RDF('type')).map(
+            (type) => type?.object,
+          ),
+        ),
     );
-    // TODO these are actually old and should ideally be updated...
-    // See https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/597
     assert.deepEqual(
-      signalTypes[0]?.object,
-      MOBILITEIT('Verkeersbord-Verkeersteken').namedNode,
+      signalTypes[0],
+      new Set([
+        MOBILITEIT('Verkeersteken').namedNode,
+        MOBILITEIT('VerkeersbordVerkeersteken').namedNode,
+      ]),
     );
     assert.deepEqual(
-      signalTypes[1]?.object,
-      MOBILITEIT('Verkeersbord-Verkeersteken').namedNode,
+      signalTypes[1],
+      new Set([
+        MOBILITEIT('Verkeersteken').namedNode,
+        MOBILITEIT('VerkeersbordVerkeersteken').namedNode,
+      ]),
     );
   });
 });


### PR DESCRIPTION
### Overview
The data in the AWV LDES feed cannot contain hyphens (at least for class names), so move to using an unhyphenated version to match theirs.

It made sense to me to make this change as I was already nearly there with the [migrations PR](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/597). This is part of what's required to ensure that the model we're using matches what we should be using, but is parhaps not the whole picture.

I didn't add any migrations to update documents created since the last release. These will continue to contain `mobiliteit:Verkeersbord` (etc) types.

##### connected issues and PRs:
Part of https://binnenland.atlassian.net/browse/GN-5765

### Setup
N/A

### How to test/reproduce
Insert a measure and check that the RDFa is correct.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
