### PR TITLE
Feature/locked placeholder

### DIFF
--- a/.changeset/fluffy-forks-roll.md
+++ b/.changeset/fluffy-forks-roll.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add locked placeholders feature

--- a/addon/components/locked-placeholder-plugin/insert.gts
+++ b/addon/components/locked-placeholder-plugin/insert.gts
@@ -1,0 +1,140 @@
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
+import AuCard from '@appuniversum/ember-appuniversum/components/au-card';
+import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
+import AuContent from '@appuniversum/ember-appuniversum/components/au-content';
+import AuFormRow from '@appuniversum/ember-appuniversum/components/au-form-row';
+import AuLabel from '@appuniversum/ember-appuniversum/components/au-label';
+import AuNativeInput from '@lblod/ember-rdfa-editor-lblod-plugins/components/au-native-input';
+import AuRadioGroup from '@appuniversum/ember-appuniversum/components/au-radio-group';
+import { NodeSelection, SayController } from '@lblod/ember-rdfa-editor';
+import { type LocationPluginConfig } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node';
+import { action } from '@ember/object';
+import t from 'ember-intl/helpers/t';
+import { tracked } from '@glimmer/tracking';
+
+interface Signature {
+  Args: {
+    controller: SayController;
+    config: LocationPluginConfig;
+    templateMode?: boolean;
+  };
+  Element: HTMLLIElement;
+}
+
+export default class LockedPlaceholderPluginInsert extends Component<Signature> {
+  @tracked key;
+  @tracked type = 'inline';
+  get selectedPlaceholderNode() {
+    const { selection, schema } = this.controller.activeEditorState;
+    if (
+      selection instanceof NodeSelection &&
+      selection.node.type === schema.nodes.placeholder
+    ) {
+      return selection.node;
+    } else {
+      return;
+    }
+  }
+
+  get controller() {
+    return this.args.controller;
+  }
+
+  get canInsert() {
+    return !this.selectedPlaceholderNode;
+  }
+
+  @action
+  insertPlaceholder() {
+    let node = 'inline_locked_placeholder';
+    if (this.type === 'block') {
+      node = 'block_locked_placeholder';
+    }
+    this.controller.withTransaction((tr) => {
+      tr.replaceSelectionWith(
+        this.controller.schema.node(node, {
+          key: this.key,
+        }),
+      );
+      if (tr.selection.$anchor.nodeBefore) {
+        const resolvedPos = tr.doc.resolve(
+          tr.selection.anchor - tr.selection.$anchor.nodeBefore?.nodeSize,
+        );
+        tr.setSelection(new NodeSelection(resolvedPos));
+      }
+      return tr;
+    });
+    this.type = 'inline';
+    this.key = null;
+  }
+
+  @action
+  updateKey(event: InputEvent) {
+    this.key = (event.target as HTMLInputElement).value;
+  }
+
+  @action
+  updateType(type: string) {
+    this.type = type;
+  }
+
+  <template>
+    {{! @glint-nocheck: not typesafe yet }}
+    <AuCard
+      @flex={{true}}
+      @divided={{true}}
+      @isOpenInitially={{true}}
+      @expandable={{true}}
+      @shadow={{true}}
+      @size='small'
+      @disableAuContent={{true}}
+      as |c|
+    >
+      <c.header>
+        <AuHeading @level='3' @skin='6'>
+          {{t 'locked-placeholder-plugin.insert-title'}}
+        </AuHeading>
+      </c.header>
+      <c.content>
+        <AuContent>
+          <AuFormRow>
+            <AuLabel for='key'>
+              {{t 'locked-placeholder-plugin.key'}}
+            </AuLabel>
+            <AuNativeInput
+              id='label'
+              placeholder={{t 'locked-placeholder-plugin.keyPlaceholder'}}
+              @type='text'
+              @width='block'
+              value={{this.key}}
+              {{on 'input' this.updateKey}}
+            />
+          </AuFormRow>
+          <AuFormRow>
+            <AuLabel for='type'>
+              {{t 'locked-placeholder-plugin.type'}}
+            </AuLabel>
+            <AuRadioGroup
+              @name='zonal'
+              @selected={{this.type}}
+              @onChange={{this.updateType}}
+              as |Group|
+            >
+              <Group.Radio @value='inline'>{{t
+                  'locked-placeholder-plugin.inline'
+                }}</Group.Radio>
+              <Group.Radio @value='block'>
+                {{t 'locked-placeholder-plugin.block'}}
+              </Group.Radio>
+            </AuRadioGroup>
+          </AuFormRow>
+          <AuButton {{on 'click' this.insertPlaceholder}}>
+            {{t 'locked-placeholder-plugin.button'}}
+          </AuButton>
+        </AuContent>
+      </c.content>
+    </AuCard>
+  </template>
+}

--- a/addon/components/locked-placeholder-plugin/insert.gts
+++ b/addon/components/locked-placeholder-plugin/insert.gts
@@ -89,7 +89,6 @@ export default class LockedPlaceholderPluginInsert extends Component<Signature> 
   }
 
   <template>
-    {{! @glint-nocheck: not typesafe yet }}
     <AuCard
       @flex={{true}}
       @divided={{true}}

