### PR TITLE
Improve performance of structure recalculation GN-6098

### DIFF
--- a/.changeset/moody-paws-punch.md
+++ b/.changeset/moody-paws-punch.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Improve performance of automatic structure-linking

--- a/addon/plugins/structure-plugin/monads/regenerate-rdfa-links.ts
+++ b/addon/plugins/structure-plugin/monads/regenerate-rdfa-links.ts
@@ -1,20 +1,20 @@
 import { Attrs, type PNode } from '@lblod/ember-rdfa-editor';
-import {
-  composeMonads,
-  type TransactionMonad,
-} from '@lblod/ember-rdfa-editor/utils/transaction-utils';
+import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { getOutgoingTripleList } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import { isSome } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
+import { difference } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/set-utils';
+import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   addPropertyToNode,
   getProperties,
   getSubject,
   removePropertyFromNode,
 } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
-import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
-import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import {
+  composeMonads,
+  type TransactionMonad,
+} from '@lblod/ember-rdfa-editor/utils/transaction-utils';
 import { isHierarchyNode } from '../structure-types';
-import { getOutgoingTripleList } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
-import { difference } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/set-utils';
-import { isSome } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 
 const factory = new SayDataFactory();
 

--- a/addon/plugins/structure-plugin/monads/regenerate-rdfa-links.ts
+++ b/addon/plugins/structure-plugin/monads/regenerate-rdfa-links.ts
@@ -1,4 +1,4 @@
-import { type PNode } from '@lblod/ember-rdfa-editor';
+import { Attrs, type PNode } from '@lblod/ember-rdfa-editor';
 import {
   composeMonads,
   type TransactionMonad,
@@ -12,9 +12,26 @@ import {
 import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { SAY } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { isHierarchyNode } from '../structure-types';
+import { getOutgoingTripleList } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import { difference } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/set-utils';
+import { isSome } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 
+const factory = new SayDataFactory();
+
+/**
+ * Generate monads to recursively sync the RDFa links with the actual document structure
+ * of the given structure node and its descendants.
+ *
+ * Takes the document hierarchy as the source of truth, and updates the rdfa links to match.
+ *
+ * Currently this is being called every transaction that modifies any structure node,
+ * which includes typing inside one. As such, the implementation should take care to avoid
+ * generating unnecessary updates.
+ *
+ * @param parent A structure node
+ * @returns a list of monads which will update the structures as described
+ */
 function linkAllChildrenToParent(parent: PNode): TransactionMonad<boolean>[] {
-  const factory = new SayDataFactory();
   const parentResource = getSubject(parent);
   if (!parentResource) {
     console.warn(
@@ -24,48 +41,104 @@ function linkAllChildrenToParent(parent: PNode): TransactionMonad<boolean>[] {
   }
   const monads: TransactionMonad<boolean>[] = [];
 
-  // Remove existing links
-  const existingLinks = getProperties(parent)?.filter((rel) =>
-    SAY('hasPart').matches(rel.predicate),
-  );
-  existingLinks?.forEach((link) => {
-    monads.push(
-      removePropertyFromNode({ resource: parentResource, property: link }),
-    );
-  });
+  const childStructures: PNode[] = [];
 
+  // collect all direct structure-node descendants, skipping non-structure nodes
+  // which is why the rest of the function calls them "children" even if they might
+  // not be direct children in the strict sense
   parent.descendants((node) => {
     if (isHierarchyNode(node)) {
-      const resource = getSubject(node);
-      if (!resource) {
-        console.warn(
-          'Trying to update RDFa links for a structure node with no subject',
-        );
-        return false;
-      }
-      const monad = addPropertyToNode({
-        resource: parentResource,
-        property: {
-          predicate: SAY('hasPart').full,
-          object: factory.resourceNode(resource),
-        },
-      });
-      monads.push(monad);
-
-      // Recurse for children
-      monads.push(...linkAllChildrenToParent(node));
-
-      // Avoid `descendants()` from handling children, we do that with recursion
+      childStructures.push(node);
       return false;
-    } else {
-      // Look for hierarchy nodes within
-      return true;
     }
+    return true;
   });
+
+  const documentChildSubjects = new Set(
+    // As far as this function is concerned,
+    // it will handle child structures without a subject just fine, so we can filter them out
+    // Any dangling reference to them in the parent will be removed.
+    // However, it is definitely unexpected and likely will break other things
+    childStructures.map((node) => getSubject(node)).filter(isSome),
+  );
+
+  const parentProps = getProperties(parent) ?? [];
+  const rdfaChildSubjects = new Set(
+    parentProps
+      .filter((p) => SAY('hasPart').matches(p.predicate))
+      .map((p) => p.object.value),
+  );
+
+  // calculating this is highly worth doing, since there will usually be no differences
+  // and avoiding the extra transactions is very worth it
+  const toBeDeleted = difference(rdfaChildSubjects, documentChildSubjects);
+  const toBeAdded = difference(documentChildSubjects, rdfaChildSubjects);
+
+  // generate the monads to update the props
+  for (const subject of toBeDeleted) {
+    monads.push(...removeChildLinks(parent.attrs, parentResource, subject));
+  }
+  for (const subject of toBeAdded) {
+    monads.push(addChildLink(parentResource, subject));
+  }
+
+  // recurse down for each child
+  for (const child of childStructures) {
+    monads.push(...linkAllChildrenToParent(child));
+  }
+
   return monads;
 }
 
+/**
+ * Generate monad to remove child from the parent's node attrs
+ *
+ * @param parentAttrs the prosemirror attrs of the parent
+ * @param parentSubject
+ * @param childSubject
+ * @returns list of monads to remove each property
+ *
+ * @private
+ */
+function removeChildLinks(
+  parentAttrs: Attrs,
+  parentSubject: string,
+  childSubject: string,
+) {
+  const toRemove = getOutgoingTripleList(parentAttrs, SAY('hasPart')).filter(
+    (t) => t.object.value === childSubject,
+  );
+  return toRemove.map((prop) =>
+    removePropertyFromNode({ resource: parentSubject, property: prop }),
+  );
+}
+
+/**
+ * Generate monad to add child to the parent's rdfa props
+ *
+ * @param parentSubject
+ * @param childSubject
+ * @returns monad to add the child to the parent with a 'hasPart' predicate
+ *
+ * @private
+ */
+function addChildLink(parentSubject: string, childSubject: string) {
+  return addPropertyToNode({
+    resource: parentSubject,
+    property: {
+      predicate: SAY('hasPart').full,
+      object: factory.resourceNode(childSubject),
+    },
+  });
+}
+
 // TODO add support for decision structure nodes to this to remove their current manual linking
+/**
+ * Generate monads to update the rdfa-hierarchy of all structure nodes to match their document hierarchy
+ * @see {@link linkAllChildrenToParent} for more details
+ *
+ * @returns list of monads to perform the update on the whole doc
+ */
 export const regenerateRdfaLinks = composeMonads((state) => {
   const monads: TransactionMonad<boolean>[] = [];
   // First find all the nodes that are in the hierarchy, but do not have a parent that is part of

--- a/addon/utils/set-utils.ts
+++ b/addon/utils/set-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Calculate the set difference a - b between two sets
+ *
+ * @param a set a, or the left hand side of the operation
+ * @param b set b, or the right hand sidde of the operation
+ * @returns a-b
+ */
+export function difference<T>(a: Set<T>, b: Set<T>): Set<T> {
+  const diff = new Set<T>();
+
+  for (const item of a) {
+    if (!b.has(item)) {
+      diff.add(item);
+    }
+  }
+
+  return diff;
+}


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Adjusts the function `linkAllChildrenToParent` which takes care of updating RDFa properties of each structure node, such that their parent-child relationship in RDFa matches their hierarchy in the document. 

Before, the function simply ran over all structures in the doc, and fully replaced all their parent-child relationships with ones that matched the document structure.
Unfortunately, updating rdfa-properties is quite costly, so this caused problems for documents with a lot of structures.

This changes it such that we fist calculate a diff between the current parent-child links, and the desired ones based on the document structure. We only update where necessary.

This is a big improvement, because on any given document change, it is highly unlikely that the relationships need to be updated at all, and even if they do, it's probably only one or two structures that changed.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->
[GN-6098](https://binnenland.atlassian.net/browse/GN-6098)

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

`pnpm start`

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

I used the following template for testing: https://reglementairebijlagen.lblod.info/template-management/69D624276D31D3BDBA054E5B/edit
or "RPR - rechtspositieregeling 2026" on RB QA.

You can copy it with `ctrl+a` and paste it into the plugin dummy app on the "Regulatory Statement Sample" page

Before the fix, typing anywhere inside a structure would be noticeably sluggish, and also show a significant impact in the browser profiler. It should be much better now. 

**additionally** extra eyes are appreciated on using it in smaller docs, to make sure it still updates everything correctly in each case we can think of.


### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness

- [x] changelog
- [x] npm lint
- [x] no new deprecations
