### PR TITLE
Fix changing between placeholders edit

### DIFF
--- a/.changeset/polite-ears-grow.md
+++ b/.changeset/polite-ears-grow.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Fix resetting the placeholder edit card

--- a/addon/components/placeholder-utils-plugin/edit.gts
+++ b/addon/components/placeholder-utils-plugin/edit.gts
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { type ComponentLike } from '@glint/template';
 import { NodeSelection, Node, SayController } from '@lblod/ember-rdfa-editor';
 import { service } from '@ember/service';
@@ -14,8 +13,8 @@ import AuNativeInput from '../au-native-input';
 import AuFormRow from '@appuniversum/ember-appuniversum/components/au-form-row';
 import checkEnterAndSubmit from '@lblod/ember-rdfa-editor-lblod-plugins/utils/check-enter-and-submit';
 import { fn } from '@ember/helper';
-import { modifier } from 'ember-modifier';
 import { not } from 'ember-truth-helpers';
+import { trackedReset } from 'tracked-toolbox';
 
 type VariableComponentArgs = {
   Args: {
@@ -36,7 +35,13 @@ type Args = {
 };
 
 export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
-  @tracked editedPlaceholderLabel?: string;
+  @trackedReset({
+    memo: 'selectedPlaceholderNode',
+    update(component: PlaceholderUtilsEditCardComponent) {
+      return component.selectedPlaceholderNode?.attrs.placeholderText;
+    },
+  })
+  placeholderLabel: string | null = null;
   lastSelectedPlaceholder: Node | null = null;
 
   @service declare intl: IntlService;
@@ -59,14 +64,8 @@ export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
   get showCard() {
     return !!this.selectedPlaceholderNode;
   }
-  get placeholderLabel() {
-    if (this.editedPlaceholderLabel !== undefined) {
-      return this.editedPlaceholderLabel;
-    }
-    return this.selectedPlaceholderNode?.attrs.placeholderText;
-  }
   updateLabelPlaceholder = (event: InputEvent) => {
-    this.editedPlaceholderLabel = (event.target as HTMLInputElement).value;
+    this.placeholderLabel = (event.target as HTMLInputElement).value;
   };
   updatePlaceholder = () => {
     const { selection } = this.controller.activeEditorState;
@@ -74,19 +73,10 @@ export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
       return tr.setNodeAttribute(
         selection.$from.pos,
         'placeholderText',
-        this.editedPlaceholderLabel,
+        this.placeholderLabel,
       );
     });
-    this.editedPlaceholderLabel = undefined;
   };
