### PR TITLE
Location context actions

### DIFF
--- a/.changeset/healthy-dodos-hug.md
+++ b/.changeset/healthy-dodos-hug.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Add "Insert address", "Insert point on the map" and "Insert area" contextual actions for the location nodes

--- a/.changeset/unlucky-snakes-complain.md
+++ b/.changeset/unlucky-snakes-complain.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Add context actions for location nodes: Insert address, insert place on map, insert area

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -47,7 +47,7 @@ import {
 export type CurrentLocation = Address | GlobalCoordinates | undefined;
 
 function updateFromNode<T extends Address | Place | Area, R>(
-  Class: new (...args: unknown[]) => T,
+  Class: new (...args: never[]) => T,
   extractFunc: (current: T) => R,
   defaultValue?: R,
 ) {
@@ -192,14 +192,14 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
     openLocationModal(this.controller.activeEditorView, type);
   }
 
-  get locationType() {
+  get locationType(): LocationType {
     return (
       // If the modal was not opened trough the context actions, this will be null
       getLocationModalsPluginState(this.controller.activeEditorState)
         ?.locationType ??
-      updateFromNode(Place, () => 'place')(this) ??
-      updateFromNode(Area, () => 'area')(this) ??
-      updateFromNode(Address, () => 'address')(this) ??
+      updateFromNode<Place, 'place'>(Place, () => 'place')(this) ??
+      updateFromNode<Area, 'area'>(Area, () => 'area')(this) ??
+      updateFromNode<Address, 'address'>(Address, () => 'address')(this) ??
       this.locationTypes[0]
     );
   }

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -38,6 +38,11 @@ import type { Option } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option
 import type { FullTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import { PROV } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
+import {
+  closeLocationModal,
+  getLocationModalsPluginState,
+  openLocationModal,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin';
 
 export type CurrentLocation = Address | GlobalCoordinates | undefined;
 
@@ -71,7 +76,6 @@ interface Signature {
 
 export default class LocationPluginInsertComponent extends Component<Signature> {
   @service declare intl: IntlService;
-  @tracked modalOpen = false;
   @tracked chosenPoint: GeoPos | undefined;
   @tracked isLoading = false;
 
@@ -121,19 +125,6 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
     update: updateFromNode(Area, (area) => area.shape.locations),
   })
   savedArea: GeoPos[] | undefined;
-
-  @trackedReset({
-    memo: 'modalOpen',
-    update(component: LocationPluginInsertComponent) {
-      return (
-        updateFromNode(Place, () => 'place')(component) ??
-        updateFromNode(Area, () => 'area')(component) ??
-        updateFromNode(Address, () => 'address')(component) ??
-        component.locationTypes[0]
-      );
-    },
-  })
-  declare locationType: LocationType;
 
   @trackedReset({
     memo: 'controller.activeEditorState',
@@ -191,9 +182,26 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
     }
   }
 
+  get modalOpen() {
+    return getLocationModalsPluginState(this.controller.activeEditorState)
+      ?.modalOpen;
+  }
+
   @action
   setLocationType(type: LocationType) {
-    this.locationType = type;
+    openLocationModal(this.controller.activeEditorView, type);
+  }
+
+  get locationType() {
+    return (
+      // If the modal was not opened trough the context actions, this will be null
+      getLocationModalsPluginState(this.controller.activeEditorState)
+        ?.locationType ??
+      updateFromNode(Place, () => 'place')(this) ??
+      updateFromNode(Area, () => 'area')(this) ??
+      updateFromNode(Address, () => 'address')(this) ??
+      this.locationTypes[0]
+    );
   }
 
   @action
@@ -212,12 +220,12 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
   @action
   closeModal() {
     this.chosenPoint = undefined;
-    this.modalOpen = false;
+    closeLocationModal(this.controller.activeEditorView);
   }
 
   @action
   insertOrEditAddress() {
-    this.modalOpen = true;
+    openLocationModal(this.controller.activeEditorView, 'address');
   }
 
   @action
@@ -275,7 +283,7 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
       });
     }
     if (toInsert) {
-      this.modalOpen = false;
+      closeLocationModal(this.controller.activeEditorView);
       if (this.selectedLocationNode) {
         const df = new SayDataFactory();
         const { pos, value: locNode } = this.selectedLocationNode;

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -1,92 +1,54 @@
-import {
-  EditorState,
-  NodeSelection,
-  Transaction,
-} from '@lblod/ember-rdfa-editor';
-import { fetchCodeListOptions } from '../utils/fetch-data';
-import { findParentNode } from '@curvenote/prosemirror-utils';
-import {
-  getOutgoingTriple,
-  hasOutgoingNamedNodeTriple,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
-import {
-  EXT,
-  MOBILITEIT,
-  RDF,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
-import {
-  ZONALITY_OPTIONS,
-  ZONALITY_OPTIONS_LEGACY,
-} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/constants';
-import { ProseParser } from '@lblod/ember-rdfa-editor';
-import { getActiveEditableNode } from '@lblod/ember-rdfa-editor/plugins/editable-node';
-import { isRdfaAttrs } from '@lblod/ember-rdfa-editor/core/rdfa-types';
+import { EditorState, NodeSelection } from '@lblod/ember-rdfa-editor';
 import { v4 as uuidv4 } from 'uuid';
 import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 import IntlService from 'ember-intl/services/intl';
-import { select } from '@ember/test-helpers';
+import { openLocationModalCommand } from '..';
+import { LocationType } from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/map';
 
-const locationActionsGroupId = 'locatie-fde16805-5b4d-4595-9742-e434d477ee1d';
-
-function createInsertPlaceDescriptionCommand(label: string) {
-  return (state: EditorState, dispatch: (tr: Transaction) => void) => {
-    return true;
-    if (dispatch) {
-      let htmlToInsert = label;
-      htmlToInsert = wrapVariableInHighlight(htmlToInsert);
-      const domParser = new DOMParser();
-      const htmlNode = domParser.parseFromString(htmlToInsert, 'text/html');
-      const contentFragment = ProseParser.fromSchema(state.schema).parseSlice(
-        htmlNode,
-        {
-          preserveWhitespace: false,
-        },
-      );
-
-      const tr = state.tr;
-      const startPos = tr.selection.from;
-      tr.replaceSelection(contentFragment);
-
-      let highlightPos: number | null = null;
-
-      contentFragment.content.descendants((child, pos) => {
-        if (highlightPos !== null) {
-          return false;
-        }
-        if (child.type.name === state.schema.nodes.placeholder.name) {
-          highlightPos = startPos + pos;
-          return false;
-        }
-        return true;
-      });
-
-      if (highlightPos !== null) {
-        tr.setSelection(NodeSelection.create(tr.doc, highlightPos));
-      }
-      dispatch(tr);
-    }
-    return true;
-  };
-}
+const otherElementsGroupId =
+  'other-elements-e01f46a0-b323-4add-8035-d81dc2e8578d';
 
 export function getContextualActions() {
   return async function (state: EditorState) {
     const t = getTranslationFunction(state);
 
-    // TODO: translate!
-    const options = [
-      { label: 'Adres invoegen', icon: 'location' },
-      { label: 'Punt op de kaart invoegen', icon: 'location-gps' },
-      { label: 'Gebied invoegen', icon: 'area' },
-      { label: 'Perceel invoegen', icon: 'focus' },
+    const options: {
+      label: string;
+      locationType: LocationType;
+      icon: string;
+    }[] = [
+      {
+        label: t(
+          'location-plugin.context-actions.insert-address',
+          'Adres invoegen',
+        ),
+        locationType: 'address',
+        icon: 'location',
+      },
+      {
+        label: t(
+          'location-plugin.context-actions.insert-point-on-map',
+          'Punt op de kaart invoegen',
+        ),
+        locationType: 'place',
+        icon: 'location-gps',
+      },
+      {
+        label: t(
+          'location-plugin.context-actions.insert-area',
+          'Gebied invoegen',
+        ),
+        locationType: 'area',
+        icon: 'area',
+      },
     ];
 
     return options.map((option) => {
       return {
         ...option,
         id: uuidv4(),
-        group: locationActionsGroupId,
-        command: createInsertPlaceDescriptionCommand(option.label),
+        group: otherElementsGroupId,
+        command: openLocationModalCommand(option.locationType),
       };
     });
   };
@@ -105,9 +67,9 @@ export function getContextualActionGroups() {
     return contextualGroupIsVisible(state)
       ? [
           {
-            id: locationActionsGroupId,
+            id: otherElementsGroupId,
             label: getTranslationFunction(state)(
-              'variable.location.label',
+              'location-plugin.context-actions.other-elements',
               'Andere elementen',
             ),
           },

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -26,8 +26,7 @@ import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/u
 import IntlService from 'ember-intl/services/intl';
 import { select } from '@ember/test-helpers';
 
-const locationActionsGroupId =
-  'locatie-fde16805-5b4d-4595-9742-e434d477ee1d';
+const locationActionsGroupId = 'locatie-fde16805-5b4d-4595-9742-e434d477ee1d';
 
 function createInsertPlaceDescriptionCommand(label: string) {
   return (state: EditorState, dispatch: (tr: Transaction) => void) => {
@@ -73,20 +72,21 @@ function createInsertPlaceDescriptionCommand(label: string) {
 export function getContextualActions() {
   return async function (state: EditorState) {
     const t = getTranslationFunction(state);
+
     // TODO: translate!
     const options = [
-      {label: 'Adres invoegen'},
-      {label: 'Punt op de kaart invoegen'},
-      {label: 'Gebied invoegen'},
-      {label: 'Perceel invoegen'}
-    ]
+      { label: 'Adres invoegen', icon: 'location' },
+      { label: 'Punt op de kaart invoegen', icon: 'location-gps' },
+      { label: 'Gebied invoegen', icon: 'area' },
+      { label: 'Perceel invoegen', icon: 'focus' },
+    ];
 
-    return options.map(({label}) => {
+    return options.map((option) => {
       return {
+        ...option,
         id: uuidv4(),
-        label,
         group: locationActionsGroupId,
-        command: createInsertPlaceDescriptionCommand(label),
+        command: createInsertPlaceDescriptionCommand(option.label),
       };
     });
   };
@@ -94,7 +94,10 @@ export function getContextualActions() {
 
 function contextualGroupIsVisible(state: EditorState) {
   const { selection } = state;
-  return (selection instanceof NodeSelection && selection.node.type === selection.node.type.schema.nodes['oslo_location']);
+  return (
+    selection instanceof NodeSelection &&
+    selection.node.type === selection.node.type.schema.nodes['oslo_location']
+  );
 }
 
 export function getContextualActionGroups() {

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -1,7 +1,6 @@
 import { EditorState, NodeSelection } from '@lblod/ember-rdfa-editor';
 import { v4 as uuidv4 } from 'uuid';
 import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
-import IntlService from 'ember-intl/services/intl';
 import { openLocationModalCommand } from '..';
 import { LocationType } from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/map';
 
@@ -9,7 +8,7 @@ const otherElementsGroupId =
   'other-elements-e01f46a0-b323-4add-8035-d81dc2e8578d';
 
 export function getContextualActions() {
-  return async function (state: EditorState) {
+  return function (state: EditorState, searchQuery?: string) {
     const t = getTranslationFunction(state);
 
     const options: {
@@ -43,14 +42,20 @@ export function getContextualActions() {
       },
     ];
 
-    return options.map((option) => {
-      return {
-        ...option,
-        id: uuidv4(),
-        group: otherElementsGroupId,
-        command: openLocationModalCommand(option.locationType),
-      };
-    });
+    return options
+      .filter(
+        (option) =>
+          !searchQuery ||
+          option.label.toLocaleLowerCase().includes(searchQuery.toLowerCase()),
+      )
+      .map((option) => {
+        return {
+          ...option,
+          id: uuidv4(),
+          group: otherElementsGroupId,
+          command: openLocationModalCommand(option.locationType),
+        };
+      });
   };
 }
 

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -1,0 +1,114 @@
+import {
+  EditorState,
+  NodeSelection,
+  Transaction,
+} from '@lblod/ember-rdfa-editor';
+import { fetchCodeListOptions } from '../utils/fetch-data';
+import { findParentNode } from '@curvenote/prosemirror-utils';
+import {
+  getOutgoingTriple,
+  hasOutgoingNamedNodeTriple,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import {
+  EXT,
+  MOBILITEIT,
+  RDF,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import {
+  ZONALITY_OPTIONS,
+  ZONALITY_OPTIONS_LEGACY,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/roadsign-regulation-plugin/constants';
+import { ProseParser } from '@lblod/ember-rdfa-editor';
+import { getActiveEditableNode } from '@lblod/ember-rdfa-editor/plugins/editable-node';
+import { isRdfaAttrs } from '@lblod/ember-rdfa-editor/core/rdfa-types';
+import { v4 as uuidv4 } from 'uuid';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
+import IntlService from 'ember-intl/services/intl';
+import { select } from '@ember/test-helpers';
+
+const locationActionsGroupId =
+  'locatie-fde16805-5b4d-4595-9742-e434d477ee1d';
+
+function createInsertPlaceDescriptionCommand(label: string) {
+  return (state: EditorState, dispatch: (tr: Transaction) => void) => {
+    return true;
+    if (dispatch) {
+      let htmlToInsert = label;
+      htmlToInsert = wrapVariableInHighlight(htmlToInsert);
+      const domParser = new DOMParser();
+      const htmlNode = domParser.parseFromString(htmlToInsert, 'text/html');
+      const contentFragment = ProseParser.fromSchema(state.schema).parseSlice(
+        htmlNode,
+        {
+          preserveWhitespace: false,
+        },
+      );
+
+      const tr = state.tr;
+      const startPos = tr.selection.from;
+      tr.replaceSelection(contentFragment);
+
+      let highlightPos: number | null = null;
+
+      contentFragment.content.descendants((child, pos) => {
+        if (highlightPos !== null) {
+          return false;
+        }
+        if (child.type.name === state.schema.nodes.placeholder.name) {
+          highlightPos = startPos + pos;
+          return false;
+        }
+        return true;
+      });
+
+      if (highlightPos !== null) {
+        tr.setSelection(NodeSelection.create(tr.doc, highlightPos));
+      }
+      dispatch(tr);
+    }
+    return true;
+  };
+}
+
+export function getContextualActions() {
+  return async function (state: EditorState) {
+    const t = getTranslationFunction(state);
+    // TODO: translate!
+    const options = [
+      {label: 'Adres invoegen'},
+      {label: 'Punt op de kaart invoegen'},
+      {label: 'Gebied invoegen'},
+      {label: 'Perceel invoegen'}
+    ]
+
+    return options.map(({label}) => {
+      return {
+        id: uuidv4(),
+        label,
+        group: locationActionsGroupId,
+        command: createInsertPlaceDescriptionCommand(label),
+      };
+    });
+  };
+}
+
+function contextualGroupIsVisible(state: EditorState) {
+  const { selection } = state;
+  return (selection instanceof NodeSelection && selection.node.type === selection.node.type.schema.nodes['oslo_location']);
+}
+
+export function getContextualActionGroups() {
+  return function (state: EditorState) {
+    return contextualGroupIsVisible(state)
+      ? [
+          {
+            id: locationActionsGroupId,
+            label: getTranslationFunction(state)(
+              'variable.location.label',
+              'Andere elementen',
+            ),
+          },
+        ]
+      : [];
+  };
+}

--- a/addon/plugins/location-plugin/index.ts
+++ b/addon/plugins/location-plugin/index.ts
@@ -1,0 +1,88 @@
+import {
+  ProsePlugin,
+  PluginKey,
+  EditorState,
+  EditorView,
+  Transaction,
+} from '@lblod/ember-rdfa-editor';
+import { LocationType } from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/map';
+
+type PluginState = {
+  modalOpen: boolean;
+  locationType: LocationType | null;
+};
+
+type LocationModalMeta =
+  | { action: 'open_location_modal'; locationType?: LocationType }
+  | { action: 'close_location_modal' }
+  | undefined;
+
+function isLocationMeta(meta: unknown): meta is LocationModalMeta {
+  if (!meta || typeof meta !== 'object') return false;
+  return 'action' in meta;
+}
+
+export const locationModalsPluginKey = new PluginKey<PluginState>(
+  'LOCATION_MODALS_PLUGIN',
+);
+
+export function closeLocationModal(view: EditorView) {
+  const tr = view.state.tr;
+  tr.setMeta(locationModalsPluginKey, { action: 'close_location_modal' });
+  view.dispatch(tr);
+}
+
+export function openLocationModal(
+  view: EditorView,
+  locationType?: LocationType,
+) {
+  const tr = view.state.tr;
+  tr.setMeta(locationModalsPluginKey, {
+    action: 'open_location_modal',
+    locationType: locationType ?? null,
+  });
+  view.dispatch(tr);
+}
+
+export function openLocationModalCommand(locationType: LocationType) {
+  return function (state: EditorState, dispatch: (tr: Transaction) => void) {
+    const tr = state.tr;
+    tr.setMeta(locationModalsPluginKey, {
+      action: 'open_location_modal',
+      locationType,
+    });
+    dispatch(tr);
+  };
+}
+
+export function locationModalsPlugin() {
+  return new ProsePlugin<PluginState>({
+    key: locationModalsPluginKey,
+    state: {
+      init() {
+        return { modalOpen: false, locationType: null };
+      },
+      apply(tr, pluginState) {
+        const meta = tr.getMeta(locationModalsPluginKey);
+        if (!isLocationMeta(meta)) return pluginState;
+
+        if (meta?.action === 'open_location_modal') {
+          return {
+            modalOpen: true,
+            locationType: meta.locationType ?? null,
+          };
+        } else if (meta?.action === 'close_location_modal') {
+          return { modalOpen: false, locationType: null };
+        } else {
+          return pluginState;
+        }
+      },
+    },
+  });
+}
+
+export function getLocationModalsPluginState(
+  state: EditorState,
+): PluginState | undefined {
+  return locationModalsPluginKey.getState(state);
+}

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@glint/ember-tsc": "^1.5.0",
     "@glint/environment-ember-loose": "^1.5.0",
     "@glint/environment-ember-template-imports": "^1.5.0",
-    "@lblod/ember-rdfa-editor": "13.7.1-dev.4609bb26b21ebbcb34eeaa13e7c0207d7a0c5470",
+    "@lblod/ember-rdfa-editor": "13.7.1-dev.50bc2ce9865c356ab514c4a03011a2876c21a821",
     "@glint/template": "^1.7.7",
     "@rdfjs/to-ntriples": "^3.0.1",
     "@rdfjs/types": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@glint/ember-tsc": "^1.5.0",
     "@glint/environment-ember-loose": "^1.5.0",
     "@glint/environment-ember-template-imports": "^1.5.0",
-    "@lblod/ember-rdfa-editor": "13.7.1-dev.121c9fda9b6cfa329851bccd58446c6d8636a857",
+    "@lblod/ember-rdfa-editor": "13.7.1-dev.4609bb26b21ebbcb34eeaa13e7c0207d7a0c5470",
     "@glint/template": "^1.7.7",
     "@rdfjs/to-ntriples": "^3.0.1",
     "@rdfjs/types": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@glint/ember-tsc": "^1.5.0",
     "@glint/environment-ember-loose": "^1.5.0",
     "@glint/environment-ember-template-imports": "^1.5.0",
-    "@lblod/ember-rdfa-editor": "13.7.1",
+    "@lblod/ember-rdfa-editor": "13.7.1-dev.121c9fda9b6cfa329851bccd58446c6d8636a857",
     "@glint/template": "^1.7.7",
     "@rdfjs/to-ntriples": "^3.0.1",
     "@rdfjs/types": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,8 +189,8 @@ importers:
         specifier: ^1.7.7
         version: 1.7.7
       '@lblod/ember-rdfa-editor':
-        specifier: 13.7.1-dev.4609bb26b21ebbcb34eeaa13e7c0207d7a0c5470
-        version: 13.7.1-dev.4609bb26b21ebbcb34eeaa13e7c0207d7a0c5470(0a1d660f56f52556014e8c7c9cef96eb)
+        specifier: 13.7.1-dev.50bc2ce9865c356ab514c4a03011a2876c21a821
+        version: 13.7.1-dev.50bc2ce9865c356ab514c4a03011a2876c21a821(0a1d660f56f52556014e8c7c9cef96eb)
       '@rdfjs/to-ntriples':
         specifier: ^3.0.1
         version: 3.0.1
@@ -1916,8 +1916,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lblod/ember-rdfa-editor@13.7.1-dev.4609bb26b21ebbcb34eeaa13e7c0207d7a0c5470':
-    resolution: {integrity: sha512-3bYnkH3w04kNcKuE35DfkF56aMzWR5m8nxMpzq8iOdDlf+bG9TvlwKKj55ab9vNgtE4tsFL1KJ5IskghbcK7Bw==}
+  '@lblod/ember-rdfa-editor@13.7.1-dev.50bc2ce9865c356ab514c4a03011a2876c21a821':
+    resolution: {integrity: sha512-u/DQIDd1Rah+LK2Kyw4bIcGPMbRiEbqMNwNmhv7gWWMskjWHJ15wzpCYkflxFXywd/vFpXfJ1EYs7Tyzrwwzvg==}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.11.0 || ^4.2.1
       '@ember/test-helpers': ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
@@ -13057,7 +13057,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lblod/ember-rdfa-editor@13.7.1-dev.4609bb26b21ebbcb34eeaa13e7c0207d7a0c5470(0a1d660f56f52556014e8c7c9cef96eb)':
+  '@lblod/ember-rdfa-editor@13.7.1-dev.50bc2ce9865c356ab514c4a03011a2876c21a821(0a1d660f56f52556014e8c7c9cef96eb)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.17.0(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@4.1.0(@babel/core@7.26.0))(webpack@5.97.1)
       '@codemirror/commands': 6.10.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,8 +189,8 @@ importers:
         specifier: ^1.7.7
         version: 1.7.7
       '@lblod/ember-rdfa-editor':
-        specifier: 13.7.1
-        version: 13.7.1(0a1d660f56f52556014e8c7c9cef96eb)
+        specifier: 13.7.1-dev.121c9fda9b6cfa329851bccd58446c6d8636a857
+        version: 13.7.1-dev.121c9fda9b6cfa329851bccd58446c6d8636a857(0a1d660f56f52556014e8c7c9cef96eb)
       '@rdfjs/to-ntriples':
         specifier: ^3.0.1
         version: 3.0.1
@@ -1916,10 +1916,10 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lblod/ember-rdfa-editor@13.7.1':
-    resolution: {integrity: sha512-busSsEJ2NjSAzropp9gwkAvh/ufocIHDZDmjbWj5M5KScrxqPMttFbvgArqXcb6Ff5kXFs9Yi4pHHf1whHtuFw==}
+  '@lblod/ember-rdfa-editor@13.7.1-dev.121c9fda9b6cfa329851bccd58446c6d8636a857':
+    resolution: {integrity: sha512-ANoFTIF0eICokUbyYqMJRZUPaAWQEoh6ed3a1mXvKFAVozpVQScdvPRvhvD8avi2ec/cNwC388pqY3scvFlcJA==}
     peerDependencies:
-      '@appuniversum/ember-appuniversum': ^3.11.0
+      '@appuniversum/ember-appuniversum': ^4.2.1
       '@ember/test-helpers': ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
       '@glimmer/component': ^1.1.2 || ^2.0.0
       '@glimmer/tracking': ^1.1.2
@@ -4789,6 +4789,15 @@ packages:
       '@glimmer/tracking': '>= 1.1.2'
       '@glint/template': '>= 1.0.0'
       ember-source: ^3.28.0 || ^4.0.0 || >= 5.0.0
+    peerDependenciesMeta:
+      '@glimmer/component':
+        optional: true
+
+  ember-resources@7.0.7:
+    resolution: {integrity: sha512-0tEfLTi9hHNwZaBsTjLf+by+YXHL4Zj2VITLfFkcqJiwHIIsBnOddxtTSrjRmYLJd6L3JXfaMcVdUwT+B050Ww==}
+    peerDependencies:
+      '@glimmer/component': '>= 1.1.2 || >= 2.0.0'
+      '@glint/template': '>= 1.0.0'
     peerDependenciesMeta:
       '@glimmer/component':
         optional: true
@@ -13048,7 +13057,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lblod/ember-rdfa-editor@13.7.1(0a1d660f56f52556014e8c7c9cef96eb)':
+  '@lblod/ember-rdfa-editor@13.7.1-dev.121c9fda9b6cfa329851bccd58446c6d8636a857(0a1d660f56f52556014e8c7c9cef96eb)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.17.0(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@4.1.0(@babel/core@7.26.0))(webpack@5.97.1)
       '@codemirror/commands': 6.10.3
@@ -13083,9 +13092,11 @@ snapshots:
       ember-headless-form: 1.1.1(@babel/core@7.26.0)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(eslint@8.57.1)
       ember-headless-form-yup: 1.0.0(ember-headless-form@1.1.1(@babel/core@7.26.0)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(eslint@8.57.1))(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(yup@1.7.1)
       ember-intl: 7.0.3(@glint/template@1.7.7)(typescript@5.7.3)(webpack@5.97.1)
+      ember-lifeline: 7.0.0(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))
       ember-modifier: 4.2.2(@babel/core@7.26.0)
       ember-power-select: 7.1.2(@babel/core@7.26.0)(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1)
       ember-power-select-with-create: 3.1.0(d7fc878a303f328bd4f014ea553cb9a5)
+      ember-resources: 7.0.7(@babel/core@7.26.0)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)
       ember-source: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1)
       ember-template-imports: 4.4.0
       ember-truth-helpers: 5.0.0
@@ -13697,7 +13708,7 @@ snapshots:
       '@types/ember__string': 3.0.15
       '@types/ember__template': 4.0.7
       '@types/ember__test': 4.0.6(@babel/core@7.26.0)
-      '@types/ember__utils': 4.0.7(@babel/core@7.26.0)
+      '@types/ember__utils': 4.0.7
       '@types/rsvp': 4.0.9
     optional: true
 
@@ -13863,6 +13874,11 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    optional: true
+
+  '@types/ember__utils@4.0.7':
+    dependencies:
+      '@types/ember': 4.0.11
     optional: true
 
   '@types/ember__utils@4.0.7(@babel/core@7.26.0)':
@@ -17476,6 +17492,17 @@ snapshots:
       '@glimmer/tracking': 1.1.2
       '@glint/template': 1.7.7
       ember-source: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1)
+    optionalDependencies:
+      '@glimmer/component': 1.1.2(@babel/core@7.26.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  ember-resources@7.0.7(@babel/core@7.26.0)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7):
+    dependencies:
+      '@embroider/addon-shim': 1.10.2
+      '@embroider/macros': 1.19.7(@babel/core@7.26.0)(@glint/template@1.7.7)
+      '@glint/template': 1.7.7
     optionalDependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,8 +189,8 @@ importers:
         specifier: ^1.7.7
         version: 1.7.7
       '@lblod/ember-rdfa-editor':
-        specifier: 13.7.1-dev.121c9fda9b6cfa329851bccd58446c6d8636a857
-        version: 13.7.1-dev.121c9fda9b6cfa329851bccd58446c6d8636a857(0a1d660f56f52556014e8c7c9cef96eb)
+        specifier: 13.7.1-dev.4609bb26b21ebbcb34eeaa13e7c0207d7a0c5470
+        version: 13.7.1-dev.4609bb26b21ebbcb34eeaa13e7c0207d7a0c5470(0a1d660f56f52556014e8c7c9cef96eb)
       '@rdfjs/to-ntriples':
         specifier: ^3.0.1
         version: 3.0.1
@@ -1916,10 +1916,10 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lblod/ember-rdfa-editor@13.7.1-dev.121c9fda9b6cfa329851bccd58446c6d8636a857':
-    resolution: {integrity: sha512-ANoFTIF0eICokUbyYqMJRZUPaAWQEoh6ed3a1mXvKFAVozpVQScdvPRvhvD8avi2ec/cNwC388pqY3scvFlcJA==}
+  '@lblod/ember-rdfa-editor@13.7.1-dev.4609bb26b21ebbcb34eeaa13e7c0207d7a0c5470':
+    resolution: {integrity: sha512-3bYnkH3w04kNcKuE35DfkF56aMzWR5m8nxMpzq8iOdDlf+bG9TvlwKKj55ab9vNgtE4tsFL1KJ5IskghbcK7Bw==}
     peerDependencies:
-      '@appuniversum/ember-appuniversum': ^4.2.1
+      '@appuniversum/ember-appuniversum': ^3.11.0 || ^4.2.1
       '@ember/test-helpers': ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
       '@glimmer/component': ^1.1.2 || ^2.0.0
       '@glimmer/tracking': ^1.1.2
@@ -13057,7 +13057,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lblod/ember-rdfa-editor@13.7.1-dev.121c9fda9b6cfa329851bccd58446c6d8636a857(0a1d660f56f52556014e8c7c9cef96eb)':
+  '@lblod/ember-rdfa-editor@13.7.1-dev.4609bb26b21ebbcb34eeaa13e7c0207d7a0c5470(0a1d660f56f52556014e8c7c9cef96eb)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.17.0(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@4.1.0(@babel/core@7.26.0))(webpack@5.97.1)
       '@codemirror/commands': 6.10.3
@@ -13691,27 +13691,6 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
-  '@types/ember@4.0.11':
-    dependencies:
-      '@types/ember__application': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__array': 4.0.10(@babel/core@7.26.0)
-      '@types/ember__component': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__controller': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__debug': 4.0.8(@babel/core@7.26.0)
-      '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__error': 4.0.6
-      '@types/ember__object': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__polyfills': 4.0.6
-      '@types/ember__routing': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__runloop': 4.0.10
-      '@types/ember__service': 4.0.9(@babel/core@7.26.0)
-      '@types/ember__string': 3.0.15
-      '@types/ember__template': 4.0.7
-      '@types/ember__test': 4.0.6(@babel/core@7.26.0)
-      '@types/ember__utils': 4.0.7
-      '@types/rsvp': 4.0.9
-    optional: true
-
   '@types/ember@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@types/ember__application': 4.0.11(@babel/core@7.26.0)
@@ -13739,7 +13718,7 @@ snapshots:
   '@types/ember__application@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
-      '@types/ember': 4.0.11
+      '@types/ember': 4.0.11(@babel/core@7.26.0)
       '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
       '@types/ember__object': 4.0.12(@babel/core@7.26.0)
       '@types/ember__owner': 4.0.9
@@ -13841,11 +13820,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@types/ember__runloop@4.0.10':
-    dependencies:
-      '@types/ember': 4.0.11
-    optional: true
-
   '@types/ember__runloop@4.0.10(@babel/core@7.26.0)':
     dependencies:
       '@types/ember': 4.0.11(@babel/core@7.26.0)
@@ -13874,11 +13848,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    optional: true
-
-  '@types/ember__utils@4.0.7':
-    dependencies:
-      '@types/ember': 4.0.11
     optional: true
 
   '@types/ember__utils@4.0.7(@babel/core@7.26.0)':

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -161,9 +161,10 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/legacy-codelist';
 import ContextualActionsContainer from '@lblod/ember-rdfa-editor/components/plugins/contextual-actions/container';
 import {
-  getContextualActionGroups,
-  getContextualActions,
+  getContextualActionGroups as placeDescriptionActionGroups,
+  getContextualActions as placeDescriptionActions,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions';
+import { getContextualActionGroups as locationActionsGroups, getContextualActions as locationActions } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/contextual-actions';
 import { slashCommandsPlugin } from '@lblod/ember-rdfa-editor/plugins/slash-commands/index';
 import Owner from '@ember/owner';
 
@@ -234,8 +235,8 @@ export default class BesluitSampleController extends Controller {
     say: 'https://say.data.gift/ns/',
   };
 
-  contextualActionGetters = [getContextualActions(this.locationOptions)];
-  contextualGroupGetters = [getContextualActionGroups()];
+  contextualActionGetters = [placeDescriptionActions(this.locationOptions), locationActions()];
+  contextualGroupGetters = [placeDescriptionActionGroups(), locationActionsGroups()];
 
   get schema() {
     return new Schema({

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -164,9 +164,13 @@ import {
   getContextualActionGroups as placeDescriptionActionGroups,
   getContextualActions as placeDescriptionActions,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions';
-import { getContextualActionGroups as locationActionsGroups, getContextualActions as locationActions } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/contextual-actions';
+import {
+  getContextualActionGroups as locationActionsGroups,
+  getContextualActions as locationActions,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/contextual-actions';
 import { slashCommandsPlugin } from '@lblod/ember-rdfa-editor/plugins/slash-commands/index';
 import Owner from '@ember/owner';
+import { locationModalsPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin';
 
 export default class BesluitSampleController extends Controller {
   queryParams = ['editableNodes'];
@@ -225,6 +229,7 @@ export default class BesluitSampleController extends Controller {
         intl: this.intl,
         getGroups: this.contextualGroupGetters,
       }),
+      locationModalsPlugin(),
     ];
   }
 
@@ -235,8 +240,14 @@ export default class BesluitSampleController extends Controller {
     say: 'https://say.data.gift/ns/',
   };
 
-  contextualActionGetters = [placeDescriptionActions(this.locationOptions), locationActions()];
-  contextualGroupGetters = [placeDescriptionActionGroups(), locationActionsGroups()];
+  contextualActionGetters = [
+    placeDescriptionActions(this.locationOptions),
+    locationActions(),
+  ];
+  contextualGroupGetters = [
+    placeDescriptionActionGroups(),
+    locationActionsGroups(),
+  ];
 
   get schema() {
     return new Schema({

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -447,6 +447,11 @@ location-plugin:
     checkbox-helptext: Checking this will remove the zipcode and municipality from the address.
   nodeview:
     placeholder: Insert location
+  context-actions:
+    insert-address: Insert Address
+    insert-point-on-map: Insert a point on the map
+    insert-area: Insert area
+    other-elements: Other elements
   types:
     address: Address
     place: Place

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -444,6 +444,11 @@ location-plugin:
     checkbox-helptext: Aanvinken verwijdert de postcode en gemeente van het adres.
   nodeview:
     placeholder: Voeg locatie in
+  context-actions:
+    insert-address: Adres invoegen
+    insert-point-on-map: Punt op de kaart invoegen
+    insert-area: Gebied invoegen
+    other-elements: Andere elementen
   types:
     address: Adres
     place: Plaats


### PR DESCRIPTION
### Overview
When highlighting a location node, we want to be able to use the context menu to quickly change/insert a location. This PR adds buttons to the context actions to open the modal in either place, address or area mode.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6003


### Setup
Depends on this PR for the editor: https://github.com/lblod/ember-rdfa-editor/pull/1374

### How to test/reproduce
In the decision-sample, clicking a location node (or location placeholder), should open the context actions with 3 options: Insert address, insert point on the map, insert area. 

### Challenges/uncertainties
Currently the context actions get shown each time a location node is selected, this can happen not only trough clicking on the node but also undo-ing, closing the modal, ... This might not be desired. It is not possible anymore to change the content of the Node anymore because clicking it opens the context actions and moves the cursor to the search field.

Also, when the context actions are closed, to reopen a user cannot click the Location Node again because the reactivity system triggers on selection change. I think it is important that this is fixed, although maybe not in this PR, but rather when we look at the rework of this component in the next sprint.


### Checks PR readiness
- [x] changelog
- [x] npm lint