--- a/addon/components/locked-placeholder-plugin/insert.gts
+++ b/addon/components/locked-placeholder-plugin/insert.gts
@@ -24,7 +24,8 @@ interface Signature {
 }
 
 export default class LockedPlaceholderPluginInsert extends Component<Signature> {
-  @tracked key;
+  @tracked key: string | null = null;
+  @tracked label: string | null = null;
   @tracked type = 'inline';
   get selectedPlaceholderNode() {
     const { selection, schema } = this.controller.activeEditorState;
@@ -56,6 +57,7 @@ export default class LockedPlaceholderPluginInsert extends Component<Signature> 
       tr.replaceSelectionWith(
         this.controller.schema.node(node, {
           key: this.key,
+          label: this.label,
         }),
       );
       if (tr.selection.$anchor.nodeBefore) {
@@ -68,11 +70,17 @@ export default class LockedPlaceholderPluginInsert extends Component<Signature> 
     });
     this.type = 'inline';
     this.key = null;
+    this.label = null;
   }
 
   @action
   updateKey(event: InputEvent) {
     this.key = (event.target as HTMLInputElement).value;
+  }
+
+  @action
+  updateLabel(event: InputEvent) {
+    this.label = (event.target as HTMLInputElement).value;
   }
 
   @action
@@ -104,12 +112,25 @@ export default class LockedPlaceholderPluginInsert extends Component<Signature> 
               {{t 'locked-placeholder-plugin.key'}}
             </AuLabel>
             <AuNativeInput
-              id='label'
+              id='key'
               placeholder={{t 'locked-placeholder-plugin.keyPlaceholder'}}
               @type='text'
               @width='block'
               value={{this.key}}
               {{on 'input' this.updateKey}}
+            />
+          </AuFormRow>
+          <AuFormRow>
+            <AuLabel for='label'>
+              {{t 'locked-placeholder-plugin.label'}}
+            </AuLabel>
+            <AuNativeInput
+              id='label'
+              placeholder={{t 'locked-placeholder-plugin.labelPlaceholder'}}
+              @type='text'
+              @width='block'
+              value={{this.label}}
+              {{on 'input' this.updateLabel}}
             />
           </AuFormRow>
           <AuFormRow>