-
-  trackNode = modifier(() => {
-    const selectedPlaceholderNode = this.selectedPlaceholderNode;
-    if (this.lastSelectedPlaceholder !== selectedPlaceholderNode) {
-      this.editedPlaceholderLabel = undefined;
-      this.lastSelectedPlaceholder = selectedPlaceholderNode;
-    }
-  });
 
   <template>
     {{#if this.showCard}}
@@ -98,7 +88,6 @@ export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
         @shadow={{true}}
         @size='small'
         @disableAuContent={{true}}
-        {{this.trackNode}}
         as |c|
       >
         <c.header>
@@ -123,7 +112,7 @@ export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
           <AuButton
             {{on 'click' this.updatePlaceholder}}
             class='au-u-margin-top'
-            @disabled={{not this.editedPlaceholderLabel}}
+            @disabled={{not this.placeholderLabel}}
           >
             {{t 'editor-plugins.utils.insert'}}
           </AuButton>

--- a/addon/components/placeholder-utils-plugin/edit.gts
+++ b/addon/components/placeholder-utils-plugin/edit.gts
@@ -37,7 +37,7 @@ type Args = {
 
 export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
   @tracked editedPlaceholderLabel?: string;
-  lastSelectedPlaceholder?: Node;
+  lastSelectedPlaceholder: Node | null = null;
 
   @service declare intl: IntlService;
 
@@ -53,7 +53,7 @@ export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
     ) {
       return selection.node;
     } else {
-      return;
+      return null;
     }
   }
   get showCard() {

--- a/addon/components/placeholder-utils-plugin/edit.gts
+++ b/addon/components/placeholder-utils-plugin/edit.gts
@@ -1,11 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { type ComponentLike } from '@glint/template';
-import {
-  NodeSelection,
-  NodeType,
-  SayController,
-} from '@lblod/ember-rdfa-editor';
+import { NodeSelection, Node, SayController } from '@lblod/ember-rdfa-editor';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 import AuCard from '@appuniversum/ember-appuniversum/components/au-card';
@@ -41,7 +37,7 @@ type Args = {
 
 export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
   @tracked editedPlaceholderLabel?: string;
-  lastSelectedPlaceholder?: NodeType;
+  lastSelectedPlaceholder?: Node;
 
   @service declare intl: IntlService;
 

--- a/addon/components/placeholder-utils-plugin/edit.gts
+++ b/addon/components/placeholder-utils-plugin/edit.gts
@@ -1,7 +1,11 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { type ComponentLike } from '@glint/template';
-import { NodeSelection, SayController } from '@lblod/ember-rdfa-editor';
+import {
+  NodeSelection,
+  NodeType,
+  SayController,
+} from '@lblod/ember-rdfa-editor';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 import AuCard from '@appuniversum/ember-appuniversum/components/au-card';
@@ -14,6 +18,8 @@ import AuNativeInput from '../au-native-input';
 import AuFormRow from '@appuniversum/ember-appuniversum/components/au-form-row';
 import checkEnterAndSubmit from '@lblod/ember-rdfa-editor-lblod-plugins/utils/check-enter-and-submit';
 import { fn } from '@ember/helper';
+import { modifier } from 'ember-modifier';
+import { not } from 'ember-truth-helpers';
 
 type VariableComponentArgs = {
   Args: {
@@ -35,6 +41,7 @@ type Args = {
 
 export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
   @tracked editedPlaceholderLabel?: string;
+  lastSelectedPlaceholder?: NodeType;
 
   @service declare intl: IntlService;
 
@@ -57,10 +64,10 @@ export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
     return !!this.selectedPlaceholderNode;
   }
   get placeholderLabel() {
-    return (
-      this.editedPlaceholderLabel ||
-      this.selectedPlaceholderNode?.attrs.placeholderText
-    );
+    if (this.editedPlaceholderLabel !== undefined) {
+      return this.editedPlaceholderLabel;
+    }
+    return this.selectedPlaceholderNode?.attrs.placeholderText;
   }
   updateLabelPlaceholder = (event: InputEvent) => {
     this.editedPlaceholderLabel = (event.target as HTMLInputElement).value;
@@ -74,7 +81,16 @@ export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
         this.editedPlaceholderLabel,
       );
     });
+    this.editedPlaceholderLabel = undefined;
   };
+
+  trackNode = modifier(() => {
+    const selectedPlaceholderNode = this.selectedPlaceholderNode;
+    if (this.lastSelectedPlaceholder !== selectedPlaceholderNode) {
+      this.editedPlaceholderLabel = undefined;
+      this.lastSelectedPlaceholder = selectedPlaceholderNode;
+    }
+  });
 
   <template>
     {{#if this.showCard}}
@@ -86,6 +102,7 @@ export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
         @shadow={{true}}
         @size='small'
         @disableAuContent={{true}}
+        {{this.trackNode}}
         as |c|
       >
         <c.header>
@@ -110,6 +127,7 @@ export default class PlaceholderUtilsEditCardComponent extends Component<Args> {
           <AuButton
             {{on 'click' this.updatePlaceholder}}
             class='au-u-margin-top'
+            @disabled={{not this.editedPlaceholderLabel}}
           >
             {{t 'editor-plugins.utils.insert'}}
           </AuButton>


### PR DESCRIPTION
### Overview
I noticed a problem that when you changed between editing a placeholder and another it keeps some data in the card, also deleting the whole label was not working fine.
I refined the placeholder edit logic

##### connected issues and PRs:
None


### Setup
None

### How to test/reproduce
Go to a template with several placeholders make sure you can switch between editing placeholders and the label gets resetted correctly even if you modify it.
It should work as expected, if you find anything weird let me know

### Challenges/uncertainties
None


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
