### PR TITLE
Add optional explicit subject to link locations to

### DIFF
--- a/.changeset/strange-queens-mix.md
+++ b/.changeset/strange-queens-mix.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add option to explicitly configure subject to link locations to

--- a/addon/components/location-plugin/insert-location-placeholder.gts
+++ b/addon/components/location-plugin/insert-location-placeholder.gts
@@ -52,12 +52,11 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
     const uri = `http://data.lblod.info/variables/${
       this.args.templateMode ? '--ref-uuid4-' : ''
     }${uuidv4()}`;
-    replaceSelectionWithLocation(
-      this.controller,
-      uri,
-      undefined,
-      this.args.config.subjectTypesToLinkTo,
-    );
+    replaceSelectionWithLocation({
+      controller: this.controller,
+      subject: uri,
+      subjectTypes: this.args.config.subjectTypesToLinkTo,
+    });
   }
 
   <template>

--- a/addon/components/location-plugin/insert-location-placeholder.gts
+++ b/addon/components/location-plugin/insert-location-placeholder.gts
@@ -56,6 +56,7 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
       controller: this.controller,
       subject: uri,
       subjectTypes: this.args.config.subjectTypesToLinkTo,
+      explicitSubjectToLinkTo: this.args.config.explicitSubjectToLinkTo,
     });
   }
 

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -283,13 +283,13 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
         // if they exist
         const newExternalTriples: FullTriple[] = (
           locNode.attrs.externalTriples as FullTriple[]
-        ).slice();
-        for (const tr of newExternalTriples) {
+        ).map((tr) => {
           if (PROV('atLocation').matches(tr.predicate)) {
-            tr.object = df.namedNode(toInsert.uri);
+            return { ...tr, object: df.namedNode(toInsert.uri) };
+          } else {
+            return tr;
           }
-        }
-        // update the location value and the external triples
+        }); // update the location value and the external triples
         this.controller.withTransaction((tr) => {
           return transactionCombinator(
             this.controller.activeEditorState,

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -35,6 +35,9 @@ import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transactio
 import { updateSubject } from '@lblod/ember-rdfa-editor/plugins/rdfa-info/utils';
 import { replaceSelectionWithLocation } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/_private/utils/node-utils';
 import type { Option } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import type { FullTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
+import { PROV } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 
 export type CurrentLocation = Address | GlobalCoordinates | undefined;
 
@@ -274,13 +277,27 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
     if (toInsert) {
       this.modalOpen = false;
       if (this.selectedLocationNode) {
-        // Update, while keeping backlinks intact
-        const { pos } = this.selectedLocationNode;
+        const df = new SayDataFactory();
+        const { pos, value: locNode } = this.selectedLocationNode;
+        // The location's subject has likely changed, so we should update the external links too
+        // if they exist
+        const newExternalTriples: FullTriple[] = (
+          locNode.attrs.externalTriples as FullTriple[]
+        ).slice();
+        for (const tr of newExternalTriples) {
+          if (PROV('atLocation').matches(tr.predicate)) {
+            tr.object = df.namedNode(toInsert.uri);
+          }
+        }
+        // update the location value and the external triples
         this.controller.withTransaction((tr) => {
           return transactionCombinator(
             this.controller.activeEditorState,
-            tr.setNodeAttribute(pos, 'value', toInsert),
+            tr
+              .setNodeAttribute(pos, 'value', toInsert)
+              .setNodeAttribute(pos, 'externalTriples', newExternalTriples),
           )([
+            // Update the subject uri, while keeping backlinks intact
             updateSubject({
               pos,
               targetSubject: toInsert.uri,

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -281,6 +281,8 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
         const { pos, value: locNode } = this.selectedLocationNode;
         // The location's subject has likely changed, so we should update the external links too
         // if they exist
+        // NOTE: It's VERY important that this is done without mutating the triple objects
+        // otherwise the attributes will not update as expected when undo-ing
         const newExternalTriples: FullTriple[] = (
           locNode.attrs.externalTriples as FullTriple[]
         ).map((tr) => {

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -297,6 +297,7 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
           subject: toInsert.uri,
           toInsert,
           subjectTypes: this.args.config.subjectTypesToLinkTo,
+          explicitSubjectToLinkTo: this.args.config.explicitSubjectToLinkTo,
         });
       }
     }

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -292,12 +292,12 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
         });
       } else {
         // Insert
-        replaceSelectionWithLocation(
-          this.controller,
-          toInsert.uri,
+        replaceSelectionWithLocation({
+          controller: this.controller,
+          subject: toInsert.uri,
           toInsert,
-          this.args.config.subjectTypesToLinkTo,
-        );
+          subjectTypes: this.args.config.subjectTypesToLinkTo,
+        });
       }
     }
   }

--- a/addon/plugins/location-plugin/_private/utils/node-utils.ts
+++ b/addon/plugins/location-plugin/_private/utils/node-utils.ts
@@ -13,24 +13,36 @@ import {
 import { Area, Place } from './geo-helpers';
 import { Address } from './address-helpers';
 
+interface ReplaceSelectionWithLocationArgs {
+  /** SayController */
+  controller: SayController;
+  /** The uri of the Location resource */
+  subject: string;
+  /** The object representing the location to insert */
+  toInsert?: Place | Address | Area;
+  /**
+   * A list of Resources, each will be looked at in turn to compare the
+   * `rdf:type` of the resource, if no parent is found matching the first, then the second will be
+   * used, etc.
+   *
+   * If found, the location will be linked to that resource using prov:atLocation
+   */
+  subjectTypes?: Resource[];
+}
+
 /**
  * Creates an 'OSLO location' node in place of the selection, along with the RDFa to create a triple
  * with the nearest parent of one of the passed types as the subject and the predicate
  * prov:atLocation. This doesn't work well with the RDFa tools, but since refactoring is required to
  * clean up the RDFa structure inherited from variables and to make it work well with 'undo', this
  * work was put off until then.
- * @param controller - SayController
- * @param toInsert - The object representing the location to insert
- * @param subjectTypes - A list of Resources, each will be looked at in turn to compare the
- * `rdf:type` of the resource, if no parent is found matching the first, then the second will be
- * used, etc.
  */
-export function replaceSelectionWithLocation(
-  controller: SayController,
-  subject: string,
-  toInsert?: Place | Address | Area,
-  subjectTypes?: Resource[],
-) {
+export function replaceSelectionWithLocation({
+  controller,
+  subject,
+  toInsert,
+  subjectTypes,
+}: ReplaceSelectionWithLocationArgs) {
   let resourceToLink: { pos: number; node: PNode } | undefined;
   subjectTypes?.forEach((subjectType) => {
     if (!resourceToLink) {

--- a/addon/plugins/location-plugin/_private/utils/node-utils.ts
+++ b/addon/plugins/location-plugin/_private/utils/node-utils.ts
@@ -1,5 +1,13 @@
-import { SayController, NodeSelection, PNode } from '@lblod/ember-rdfa-editor';
-import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
+import {
+  SayController,
+  NodeSelection,
+  PNode,
+  RdfaAttrs,
+} from '@lblod/ember-rdfa-editor';
+import {
+  SayDataFactory,
+  sayDataFactory,
+} from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   PROV,
   RDF,
@@ -12,7 +20,9 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
 import { Area, Place } from './geo-helpers';
 import { Address } from './address-helpers';
+import { FullTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 
+const df = new SayDataFactory();
 interface ReplaceSelectionWithLocationArgs {
   /** SayController */
   controller: SayController;
@@ -48,9 +58,6 @@ export function replaceSelectionWithLocation({
   subjectTypes,
   explicitSubjectToLinkTo,
 }: ReplaceSelectionWithLocationArgs) {
-  if (explicitSubjectToLinkTo) {
-    console.log('EXPLICIT SUBJECT RECIEVED', explicitSubjectToLinkTo);
-  }
   let resourceToLink: { pos: number; node: PNode } | undefined;
   subjectTypes?.forEach((subjectType) => {
     if (!resourceToLink) {
@@ -79,7 +86,16 @@ export function replaceSelectionWithLocation({
           ),
         },
       ];
-
+  let externalTriples: FullTriple[];
+  if (explicitSubjectToLinkTo) {
+    externalTriples = [
+      {
+        subject: df.namedNode(explicitSubjectToLinkTo),
+        predicate: PROV('atLocation').full,
+        object: df.namedNode(subject),
+      },
+    ];
+  }
   controller.withTransaction((tr) => {
     tr.replaceSelectionWith(
       controller.schema.node('oslo_location', {
@@ -89,7 +105,8 @@ export function replaceSelectionWithLocation({
         value: toInsert,
         properties: [],
         backlinks,
-      }),
+        externalTriples,
+      } satisfies RdfaAttrs & { value: Place | Address | Area | undefined }),
     );
     if (tr.selection.$anchor.nodeBefore) {
       const resolvedPos = tr.doc.resolve(

--- a/addon/plugins/location-plugin/_private/utils/node-utils.ts
+++ b/addon/plugins/location-plugin/_private/utils/node-utils.ts
@@ -28,6 +28,10 @@ interface ReplaceSelectionWithLocationArgs {
    * If found, the location will be linked to that resource using prov:atLocation
    */
   subjectTypes?: Resource[];
+  /**
+   * If present, the location will be linked to this uri using prov:atLocation using external triples.
+   */
+  explicitSubjectToLinkTo?: string;
 }
 
 /**
@@ -42,7 +46,11 @@ export function replaceSelectionWithLocation({
   subject,
   toInsert,
   subjectTypes,
+  explicitSubjectToLinkTo,
 }: ReplaceSelectionWithLocationArgs) {
+  if (explicitSubjectToLinkTo) {
+    console.log('EXPLICIT SUBJECT RECIEVED', explicitSubjectToLinkTo);
+  }
   let resourceToLink: { pos: number; node: PNode } | undefined;
   subjectTypes?.forEach((subjectType) => {
     if (!resourceToLink) {

--- a/addon/plugins/location-plugin/node.ts
+++ b/addon/plugins/location-plugin/node.ts
@@ -49,6 +49,7 @@ export interface LocationPluginConfig {
   defaultPlaceUriRoot: string;
   defaultPointUriRoot: string;
   subjectTypesToLinkTo?: Resource[];
+  explicitSubjectToLinkTo?: string;
   additionalRDFTypes?: NamedNode[];
 }
 

--- a/addon/plugins/location-plugin/utils/node-utils.ts
+++ b/addon/plugins/location-plugin/utils/node-utils.ts
@@ -21,10 +21,10 @@ export function replaceSelectionWithLocation(
   toInsert: Place | Address | Area,
   subjectTypes?: Resource[],
 ) {
-  return replaceSelectionWithLocationInternal(
+  return replaceSelectionWithLocationInternal({
     controller,
-    toInsert.uri,
+    subject: toInsert.uri,
     toInsert,
     subjectTypes,
-  );
+  });
 }

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -355,6 +355,7 @@ export default class BesluitSampleController extends Controller {
         defaultAddressUriRoot:
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
         subjectTypesToLinkTo: [BESLUIT('Artikel'), BESLUIT('Besluit')],
+        explicitSubjectToLinkTo: 'http://example.org/foo-decision',
         additionalRDFTypes: [
           sayDataFactory.namedNode(
             'https://data.vlaanderen.be/ns/mobiliteit#Zone',


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

For usecases like cipal, there is no relevant subject present to link the location to, since their documents do not contain the decision or article nodes.
So this pr adds a config option which allows you to link all locations to an explicit subject, in a similar way as the decision-topic plugin and others work.

As part of the process, I refactored the replaceSelectionWithLocation function to take named args. That's a separate commit, so you can see meaningful diffs if you filter it out.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->
https://binnenland.atlassian.net/browse/GN-6074

https://github.com/lblod/frontend-embeddable-notule-editor/pull/288


### Setup
<!-- PR dependencies -->
<!-- override snippets -->
`pnpm start`

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

The besluit-sample page of the dummy app has an explicit subject configured as `http://example.org/foo-decision`

Check that all operations with locations produce a triple which links the location to that subject using the prov:atLocation predicate.

It should also not intervene with the subjectTypesToLinkTo logic
### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness

- [x] changelog
- [x] npm lint
- [x] no new deprecations
