### PR TITLE
Add required argument to besluit type select to mark label

### DIFF
--- a/.changeset/two-olives-explode.md
+++ b/.changeset/two-olives-explode.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add a way to set the required attribute of the label of the besluit type select

--- a/addon/components/besluit-type-plugin/besluit-type-form.gts
+++ b/addon/components/besluit-type-plugin/besluit-type-form.gts
@@ -8,6 +8,7 @@ interface Sig {
     types: BesluitType[];
     selectedType?: BesluitTypeInstance;
     setType: (selected: BesluitTypeInstance) => void;
+    required?: boolean;
   };
   Element: HTMLDivElement;
 }
@@ -44,6 +45,7 @@ export default class BesluitTypePluginBesluitTypeSelectComponent extends Compone
         @onchange={{this.updateParentType}}
         @selected={{@selectedType.parent}}
         @showWarningWhenEmpty={{false}}
+        @required={{@required}}
       />
       {{#if @selectedType.parent.subTypes.length}}
         <BesluitTypeSelect
@@ -52,6 +54,7 @@ export default class BesluitTypePluginBesluitTypeSelectComponent extends Compone
           @onchange={{this.updateSubType}}
           @selected={{@selectedType.subType}}
           @showWarningWhenEmpty={{true}}
+          @required={{@required}}
         />
       {{/if}}
       {{#if @selectedType.subType.subTypes.length}}
@@ -61,6 +64,7 @@ export default class BesluitTypePluginBesluitTypeSelectComponent extends Compone
           @onchange={{this.updateSubSubType}}
           @selected={{@selectedType.subSubType}}
           @showWarningWhenEmpty={{true}}
+          @required={{@required}}
         />
       {{/if}}
     </div>

--- a/addon/components/besluit-type-plugin/besluit-type-select.gts
+++ b/addon/components/besluit-type-plugin/besluit-type-select.gts
@@ -15,6 +15,7 @@ interface Sig {
     selected?: BesluitType;
     showWarningWhenEmpty: boolean;
     onchange: (selected: BesluitType) => void;
+    required?: boolean;
   };
   Element: HTMLDivElement;
 }
@@ -43,7 +44,7 @@ export default class BesluitTypePluginBesluitTypeSelectComponent extends Compone
   <template>
     <div ...attributes>
       {{#let (uuidv4) as |id|}}
-        <AuLabel for={{id}}>
+        <AuLabel for={{id}} @required={{@required}}>
           {{t @fieldNameTranslation}}
         </AuLabel>
         <PowerSelect


### PR DESCRIPTION
### Overview
Add a way to set the required attribute of the label of the besluit type select

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-5974


### Setup
None

### How to test/reproduce
Check that you can set the required attribute on the label via the component

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