--- a/addon/components/locked-placeholder-plugin/nodeviews/block.gts
+++ b/addon/components/locked-placeholder-plugin/nodeviews/block.gts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
+
+interface Sig {
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class BlockLockedPlaceholder extends Component<Sig> {
+  <template>
+    <AuAlert>
+      Locked placeholder
+    </AuAlert>
+  </template>
+}

--- a/addon/components/locked-placeholder-plugin/nodeviews/block.gts
+++ b/addon/components/locked-placeholder-plugin/nodeviews/block.gts
@@ -12,7 +12,7 @@ export default class BlockLockedPlaceholder extends Component<Sig> {
     return this.args.node.attrs.label;
   }
   <template>
-    <AuAlert>
+    <AuAlert class='say-block-locked-placeholder'>
       {{this.label}}
     </AuAlert>
   </template>

--- a/addon/components/locked-placeholder-plugin/nodeviews/block.gts
+++ b/addon/components/locked-placeholder-plugin/nodeviews/block.gts
@@ -1,7 +1,11 @@
 import Component from '@glimmer/component';
 import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
+import { PNode } from '@lblod/ember-rdfa-editor';
 
 interface Sig {
+  Args: {
+    node: PNode;
+  };
   Blocks: {
     default: [];
   };

--- a/addon/components/locked-placeholder-plugin/nodeviews/block.gts
+++ b/addon/components/locked-placeholder-plugin/nodeviews/block.gts
@@ -8,9 +8,12 @@ interface Sig {
 }
 
 export default class BlockLockedPlaceholder extends Component<Sig> {
+  get label() {
+    return this.args.node.attrs.label;
+  }
   <template>
     <AuAlert>
-      Locked placeholder
+      {{this.label}}
     </AuAlert>
   </template>
 }

--- a/addon/components/locked-placeholder-plugin/nodeviews/inline.gts
+++ b/addon/components/locked-placeholder-plugin/nodeviews/inline.gts
@@ -8,9 +8,12 @@ interface Sig {
 }
 
 export default class InlineLockedPlaceholder extends Component<Sig> {
+  get label() {
+    return this.args.node.attrs.label;
+  }
   <template>
-    <AuPill class='say-pill'>
-      Locked placeholder
+    <AuPill class='say-pill say-inline-locked-placeholder'>
+      {{this.label}}
     </AuPill>
   </template>
 }

--- a/addon/components/locked-placeholder-plugin/nodeviews/inline.gts
+++ b/addon/components/locked-placeholder-plugin/nodeviews/inline.gts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import AuPill from '@appuniversum/ember-appuniversum/components/au-pill';
+
+interface Sig {
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class InlineLockedPlaceholder extends Component<Sig> {
+  <template>
+    <AuPill class='say-pill'>
+      Locked placeholder
+    </AuPill>
+  </template>
+}

--- a/addon/components/locked-placeholder-plugin/nodeviews/inline.gts
+++ b/addon/components/locked-placeholder-plugin/nodeviews/inline.gts
@@ -1,7 +1,11 @@
 import Component from '@glimmer/component';
 import AuPill from '@appuniversum/ember-appuniversum/components/au-pill';
+import { PNode } from '@lblod/ember-rdfa-editor';
 
 interface Sig {
+  Args: {
+    node: PNode;
+  };
   Blocks: {
     default: [];
   };

--- a/addon/plugins/locked-placeholder-plugin/nodes/block-locked-placeholder.ts
+++ b/addon/plugins/locked-placeholder-plugin/nodes/block-locked-placeholder.ts
@@ -9,7 +9,7 @@ import type { ComponentLike } from '@glint/template';
 
 const parseDOM = [
   {
-    tag: 'span',
+    tag: 'div',
     getAttrs: (node: HTMLElement) => {
       if (
         node.dataset.lockedPlaceholder &&
@@ -29,7 +29,7 @@ const parseDOM = [
 
 const toDOM = (node: PNode): DOMOutputSpec => {
   return [
-    'span',
+    'div',
     {
       'data-locked-placeholder': 'true',
       'data-locked-placeholder-type': 'block',

--- a/addon/plugins/locked-placeholder-plugin/nodes/block-locked-placeholder.ts
+++ b/addon/plugins/locked-placeholder-plugin/nodes/block-locked-placeholder.ts
@@ -3,67 +3,41 @@ import {
   createEmberNodeView,
   EmberNodeConfig,
 } from '@lblod/ember-rdfa-editor/utils/ember-node';
-import {
-  DOMOutputSpec,
-  getRdfaAttrs,
-  PNode,
-  rdfaAttrSpec,
-} from '@lblod/ember-rdfa-editor';
+import { DOMOutputSpec, PNode } from '@lblod/ember-rdfa-editor';
 import BlockLockedPlaceholderNodeView from '@lblod/ember-rdfa-editor-lblod-plugins/components/locked-placeholder-plugin/nodeviews/block';
 import type { ComponentLike } from '@glint/template';
-import { renderRdfaAware } from '@lblod/ember-rdfa-editor/core/schema';
-import getClassnamesFromNode from '@lblod/ember-rdfa-editor/utils/get-classnames-from-node';
-
-const rdfaAware = true;
-
-const CONTENT_SELECTOR = '[data-content-container="true"]';
 
 const parseDOM = [
   {
     tag: 'span',
     getAttrs: (node: HTMLElement) => {
-      const attrs = getRdfaAttrs(node, { rdfaAware });
-      if (!attrs) {
-        return false;
-      }
       if (
         node.dataset.lockedPlaceholder &&
         node.dataset.lockedPlaceholderType === 'block'
       ) {
-        const filled = node.dataset.filled;
+        const label = node.dataset.label;
         const key = node.dataset.key;
         return {
-          ...attrs,
-          filled,
+          label,
           key,
         };
       }
       return false;
     },
-    contentElement: CONTENT_SELECTOR,
   },
 ];
 
 const toDOM = (node: PNode): DOMOutputSpec => {
-  const onlyContentType =
-    node.content.size === 1 && node.content.firstChild?.type;
-  const className =
-    onlyContentType &&
-    onlyContentType === onlyContentType.schema.nodes['placeholder']
-      ? ' say-variable'
-      : '';
-  return renderRdfaAware({
-    renderable: node,
-    tag: 'span',
-    attrs: {
-      class: `${getClassnamesFromNode(node)}${className}`,
+  return [
+    'span',
+    {
       'data-locked-placeholder': 'true',
       'data-locked-placeholder-type': 'block',
-      'data-filled': node.attrs['filled'],
+      'data-label': node.attrs['label'],
       'data-key': node.attrs['key'],
     },
-    content: 0,
-  });
+    0,
+  ];
 };
 
 const emberNodeConfig: EmberNodeConfig = {
@@ -73,15 +47,13 @@ const emberNodeConfig: EmberNodeConfig = {
   group: 'block',
   content: 'inline*',
   atom: true,
-  //recreateUriFunction: recreateVariableUris,
   draggable: false,
   needsFFKludge: true,
   editable: true,
   selectable: true,
   attrs: {
-    ...rdfaAttrSpec({ rdfaAware }),
-    filled: {
-      default: false,
+    label: {
+      default: '',
     },
     key: {
       default: undefined,

--- a/addon/plugins/locked-placeholder-plugin/nodes/block-locked-placeholder.ts
+++ b/addon/plugins/locked-placeholder-plugin/nodes/block-locked-placeholder.ts
@@ -1,0 +1,96 @@
+import {
+  createEmberNodeSpec,
+  createEmberNodeView,
+  EmberNodeConfig,
+} from '@lblod/ember-rdfa-editor/utils/ember-node';
+import {
+  DOMOutputSpec,
+  getRdfaAttrs,
+  PNode,
+  rdfaAttrSpec,
+} from '@lblod/ember-rdfa-editor';
+import BlockLockedPlaceholderNodeView from '@lblod/ember-rdfa-editor-lblod-plugins/components/locked-placeholder-plugin/nodeviews/block';
+import type { ComponentLike } from '@glint/template';
+import { renderRdfaAware } from '@lblod/ember-rdfa-editor/core/schema';
+import getClassnamesFromNode from '@lblod/ember-rdfa-editor/utils/get-classnames-from-node';
+
+const rdfaAware = true;
+
+const CONTENT_SELECTOR = '[data-content-container="true"]';
+
+const parseDOM = [
+  {
+    tag: 'span',
+    getAttrs: (node: HTMLElement) => {
+      const attrs = getRdfaAttrs(node, { rdfaAware });
+      if (!attrs) {
+        return false;
+      }
+      if (
+        node.dataset.lockedPlaceholder &&
+        node.dataset.lockedPlaceholderType === 'block'
+      ) {
+        const filled = node.dataset.filled;
+        const key = node.dataset.key;
+        return {
+          ...attrs,
+          filled,
+          key,
+        };
+      }
+      return false;
+    },
+    contentElement: CONTENT_SELECTOR,
+  },
+];
+
+const toDOM = (node: PNode): DOMOutputSpec => {
+  const onlyContentType =
+    node.content.size === 1 && node.content.firstChild?.type;
+  const className =
+    onlyContentType &&
+    onlyContentType === onlyContentType.schema.nodes['placeholder']
+      ? ' say-variable'
+      : '';
+  return renderRdfaAware({
+    renderable: node,
+    tag: 'span',
+    attrs: {
+      class: `${getClassnamesFromNode(node)}${className}`,
+      'data-locked-placeholder': 'true',
+      'data-locked-placeholder-type': 'block',
+      'data-filled': node.attrs['filled'],
+      'data-key': node.attrs['key'],
+    },
+    content: 0,
+  });
+};
+
+const emberNodeConfig: EmberNodeConfig = {
+  name: 'block-locked-placeholder',
+  component: BlockLockedPlaceholderNodeView as unknown as ComponentLike,
+  inline: false,
+  group: 'block',
+  content: 'inline*',
+  atom: true,
+  //recreateUriFunction: recreateVariableUris,
+  draggable: false,
+  needsFFKludge: true,
+  editable: true,
+  selectable: true,
+  attrs: {
+    ...rdfaAttrSpec({ rdfaAware }),
+    filled: {
+      default: false,
+    },
+    key: {
+      default: undefined,
+    },
+  },
+  classNames: ['say-block-locked-placeholder'],
+  toDOM,
+  parseDOM: parseDOM,
+};
+
+export const blockLockedPlaceholder = createEmberNodeSpec(emberNodeConfig);
+export const blockLockedPlaceholderView = createEmberNodeView(emberNodeConfig);

--- a/addon/plugins/locked-placeholder-plugin/nodes/inline-locked-placeholder.ts
+++ b/addon/plugins/locked-placeholder-plugin/nodes/inline-locked-placeholder.ts
@@ -1,0 +1,96 @@
+import {
+  createEmberNodeSpec,
+  createEmberNodeView,
+  EmberNodeConfig,
+} from '@lblod/ember-rdfa-editor/utils/ember-node';
+import {
+  DOMOutputSpec,
+  getRdfaAttrs,
+  PNode,
+  rdfaAttrSpec,
+} from '@lblod/ember-rdfa-editor';
+import InlineLockedPlaceholderNodeView from '@lblod/ember-rdfa-editor-lblod-plugins/components/locked-placeholder-plugin/nodeviews/inline';
+import type { ComponentLike } from '@glint/template';
+import { renderRdfaAware } from '@lblod/ember-rdfa-editor/core/schema';
+import getClassnamesFromNode from '@lblod/ember-rdfa-editor/utils/get-classnames-from-node';
+
+const rdfaAware = true;
+
+const CONTENT_SELECTOR = '[data-content-container="true"]';
+
+const parseDOM = [
+  {
+    tag: 'span',
+    getAttrs: (node: HTMLElement) => {
+      const attrs = getRdfaAttrs(node, { rdfaAware });
+      if (!attrs) {
+        return false;
+      }
+      if (
+        node.dataset.lockedPlaceholder &&
+        node.dataset.lockedPlaceholderType === 'inline'
+      ) {
+        const filled = node.dataset.filled;
+        const key = node.dataset.key;
+        return {
+          ...attrs,
+          filled,
+          key,
+        };
+      }
+      return false;
+    },
+    contentElement: CONTENT_SELECTOR,
+  },
+];
+
+const toDOM = (node: PNode): DOMOutputSpec => {
+  const onlyContentType =
+    node.content.size === 1 && node.content.firstChild?.type;
+  const className =
+    onlyContentType &&
+    onlyContentType === onlyContentType.schema.nodes['placeholder']
+      ? ' say-variable'
+      : '';
+  return renderRdfaAware({
+    renderable: node,
+    tag: 'span',
+    attrs: {
+      class: `${getClassnamesFromNode(node)}${className}`,
+      'data-locked-placeholder': 'true',
+      'data-locked-placeholder-type': 'inline',
+      'data-filled': node.attrs['filled'],
+      'data-key': node.attrs['key'],
+    },
+    content: 0,
+  });
+};
+
+const emberNodeConfig: EmberNodeConfig = {
+  name: 'inline-locked-placeholder',
+  component: InlineLockedPlaceholderNodeView as unknown as ComponentLike,
+  inline: true,
+  group: 'inline variable',
+  content: 'inline*',
+  atom: true,
+  //recreateUriFunction: recreateVariableUris,
+  draggable: false,
+  needsFFKludge: true,
+  editable: true,
+  selectable: true,
+  attrs: {
+    ...rdfaAttrSpec({ rdfaAware }),
+    filled: {
+      default: false,
+    },
+    key: {
+      default: undefined,
+    },
+  },
+  classNames: ['say-inline-locked-placeholder'],
+  toDOM,
+  parseDOM: parseDOM,
+};
+
+export const inlineLockedPlaceholder = createEmberNodeSpec(emberNodeConfig);
+export const inlineLockedPlaceholderView = createEmberNodeView(emberNodeConfig);

--- a/addon/plugins/locked-placeholder-plugin/nodes/inline-locked-placeholder.ts
+++ b/addon/plugins/locked-placeholder-plugin/nodes/inline-locked-placeholder.ts
@@ -44,7 +44,7 @@ const emberNodeConfig: EmberNodeConfig = {
   name: 'inline-locked-placeholder',
   component: InlineLockedPlaceholderNodeView as unknown as ComponentLike,
   inline: true,
-  group: 'inline variable',
+  group: 'inline',
   content: 'inline*',
   atom: true,
   draggable: false,

--- a/addon/plugins/locked-placeholder-plugin/nodes/inline-locked-placeholder.ts
+++ b/addon/plugins/locked-placeholder-plugin/nodes/inline-locked-placeholder.ts
@@ -3,67 +3,41 @@ import {
   createEmberNodeView,
   EmberNodeConfig,
 } from '@lblod/ember-rdfa-editor/utils/ember-node';
-import {
-  DOMOutputSpec,
-  getRdfaAttrs,
-  PNode,
-  rdfaAttrSpec,
-} from '@lblod/ember-rdfa-editor';
+import { DOMOutputSpec, PNode } from '@lblod/ember-rdfa-editor';
 import InlineLockedPlaceholderNodeView from '@lblod/ember-rdfa-editor-lblod-plugins/components/locked-placeholder-plugin/nodeviews/inline';
 import type { ComponentLike } from '@glint/template';
-import { renderRdfaAware } from '@lblod/ember-rdfa-editor/core/schema';
-import getClassnamesFromNode from '@lblod/ember-rdfa-editor/utils/get-classnames-from-node';
-
-const rdfaAware = true;
-
-const CONTENT_SELECTOR = '[data-content-container="true"]';
 
 const parseDOM = [
   {
     tag: 'span',
     getAttrs: (node: HTMLElement) => {
-      const attrs = getRdfaAttrs(node, { rdfaAware });
-      if (!attrs) {
-        return false;
-      }
       if (
         node.dataset.lockedPlaceholder &&
         node.dataset.lockedPlaceholderType === 'inline'
       ) {
-        const filled = node.dataset.filled;
+        const label = node.dataset.label;
         const key = node.dataset.key;
         return {
-          ...attrs,
-          filled,
+          label,
           key,
         };
       }
       return false;
     },
-    contentElement: CONTENT_SELECTOR,
   },
 ];
 
 const toDOM = (node: PNode): DOMOutputSpec => {
-  const onlyContentType =
-    node.content.size === 1 && node.content.firstChild?.type;
-  const className =
-    onlyContentType &&
-    onlyContentType === onlyContentType.schema.nodes['placeholder']
-      ? ' say-variable'
-      : '';
-  return renderRdfaAware({
-    renderable: node,
-    tag: 'span',
-    attrs: {
-      class: `${getClassnamesFromNode(node)}${className}`,
+  return [
+    'span',
+    {
       'data-locked-placeholder': 'true',
       'data-locked-placeholder-type': 'inline',
-      'data-filled': node.attrs['filled'],
+      'data-label': node.attrs['label'],
       'data-key': node.attrs['key'],
     },
-    content: 0,
-  });
+    0,
+  ];
 };
 
 const emberNodeConfig: EmberNodeConfig = {
@@ -73,15 +47,13 @@ const emberNodeConfig: EmberNodeConfig = {
   group: 'inline variable',
   content: 'inline*',
   atom: true,
-  //recreateUriFunction: recreateVariableUris,
   draggable: false,
   needsFFKludge: true,
   editable: true,
   selectable: true,
   attrs: {
-    ...rdfaAttrSpec({ rdfaAware }),
-    filled: {
-      default: false,
+    label: {
+      default: '',
     },
     key: {
       default: undefined,

--- a/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
+++ b/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
@@ -35,7 +35,8 @@ export default function replaceLockedPlaceholderContent(
   });
   placeholdersWithPos.reverse();
   const monads = [];
-  const valuesResolved = typeof values === 'function' ? values(state) : values;
+  const valuesResolved =
+    typeof values === 'function' ? values(initialState) : values;
   for (const { placeholder, pos } of placeholdersWithPos) {
     const key = placeholder.attrs.key as string;
     const valueToReplace = valuesResolved[key];
@@ -83,5 +84,6 @@ function replacePlaceholderWithProsemirrorNode(
   return (state: EditorState) => {
     const tr = state.tr;
     tr.replaceWith(pos, pos + placeholder.nodeSize, value);
+    return { initialState: state, transaction: tr, result: true };
   };
 }

--- a/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
+++ b/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
@@ -1,0 +1,85 @@
+import { Node, SayController } from '@lblod/ember-rdfa-editor';
+import { DOMParser as ProseParser } from '@lblod/ember-rdfa-editor';
+
+type PlaceholderWithPos = {
+  placeholder: Node;
+  pos: number;
+};
+
+type ReplacementValues = {
+  [key: string]: string;
+};
+
+export default function replaceLockedPlaceholderContent(
+  controller: SayController,
+  values: ReplacementValues,
+) {
+  const doc = controller.mainEditorState.doc;
+  const placeholdersWithPos: PlaceholderWithPos[] = [];
+  doc.descendants((node, pos) => {
+    if (
+      node.type.name === 'block_locked_placeholder' ||
+      node.type.name === 'inline_locked_placeholder'
+    ) {
+      placeholdersWithPos.push({
+        placeholder: node,
+        pos: pos,
+      });
+      return false;
+    }
+    return true;
+  });
+  placeholdersWithPos.reverse();
+  for (const { placeholder, pos } of placeholdersWithPos) {
+    const key = placeholder.attrs.key as string;
+    const valueToReplace = values[key];
+    if (!valueToReplace) continue;
+    if (typeof valueToReplace === 'string') {
+      replacePlaceholderWithHtml(controller, placeholder, pos, valueToReplace);
+    } else {
+      replacePlaceholderWithProsemirrorNode(
+        controller,
+        placeholder,
+        pos,
+        valueToReplace,
+      );
+    }
+  }
+}
+
+function replacePlaceholderWithHtml(
+  controller: SayController,
+  placeholder: Node,
+  pos: number,
+  value: string,
+) {
+  console.log(placeholder);
+  const domParser = new DOMParser();
+  const contentFragment = ProseParser.fromSchema(controller.schema).parse(
+    domParser.parseFromString(value, 'text/html'),
+  ).content;
+  controller.withTransaction(
+    (transaction) => {
+      return transaction.replaceWith(
+        pos,
+        pos + placeholder.nodeSize,
+        contentFragment,
+      );
+    },
+    { view: controller.mainEditorView },
+  );
+}
+
+function replacePlaceholderWithProsemirrorNode(
+  controller: SayController,
+  placeholder: Node,
+  pos: number,
+  value: Node,
+) {
+  controller.withTransaction(
+    (transaction) => {
+      return transaction.replaceWith(pos, pos + placeholder.nodeSize, value);
+    },
+    { view: controller.mainEditorView },
+  );
+}

--- a/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
+++ b/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
@@ -1,5 +1,9 @@
-import { Node, SayController } from '@lblod/ember-rdfa-editor';
+import { Node, EditorState } from '@lblod/ember-rdfa-editor';
 import { DOMParser as ProseParser } from '@lblod/ember-rdfa-editor';
+import {
+  transactionCombinator,
+  type TransactionCombinatorResult,
+} from '@lblod/ember-rdfa-editor/utils/transaction-utils';
 
 type PlaceholderWithPos = {
   placeholder: Node;
@@ -11,10 +15,10 @@ type ReplacementValues = {
 };
 
 export default function replaceLockedPlaceholderContent(
-  controller: SayController,
+  initialState: EditorState,
   values: ReplacementValues,
-) {
-  const doc = controller.mainEditorState.doc;
+): TransactionCombinatorResult<boolean> {
+  const doc = initialState.doc;
   const placeholdersWithPos: PlaceholderWithPos[] = [];
   doc.descendants((node, pos) => {
     if (
@@ -30,55 +34,53 @@ export default function replaceLockedPlaceholderContent(
     return true;
   });
   placeholdersWithPos.reverse();
+  const monads = [];
   for (const { placeholder, pos } of placeholdersWithPos) {
     const key = placeholder.attrs.key as string;
     const valueToReplace = values[key];
     if (!valueToReplace) continue;
     if (typeof valueToReplace === 'string') {
-      replacePlaceholderWithHtml(controller, placeholder, pos, valueToReplace);
-    } else {
-      replacePlaceholderWithProsemirrorNode(
-        controller,
+      const monad = replacePlaceholderWithHtml(
         placeholder,
         pos,
         valueToReplace,
       );
+      monads.push(monad);
+    } else {
+      const monad = replacePlaceholderWithProsemirrorNode(
+        placeholder,
+        pos,
+        valueToReplace,
+      );
+      monads.push(monad);
     }
   }
+  return transactionCombinator<boolean>(initialState)(monads);
 }
 
 function replacePlaceholderWithHtml(
-  controller: SayController,
   placeholder: Node,
   pos: number,
   value: string,
 ) {
-  const domParser = new DOMParser();
-  const contentFragment = ProseParser.fromSchema(controller.schema).parse(
-    domParser.parseFromString(value, 'text/html'),
-  ).content;
-  controller.withTransaction(
-    (transaction) => {
-      return transaction.replaceWith(
-        pos,
-        pos + placeholder.nodeSize,
-        contentFragment,
-      );
-    },
-    { view: controller.mainEditorView },
-  );
+  return (state: EditorState) => {
+    const domParser = new DOMParser();
+    const contentFragment = ProseParser.fromSchema(state.schema).parse(
+      domParser.parseFromString(value, 'text/html'),
+    ).content;
+    const tr = state.tr;
+    tr.replaceWith(pos, pos + placeholder.nodeSize, contentFragment);
+    return { initialState: state, transaction: tr, result: true };
+  };
 }
 
 function replacePlaceholderWithProsemirrorNode(
-  controller: SayController,
   placeholder: Node,
   pos: number,
   value: Node,
 ) {
-  controller.withTransaction(
-    (transaction) => {
-      return transaction.replaceWith(pos, pos + placeholder.nodeSize, value);
-    },
-    { view: controller.mainEditorView },
-  );
+  return (state: EditorState) => {
+    const tr = state.tr;
+    tr.replaceWith(pos, pos + placeholder.nodeSize, value);
+  };
 }

--- a/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
+++ b/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
@@ -16,7 +16,7 @@ type ReplacementValues = {
 
 export default function replaceLockedPlaceholderContent(
   initialState: EditorState,
-  values: ReplacementValues,
+  values: ReplacementValues | ((state: EditorState) => ReplacementValues),
 ): TransactionCombinatorResult<boolean> {
   const doc = initialState.doc;
   const placeholdersWithPos: PlaceholderWithPos[] = [];
@@ -35,9 +35,10 @@ export default function replaceLockedPlaceholderContent(
   });
   placeholdersWithPos.reverse();
   const monads = [];
+  const valuesResolved = typeof values === 'function' ? values(state) : values;
   for (const { placeholder, pos } of placeholdersWithPos) {
     const key = placeholder.attrs.key as string;
-    const valueToReplace = values[key];
+    const valueToReplace = valuesResolved[key];
     if (!valueToReplace) continue;
     if (typeof valueToReplace === 'string') {
       const monad = replacePlaceholderWithHtml(

--- a/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
+++ b/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
@@ -53,7 +53,6 @@ function replacePlaceholderWithHtml(
   pos: number,
   value: string,
 ) {
-  console.log(placeholder);
   const domParser = new DOMParser();
   const contentFragment = ProseParser.fromSchema(controller.schema).parse(
     domParser.parseFromString(value, 'text/html'),

--- a/app/components/locked-placeholder-plugin/insert.js
+++ b/app/components/locked-placeholder-plugin/insert.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor-lblod-plugins/components/locked-placeholder-plugin/insert';

--- a/app/styles/locked-placeholder-plugin.scss
+++ b/app/styles/locked-placeholder-plugin.scss
@@ -1,0 +1,11 @@
+.say-inline-locked-placeholder {
+  background-color: var(--au-gray-200);
+  color: var(--au-gray-700);
+  border-color: var(--au-gray-300)
+}
+
+.say-block-locked-placeholder {
+  background-color: var(--au-gray-200);
+  color: var(--au-gray-700);
+  border-color: var(--au-gray-300)
+}

--- a/app/styles/locked-placeholder-plugin.scss
+++ b/app/styles/locked-placeholder-plugin.scss
@@ -1,11 +1,12 @@
 .say-inline-locked-placeholder {
   background-color: var(--au-gray-200);
   color: var(--au-gray-700);
-  border-color: var(--au-gray-300)
+  border-color: var(--au-gray-300);
 }
 
 .say-block-locked-placeholder {
   background-color: var(--au-gray-200);
   color: var(--au-gray-700);
-  border-color: var(--au-gray-300)
+  border-color: var(--au-gray-300);
+  padding: 1.2rem;
 }

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -172,6 +172,3 @@
   background-color: var(--au-orange-300);
   font-style: italic;
 }
-
-
-

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -172,3 +172,10 @@
   background-color: var(--au-orange-300);
   font-style: italic;
 }
+
+
+.say-inline-locked-placeholder {
+  background-color: var(--au-gray-200);
+  color: var(--au-gray-700);
+  border-color: var(--au-gray-300)
+}

--- a/app/styles/variable-plugin.scss
+++ b/app/styles/variable-plugin.scss
@@ -174,8 +174,4 @@
 }
 
 
-.say-inline-locked-placeholder {
-  background-color: var(--au-gray-200);
-  color: var(--au-gray-700);
-  border-color: var(--au-gray-300)
-}
+

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -112,6 +112,15 @@ import {
   structureWithConfig,
   structureViewWithConfig,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/structure-plugin/node';
+import {
+  inlineLockedPlaceholder,
+  inlineLockedPlaceholderView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/locked-placeholder-plugin/nodes/inline-locked-placeholder';
+
+import {
+  blockLockedPlaceholder,
+  blockLockedPlaceholderView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/locked-placeholder-plugin/nodes/block-locked-placeholder';
 
 import InsertArticleComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/decision-plugin/insert-article';
 import StructureControlCardComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/structure-plugin/control-card';
@@ -166,6 +175,7 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions';
 import { slashCommandsPlugin } from '@lblod/ember-rdfa-editor/plugins/slash-commands/index';
 import Owner from '@ember/owner';
+import replaceLockedPlaceholderContent from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/locked-placeholder-plugin/utils/replace-content-function';
 
 export default class BesluitSampleController extends Controller {
   queryParams = ['editableNodes'];
@@ -289,6 +299,8 @@ export default class BesluitSampleController extends Controller {
         link: link(this.config.link),
         snippet_placeholder: snippetPlaceholder(this.config.snippet),
         snippet: snippet(this.config.snippet),
+        inline_locked_placeholder: inlineLockedPlaceholder,
+        block_locked_placeholder: blockLockedPlaceholder,
       },
       marks: {
         em,
@@ -523,6 +535,8 @@ export default class BesluitSampleController extends Controller {
       snippet: snippetView(this.config.snippet)(controller),
       block_rdfa: (...args: Parameters<NodeViewConstructor>) =>
         new BlockRDFaView(args, controller),
+      inline_locked_placeholder: inlineLockedPlaceholderView(controller),
+      block_locked_placeholder: blockLockedPlaceholderView(controller),
     } satisfies Record<string, NodeViewConstructor>;
   };
 

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -175,7 +175,6 @@ import {
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions';
 import { slashCommandsPlugin } from '@lblod/ember-rdfa-editor/plugins/slash-commands/index';
 import Owner from '@ember/owner';
-import replaceLockedPlaceholderContent from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/locked-placeholder-plugin/utils/replace-content-function';
 
 export default class BesluitSampleController extends Controller {
   queryParams = ['editableNodes'];

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -20,6 +20,7 @@
 @import 'mandatee-table-plugin';
 @import 'roadsign-regulation-table';
 @import 'document-validation';
+@import 'locked-placeholder-plugin';
 
 div.table-of-contents {
   padding: $au-unit-small !important;

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -157,6 +157,7 @@
               <PlaceholderUtilsPlugin::Insert
                 @controller={{container.controller}}
               />
+
             </Sidebar.Collapsible>
             <div class='au-u-flex au-u-flex--column au-u-flex--spaced-tiny'>
               <DocumentValidationPlugin::Card
@@ -193,6 +194,9 @@
                 @config={{this.config.lmb}}
               />
               <PlaceholderUtilsPlugin::Edit
+                @controller={{container.controller}}
+              />
+              <LockedPlaceholderPlugin::Insert
                 @controller={{container.controller}}
               />
               {{#if this.editableNodes}}

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -534,3 +534,12 @@ placeholder-utils-plugin:
   card-title: Edit placeholder
   button-title: Insert placeholder
   placeholder-text: Placeholder Text
+
+locked-placeholder-plugin:
+  insert-title: Insert locked placeholder
+  key: Key
+  keyPlaceholder: Key
+  type: Type
+  inline: Inline
+  block: Block
+  button: Insert

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -539,6 +539,8 @@ locked-placeholder-plugin:
   insert-title: Insert locked placeholder
   key: Key
   keyPlaceholder: Key
+  label: Label
+  labelPlaceholder: Label
   type: Type
   inline: Inline
   block: Block

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -536,6 +536,8 @@ locked-placeholder-plugin:
   insert-title: Samenvoegveld invoegen
   key: Key
   keyPlaceholder: Key
+  label: Label
+  labelPlaceholder: Label
   type: Type
   inline: Inline
   block: Blok

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -531,3 +531,12 @@ placeholder-utils-plugin:
   card-title: Plaatshouder bewerken
   button-title: Plaatshouder invoegen
   placeholder-text: Plaatshoudertekst
+
+locked-placeholder-plugin:
+  insert-title: Samenvoegveld invoegen
+  key: Key
+  keyPlaceholder: Key
+  type: Type
+  inline: Inline
+  block: Blok
+  button: Invoegen


### PR DESCRIPTION
### Overview
Added the new locked placeholder feature, this consists of 2 new nodes, a card to insert locked placeholders and a function to replace them, that works with the processDocumentHeadlessly function

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6126


### Setup
You can replace any button in the editor to run your replace function in order to test it,
```
const values = {
      block: '<ul><li>Hello</li></ul>',
      inline: '<b>Inline content</b>',
    };
    this.controller.doCommand((state, dispatch) => {
      if (!dispatch) {
        return false;
      }
      const { result, transaction } = replaceLockedPlaceholderContent(
        state,
        values,
      );
      if (result.every((ok) => ok)) {
        dispatch(transaction);
        return true;
      }
      return false;
    });
 ```
 This is what I was doing while testing, you can use the keys and values that you want and you can try constructing prosemirror nodes by passing down a function that takes the state as an argument


### How to test/reproduce
Verify that you can add both types of placeholders, via the card and by editing the html directly and that you can replace them

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
