### PR TITLE
Add function to get oslo locations from document

### DIFF
--- a/.changeset/quick-frogs-type.md
+++ b/.changeset/quick-frogs-type.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add function to search the document for oslo locations

--- a/addon/plugins/location-plugin/utils/get-document-locations.ts
+++ b/addon/plugins/location-plugin/utils/get-document-locations.ts
@@ -1,15 +1,68 @@
 import { SayController } from '@lblod/ember-rdfa-editor';
+import { Area, Place } from './geo-helpers';
+import { Address } from './address-helpers';
+
+type locationsWithDistanceType = {
+  location: Place | Address | Area;
+  distance: number;
+};
+
+type locationMetadataType = {
+  [locationUri: string]: { ocurrences: number; distance: number };
+};
 
 export default function getDocumentLocations(controller: SayController) {
   const state = controller.mainEditorState;
   const doc = state.doc;
-  const locations: (Place | Address | Area)[] = [];
-  doc.descendants((node) => {
+  const locationsWithDistance: locationsWithDistanceType[] = [];
+  const { selection } = controller.mainEditorState;
+  doc.descendants((node, pos) => {
     if (node.type.name === 'oslo_location') {
-      locations.push(node.attrs.value);
+      const distance = Math.abs(pos - selection.from);
+      locationsWithDistance.push({
+        location: node.attrs.value,
+        distance: distance,
+      });
       return false;
     }
     return true;
   });
+  const locationMetadata: locationMetadataType = {};
+  const locationsDedup: locationsWithDistanceType[] = [];
+  for (const locationWithDistance of locationsWithDistance) {
+    const uri =
+      (locationWithDistance.location as Address).belgianAddressUri ||
+      locationWithDistance.location.uri;
+    if (!locationMetadata[uri]) {
+      locationMetadata[uri] = {
+        ocurrences: 1,
+        distance: locationWithDistance.distance,
+      };
+      locationsDedup.push(locationWithDistance);
+    } else {
+      locationMetadata[uri].ocurrences++;
+      if (locationWithDistance.distance < locationMetadata[uri].distance) {
+        locationMetadata[uri].distance = locationWithDistance.distance;
+      }
+    }
+  }
+
+  const locations = locationsDedup
+    .sort((a, b) => {
+      const uriA = (a.location as Address).belgianAddressUri || a.location.uri;
+      const uriB = (b.location as Address).belgianAddressUri || b.location.uri;
+      if (
+        locationMetadata[uriA].ocurrences === locationMetadata[uriB].ocurrences
+      ) {
+        return (
+          locationMetadata[uriA].distance - locationMetadata[uriB].distance
+        );
+      } else {
+        return (
+          locationMetadata[uriB].ocurrences - locationMetadata[uriA].ocurrences
+        );
+      }
+    })
+    .map((locationWithPos) => locationWithPos.location);
   return locations;
 }

--- a/addon/plugins/location-plugin/utils/get-document-locations.ts
+++ b/addon/plugins/location-plugin/utils/get-document-locations.ts
@@ -28,7 +28,7 @@ export default function getDocumentLocations(controller: SayController) {
     return true;
   });
   const locationMetadata: locationMetadataType = {};
-  const locationsDedup: locationsWithDistanceType[] = [];
+  const locationsDedup: (Place | Address | Area)[] = [];
   for (const locationWithDistance of locationsWithDistance) {
     const uri =
       (locationWithDistance.location as Address).belgianAddressUri ||
@@ -38,7 +38,7 @@ export default function getDocumentLocations(controller: SayController) {
         ocurrences: 1,
         distance: locationWithDistance.distance,
       };
-      locationsDedup.push(locationWithDistance);
+      locationsDedup.push(locationWithDistance.location);
     } else {
       locationMetadata[uri].ocurrences++;
       if (locationWithDistance.distance < locationMetadata[uri].distance) {
@@ -47,22 +47,18 @@ export default function getDocumentLocations(controller: SayController) {
     }
   }
 
-  const locations = locationsDedup
-    .sort((a, b) => {
-      const uriA = (a.location as Address).belgianAddressUri || a.location.uri;
-      const uriB = (b.location as Address).belgianAddressUri || b.location.uri;
-      if (
-        locationMetadata[uriA].ocurrences === locationMetadata[uriB].ocurrences
-      ) {
-        return (
-          locationMetadata[uriA].distance - locationMetadata[uriB].distance
-        );
-      } else {
-        return (
-          locationMetadata[uriB].ocurrences - locationMetadata[uriA].ocurrences
-        );
-      }
-    })
-    .map((locationWithPos) => locationWithPos.location);
+  const locations = locationsDedup.sort((a, b) => {
+    const uriA = (a as Address).belgianAddressUri || a.uri;
+    const uriB = (b as Address).belgianAddressUri || b.uri;
+    if (
+      locationMetadata[uriA].ocurrences === locationMetadata[uriB].ocurrences
+    ) {
+      return locationMetadata[uriA].distance - locationMetadata[uriB].distance;
+    } else {
+      return (
+        locationMetadata[uriB].ocurrences - locationMetadata[uriA].ocurrences
+      );
+    }
+  });
   return locations;
 }

--- a/addon/plugins/location-plugin/utils/get-document-locations.ts
+++ b/addon/plugins/location-plugin/utils/get-document-locations.ts
@@ -1,21 +1,20 @@
-import { SayController } from '@lblod/ember-rdfa-editor';
+import { EditorState } from '@lblod/ember-rdfa-editor';
 import { Area, Place } from './geo-helpers';
 import { Address } from './address-helpers';
 
-type locationsWithDistanceType = {
+type LocationsWithDistanceType = {
   location: Place | Address | Area;
   distance: number;
 };
 
-type locationMetadataType = {
+type LocationMetadataType = {
   [locationUri: string]: { ocurrences: number; distance: number };
 };
 
-export default function getDocumentLocations(controller: SayController) {
-  const state = controller.mainEditorState;
+export default function getDocumentLocations(state: EditorState) {
   const doc = state.doc;
-  const locationsWithDistance: locationsWithDistanceType[] = [];
-  const { selection } = controller.mainEditorState;
+  const locationsWithDistance: LocationsWithDistanceType[] = [];
+  const selection = state.selection;
   doc.descendants((node, pos) => {
     if (node.type.name === 'oslo_location') {
       const distance = Math.abs(pos - selection.from);
@@ -27,7 +26,7 @@ export default function getDocumentLocations(controller: SayController) {
     }
     return true;
   });
-  const locationMetadata: locationMetadataType = {};
+  const locationMetadata: LocationMetadataType = {};
   const locationsDedup: (Place | Address | Area)[] = [];
   for (const locationWithDistance of locationsWithDistance) {
     const uri =

--- a/addon/plugins/location-plugin/utils/get-document-locations.ts
+++ b/addon/plugins/location-plugin/utils/get-document-locations.ts
@@ -1,0 +1,15 @@
+import { SayController } from '@lblod/ember-rdfa-editor';
+
+export default function getDocumentLocations(controller: SayController) {
+  const state = controller.mainEditorState;
+  const doc = state.doc;
+  const locations: (Place | Address | Area)[] = [];
+  doc.descendants((node) => {
+    if (node.type.name === 'oslo_location') {
+      locations.push(node.attrs.value);
+      return false;
+    }
+    return true;
+  });
+  return locations;
+}


### PR DESCRIPTION
### Overview
Added a function that scans the document for all the oslo locations and returns the place/address/area associated with them

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6104


### Setup
None

### How to test/reproduce
To be tested with Kobe work but you can add it to any button and check that it returns the appropiate data

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
