### PR TITLE
Change oslo location map toggle to switch GRB instead of the inverse

### DIFF
--- a/.changeset/shaggy-elephants-raise.md
+++ b/.changeset/shaggy-elephants-raise.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Invert oslo-location toggle to be 'GRB' in place of 'Open Streetmap'

--- a/addon/components/location-plugin/map.gts
+++ b/addon/components/location-plugin/map.gts
@@ -230,7 +230,7 @@ class MapWrapper extends Component<MapWrapperSig> {
 
 export default class LocationPluginMapComponent extends Component<Signature> {
   @tracked vertices: GlobalCoordinates[] = [];
-  @tracked useOpenStreetMaps = false;
+  @tracked useGRB = true;
 
   // Use untracked properties as otherwise the map jumps to any area or location we pick
   existingAreaBounds = generateBoundsFromShape(this.args.existingArea);
@@ -275,7 +275,7 @@ export default class LocationPluginMapComponent extends Component<Signature> {
   }
 
   get tileProvider() {
-    if (this.useOpenStreetMaps) {
+    if (!this.useGRB) {
       return TILE_PROVIDER_CONSTANTS.OPEN_STREET_MAP;
     } else {
       return TILE_PROVIDER_CONSTANTS.GRB;
@@ -331,10 +331,11 @@ export default class LocationPluginMapComponent extends Component<Signature> {
             as |c|
           >
             <c.content>
-              <AuToggleSwitch @onChange={{set this 'useOpenStreetMaps'}}>
-                <p class='au-u-para-tiny'>{{t
-                    'location-plugin.use-open-street-map'
-                  }}</p>
+              <AuToggleSwitch
+                @checked={{this.useGRB}}
+                @onChange={{set this 'useGRB'}}
+              >
+                <p class='au-u-para-tiny'>{{t 'location-plugin.use-grb'}}</p>
               </AuToggleSwitch>
             </c.content>
           </AuCard>

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -434,7 +434,7 @@ lmb-plugin:
 
 location-plugin:
   insert-placeholder: Insert location placeholder
-  use-open-street-map: OpenStreetMap
+  use-grb: GRB
   modal:
     insert: Insert location
     edit: Edit location

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -431,7 +431,7 @@ lmb-plugin:
 
 location-plugin:
   insert-placeholder: Voeg locatie-placeholder in
-  use-open-street-map: OpenStreetMap
+  use-grb: GRB
   modal:
     insert: Locatie invoegen
     edit: Bewerk locatie


### PR DESCRIPTION
### Overview
Switch toggles GRB on or off instead of OpenStreetmap on or off.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-6064

### Setup
N/A

### How to test/reproduce
Open the location plugin and check that it says the correct thing.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
