### PR TITLE
Allow to modify renderInPlace for besluit topic form component

### DIFF
--- a/.changeset/orange-owls-refuse.md
+++ b/.changeset/orange-owls-refuse.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Allow to modify render in place for besluit topic select

--- a/addon/components/besluit-topic-plugin/besluit-topic-select.hbs
+++ b/addon/components/besluit-topic-plugin/besluit-topic-select.hbs
@@ -1,7 +1,6 @@
 {{! @glint-nocheck: not typesafe yet }}
 <div ...attributes>
   <PowerSelectMultiple
-    @renderInPlace={{true}}
     @searchEnabled={{true}}
     @searchMessage={{t 'besluit-topic-plugin.search-message'}}
     @noMatchesMessage={{t 'besluit-topic-plugin.no-matches-message'}}
@@ -9,6 +8,7 @@
     @options={{this.besluitTopics}}
     @selected={{@selected}}
     @onChange={{@onchange}}
+    @renderInPlace={{this.renderInPlace}}
     as |besluitTopic|
   >
     {{besluitTopic.label}}

--- a/addon/components/besluit-topic-plugin/besluit-topic-select.ts
+++ b/addon/components/besluit-topic-plugin/besluit-topic-select.ts
@@ -8,6 +8,7 @@ type Args = {
   besluitTopics: BesluitTopic[];
   selected?: BesluitTopic[];
   onchange: (topic: BesluitTopic[]) => void;
+  renderInPlace?: boolean;
 };
 
 export default class BesluitTopicSelectComponent extends Component<Args> {
@@ -30,5 +31,9 @@ export default class BesluitTopicSelectComponent extends Component<Args> {
     return this.args.besluitTopics.filter((besluitTopic) =>
       besluitTopic.label.toLowerCase().includes(lowerTerm),
     );
+  }
+  get renderInPlace() {
+    if (this.args.renderInPlace === false) return false;
+    return true;
   }
 }


### PR DESCRIPTION
### Overview
In order to solve responsiveness problems in GN we have to set the renderInPlace attribute of the besluit topic selects to false, this PR allows that

##### connected issues and PRs:
https://github.com/lblod/frontend-gelinkt-notuleren/pull/916


### Setup
None

### How to test/reproduce
Test that everything works as before and now you can get the topic selects to have renderInPlace false

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
