### PR TITLE
Integrate location suggestions in context menu

### DIFF
--- a/.changeset/sixty-apes-exist.md
+++ b/.changeset/sixty-apes-exist.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Integrate location suggestions in context menu

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -282,10 +282,9 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
 
     closeLocationModal(this.controller.activeEditorView);
     if (this.selectedLocationNode) {
-      const dispatch = this.controller.activeEditorView.dispatch;
       replaceLocationCommand(this.selectedLocationNode, toInsert)(
         this.controller.activeEditorState,
-        dispatch,
+        this.controller.activeEditorView.dispatch,
       );
     } else {
       // Insert

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -31,18 +31,14 @@ import LocationMap, {
   SUPPORTED_LOCATION_TYPES,
   type LocationType,
 } from './map';
-import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
-import { updateSubject } from '@lblod/ember-rdfa-editor/plugins/rdfa-info/utils';
 import { replaceSelectionWithLocation } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/_private/utils/node-utils';
 import type { Option } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
-import type { FullTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
-import { PROV } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
-import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import {
   closeLocationModal,
   getLocationModalsPluginState,
   openLocationModal,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin';
+import { replaceLocationCommand } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/utils/replace-location';
 
 export type CurrentLocation = Address | GlobalCoordinates | undefined;
 
@@ -282,51 +278,24 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
         }),
       });
     }
-    if (toInsert) {
-      closeLocationModal(this.controller.activeEditorView);
-      if (this.selectedLocationNode) {
-        const df = new SayDataFactory();
-        const { pos, value: locNode } = this.selectedLocationNode;
-        // The location's subject has likely changed, so we should update the external links too
-        // if they exist
-        // NOTE: It's VERY important that this is done without mutating the triple objects
-        // otherwise the attributes will not update as expected when undo-ing
-        const newExternalTriples: FullTriple[] = (
-          locNode.attrs.externalTriples as FullTriple[]
-        ).map((tr) => {
-          if (PROV('atLocation').matches(tr.predicate)) {
-            return { ...tr, object: df.namedNode(toInsert.uri) };
-          } else {
-            return tr;
-          }
-        }); // update the location value and the external triples
-        this.controller.withTransaction((tr) => {
-          return transactionCombinator(
-            this.controller.activeEditorState,
-            tr
-              .setNodeAttribute(pos, 'value', toInsert)
-              .setNodeAttribute(pos, 'externalTriples', newExternalTriples),
-          )([
-            // Update the subject uri, while keeping backlinks intact
-            updateSubject({
-              pos,
-              targetSubject: toInsert.uri,
-              keepBacklinks: true,
-              keepProperties: false,
-              keepExternalTriples: true,
-            }),
-          ]).transaction;
-        });
-      } else {
-        // Insert
-        replaceSelectionWithLocation({
-          controller: this.controller,
-          subject: toInsert.uri,
-          toInsert,
-          subjectTypes: this.args.config.subjectTypesToLinkTo,
-          explicitSubjectToLinkTo: this.args.config.explicitSubjectToLinkTo,
-        });
-      }
+    if (!toInsert) return;
+
+    closeLocationModal(this.controller.activeEditorView);
+    if (this.selectedLocationNode) {
+      const dispatch = this.controller.activeEditorView.dispatch;
+      replaceLocationCommand(this.selectedLocationNode, toInsert)(
+        this.controller.activeEditorState,
+        dispatch,
+      );
+    } else {
+      // Insert
+      replaceSelectionWithLocation({
+        controller: this.controller,
+        subject: toInsert.uri,
+        toInsert,
+        subjectTypes: this.args.config.subjectTypesToLinkTo,
+        explicitSubjectToLinkTo: this.args.config.explicitSubjectToLinkTo,
+      });
     }
   }
 

--- a/addon/plugins/location-plugin/_private/utils/location-helpers.ts
+++ b/addon/plugins/location-plugin/_private/utils/location-helpers.ts
@@ -1,0 +1,7 @@
+import { Address } from './address-helpers';
+import { Area, Place } from './geo-helpers';
+
+// For 2 addresses that are the same, the belgianAddressUri will be the same, regardless of how they were created
+export function getLocationUri(location: Address | Place | Area) {
+  return (location as Address)?.belgianAddressUri ?? location.uri;
+}

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -13,6 +13,8 @@ const otherElementsGroupId =
 const recentLocationsGroupId =
   'other-elements-de3e5a9a-40de-4fb5-832e-c22199ec584f';
 
+const SUGGESTION_AMOUNT = 15;
+
 export function getContextualActions() {
   return function (state: EditorState, searchQuery?: string) {
     const t = getTranslationFunction(state);
@@ -33,7 +35,8 @@ export function getContextualActions() {
           { value: selection.node, pos: selection.from },
           location,
         ),
-      }));
+      }))
+      .slice(0, SUGGESTION_AMOUNT);
 
     const otherElementsOptions = [
       {

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -33,7 +33,7 @@ export function getContextualActions() {
     const locationSuggestionOptions = getDocumentLocations(state)
       .filter(
         (location) =>
-          selectedLocation &&
+          !selectedLocation ||
           getLocationUri(selectedLocation) !== getLocationUri(location),
       )
       .slice(0, SUGGESTION_AMOUNT)

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -3,25 +3,41 @@ import { v4 as uuidv4 } from 'uuid';
 import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
 import { openLocationModalCommand } from '..';
 import { LocationType } from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/map';
+import getDocumentLocations from '../utils/get-document-locations';
+import { replaceLocationCommand } from '../utils/replace-location';
 
 const otherElementsGroupId =
   'other-elements-e01f46a0-b323-4add-8035-d81dc2e8578d';
+const recentLocationsGroupId =
+  'other-elements-de3e5a9a-40de-4fb5-832e-c22199ec584f';
 
 export function getContextualActions() {
   return function (state: EditorState, searchQuery?: string) {
     const t = getTranslationFunction(state);
+    const { selection } = state;
+    if (!(selection instanceof NodeSelection)) return [];
 
-    const options: {
-      label: string;
-      locationType: LocationType;
-      icon: string;
-    }[] = [
+    const locationSuggestionOptions = getDocumentLocations(state).map(
+      (location) => ({
+        label: location.formatted,
+        id: uuidv4(),
+        group: recentLocationsGroupId,
+        command: replaceLocationCommand(
+          { value: selection.node, pos: selection.from },
+          location,
+        ),
+      }),
+    );
+
+    console.log(getDocumentLocations(state));
+
+    const otherElementsOptions = [
       {
         label: t(
           'location-plugin.context-actions.insert-address',
           'Adres invoegen',
         ),
-        locationType: 'address',
+        locationType: 'address' as LocationType,
         icon: 'location',
       },
       {
@@ -29,7 +45,7 @@ export function getContextualActions() {
           'location-plugin.context-actions.insert-point-on-map',
           'Punt op de kaart invoegen',
         ),
-        locationType: 'place',
+        locationType: 'place' as LocationType,
         icon: 'location-gps',
       },
       {
@@ -37,25 +53,25 @@ export function getContextualActions() {
           'location-plugin.context-actions.insert-area',
           'Gebied invoegen',
         ),
-        locationType: 'area',
+        locationType: 'area' as LocationType,
         icon: 'area',
       },
-    ];
+    ].map((option) => {
+      return {
+        ...option,
+        id: uuidv4(),
+        group: otherElementsGroupId,
+        command: openLocationModalCommand(option.locationType),
+      };
+    });
 
-    return options
+    return locationSuggestionOptions
+      .concat(otherElementsOptions)
       .filter(
         (option) =>
           !searchQuery ||
           option.label.toLocaleLowerCase().includes(searchQuery.toLowerCase()),
-      )
-      .map((option) => {
-        return {
-          ...option,
-          id: uuidv4(),
-          group: otherElementsGroupId,
-          command: openLocationModalCommand(option.locationType),
-        };
-      });
+      );
   };
 }
 
@@ -69,16 +85,22 @@ function contextualGroupIsVisible(state: EditorState) {
 
 export function getContextualActionGroups() {
   return function (state: EditorState) {
-    return contextualGroupIsVisible(state)
-      ? [
-          {
-            id: otherElementsGroupId,
-            label: getTranslationFunction(state)(
-              'location-plugin.context-actions.other-elements',
-              'Andere elementen',
-            ),
-          },
-        ]
-      : [];
+    if (!contextualGroupIsVisible(state)) return [];
+    return [
+      {
+        id: recentLocationsGroupId,
+        label: getTranslationFunction(state)(
+          'location-plugin.context-actions.location-suggestions',
+          'Locatiesuggesties',
+        ),
+      },
+      {
+        id: otherElementsGroupId,
+        label: getTranslationFunction(state)(
+          'location-plugin.context-actions.other-elements',
+          'Andere elementen',
+        ),
+      },
+    ];
   };
 }

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -7,6 +7,7 @@ import getDocumentLocations from '../utils/get-document-locations';
 import { replaceLocationCommand } from '../utils/replace-location';
 import { Area, Place } from '../utils/geo-helpers';
 import { Address } from '../utils/address-helpers';
+import { getLocationUri } from '../_private/utils/location-helpers';
 
 const otherElementsGroupId =
   'other-elements-e01f46a0-b323-4add-8035-d81dc2e8578d';
@@ -30,7 +31,11 @@ export function getContextualActions() {
       | undefined;
 
     const locationSuggestionOptions = getDocumentLocations(state)
-      .filter((location) => selectedLocation?.uri !== location.uri)
+      .filter(
+        (location) =>
+          selectedLocation &&
+          getLocationUri(selectedLocation) !== getLocationUri(location),
+      )
       .slice(0, SUGGESTION_AMOUNT)
       .map((location) => ({
         label: location.formatted,

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -5,6 +5,8 @@ import { openLocationModalCommand } from '..';
 import { LocationType } from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/map';
 import getDocumentLocations from '../utils/get-document-locations';
 import { replaceLocationCommand } from '../utils/replace-location';
+import { Area, Place } from '../utils/geo-helpers';
+import { Address } from '../utils/address-helpers';
 
 const otherElementsGroupId =
   'other-elements-e01f46a0-b323-4add-8035-d81dc2e8578d';
@@ -16,9 +18,14 @@ export function getContextualActions() {
     const t = getTranslationFunction(state);
     const { selection } = state;
     if (!(selection instanceof NodeSelection)) return [];
+    const selectedNode = selection.node;
+    if (selectedNode.type.name !== 'oslo_location') return [];
 
-    const locationSuggestionOptions = getDocumentLocations(state).map(
-      (location) => ({
+    const selectedLocation = selectedNode.attrs.value as Address | Place | Area;
+
+    const locationSuggestionOptions = getDocumentLocations(state)
+      .filter((location) => selectedLocation.uri !== location.uri)
+      .map((location) => ({
         label: location.formatted,
         id: uuidv4(),
         group: recentLocationsGroupId,
@@ -26,10 +33,7 @@ export function getContextualActions() {
           { value: selection.node, pos: selection.from },
           location,
         ),
-      }),
-    );
-
-    console.log(getDocumentLocations(state));
+      }));
 
     const otherElementsOptions = [
       {

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -23,10 +23,14 @@ export function getContextualActions() {
     const selectedNode = selection.node;
     if (selectedNode.type.name !== 'oslo_location') return [];
 
-    const selectedLocation = selectedNode.attrs.value as Address | Place | Area;
+    const selectedLocation = selectedNode.attrs.value as
+      | Address
+      | Place
+      | Area
+      | undefined;
 
     const locationSuggestionOptions = getDocumentLocations(state)
-      .filter((location) => selectedLocation.uri !== location.uri)
+      .filter((location) => selectedLocation?.uri !== location.uri)
       .map((location) => ({
         label: location.formatted,
         id: uuidv4(),

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -116,6 +116,7 @@ export function getContextualActionGroups() {
           'location-plugin.context-actions.other-elements',
           'Andere elementen',
         ),
+        sticky: 'bottom',
       },
     ];
   };

--- a/addon/plugins/location-plugin/contextual-actions/index.ts
+++ b/addon/plugins/location-plugin/contextual-actions/index.ts
@@ -31,6 +31,7 @@ export function getContextualActions() {
 
     const locationSuggestionOptions = getDocumentLocations(state)
       .filter((location) => selectedLocation?.uri !== location.uri)
+      .slice(0, SUGGESTION_AMOUNT)
       .map((location) => ({
         label: location.formatted,
         id: uuidv4(),
@@ -39,8 +40,7 @@ export function getContextualActions() {
           { value: selection.node, pos: selection.from },
           location,
         ),
-      }))
-      .slice(0, SUGGESTION_AMOUNT);
+      }));
 
     const otherElementsOptions = [
       {

--- a/addon/plugins/location-plugin/index.ts
+++ b/addon/plugins/location-plugin/index.ts
@@ -3,7 +3,6 @@ import {
   PluginKey,
   EditorState,
   EditorView,
-  Transaction,
   Command,
 } from '@lblod/ember-rdfa-editor';
 import { LocationType } from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/map';

--- a/addon/plugins/location-plugin/utils/get-document-locations.ts
+++ b/addon/plugins/location-plugin/utils/get-document-locations.ts
@@ -29,26 +29,28 @@ export default function getDocumentLocations(state: EditorState) {
   const locationMetadata: LocationMetadataType = {};
   const locationsDedup: (Place | Address | Area)[] = [];
   for (const locationWithDistance of locationsWithDistance) {
-    const uri =
-      (locationWithDistance.location as Address).belgianAddressUri ||
-      locationWithDistance.location.uri;
+    const { location, distance } = locationWithDistance;
+    if (!location) {
+      continue;
+    }
+    const uri = (location as Address).belgianAddressUri ?? location.uri;
     if (!locationMetadata[uri]) {
       locationMetadata[uri] = {
         ocurrences: 1,
-        distance: locationWithDistance.distance,
+        distance,
       };
-      locationsDedup.push(locationWithDistance.location);
+      locationsDedup.push(location);
     } else {
       locationMetadata[uri].ocurrences++;
-      if (locationWithDistance.distance < locationMetadata[uri].distance) {
-        locationMetadata[uri].distance = locationWithDistance.distance;
+      if (distance < locationMetadata[uri].distance) {
+        locationMetadata[uri].distance = distance;
       }
     }
   }
 
   const locations = locationsDedup.sort((a, b) => {
-    const uriA = (a as Address).belgianAddressUri || a.uri;
-    const uriB = (b as Address).belgianAddressUri || b.uri;
+    const uriA = (a as Address).belgianAddressUri ?? a.uri;
+    const uriB = (b as Address).belgianAddressUri ?? b.uri;
     if (
       locationMetadata[uriA].ocurrences === locationMetadata[uriB].ocurrences
     ) {

--- a/addon/plugins/location-plugin/utils/get-document-locations.ts
+++ b/addon/plugins/location-plugin/utils/get-document-locations.ts
@@ -33,7 +33,7 @@ export default function getDocumentLocations(state: EditorState) {
     if (!location) {
       continue;
     }
-    const uri = (location as Address).belgianAddressUri ?? location.uri;
+    const { uri } = location;
     if (!locationMetadata[uri]) {
       locationMetadata[uri] = {
         ocurrences: 1,
@@ -48,9 +48,7 @@ export default function getDocumentLocations(state: EditorState) {
     }
   }
 
-  const locations = locationsDedup.sort((a, b) => {
-    const uriA = (a as Address).belgianAddressUri ?? a.uri;
-    const uriB = (b as Address).belgianAddressUri ?? b.uri;
+  locationsDedup.sort(({ uri: uriA }, { uri: uriB }) => {
     if (
       locationMetadata[uriA].ocurrences === locationMetadata[uriB].ocurrences
     ) {
@@ -61,5 +59,6 @@ export default function getDocumentLocations(state: EditorState) {
       );
     }
   });
-  return locations;
+
+  return locationsDedup;
 }

--- a/addon/plugins/location-plugin/utils/get-document-locations.ts
+++ b/addon/plugins/location-plugin/utils/get-document-locations.ts
@@ -1,6 +1,7 @@
 import { EditorState } from '@lblod/ember-rdfa-editor';
 import { Area, Place } from './geo-helpers';
 import { Address } from './address-helpers';
+import { getLocationUri } from '../_private/utils/location-helpers';
 
 type LocationsWithDistanceType = {
   location: Place | Address | Area;
@@ -70,7 +71,7 @@ export default function getDocumentLocations(state: EditorState) {
     if (!location) {
       continue;
     }
-    const { uri } = location;
+    const uri = getLocationUri(location);
     if (!locationMetadata[uri]) {
       locationMetadata[uri] = {
         location,

--- a/addon/plugins/location-plugin/utils/get-document-locations.ts
+++ b/addon/plugins/location-plugin/utils/get-document-locations.ts
@@ -8,8 +8,46 @@ type LocationsWithDistanceType = {
 };
 
 type LocationMetadataType = {
-  [locationUri: string]: { ocurrences: number; distance: number };
+  [locationUri: string]: {
+    occurrences: number;
+    distance: number;
+    location: Address | Place | Area;
+  };
 };
+
+const PROXIMITY_WEIGHT = 0.8;
+const FREQUENCY_WEIGHT = 1 - PROXIMITY_WEIGHT;
+const PROXIMITY_DECAY = 50;
+
+/**
+ * Returns a frequency score that normalizes logarithmically to avoid domination by a few very large occurences.
+ * @param occurences amount of occurences of the location
+ * @param maxOccurences max amount of occurences for any location
+ */
+function getFrequencyScore(occurences: number, maxOccurences: number) {
+  return Math.log(occurences + 1) / Math.log(maxOccurences + 1);
+}
+
+/**
+ * Uses exponential decay to calculate a proximity score
+ * @param distance Distance from the selection
+ * @returns proximity score
+ */
+function getProximityScore(distance: number) {
+  return Math.exp(-distance / PROXIMITY_DECAY);
+}
+
+function getSuggestionScore(
+  occurrences: number,
+  maxOccurences: number,
+  distance: number,
+) {
+  const score =
+    PROXIMITY_WEIGHT * getProximityScore(distance) +
+    FREQUENCY_WEIGHT * getFrequencyScore(occurrences, maxOccurences);
+
+  return score;
+}
 
 export default function getDocumentLocations(state: EditorState) {
   const doc = state.doc;
@@ -27,7 +65,6 @@ export default function getDocumentLocations(state: EditorState) {
     return true;
   });
   const locationMetadata: LocationMetadataType = {};
-  const locationsDedup: (Place | Address | Area)[] = [];
   for (const locationWithDistance of locationsWithDistance) {
     const { location, distance } = locationWithDistance;
     if (!location) {
@@ -36,29 +73,36 @@ export default function getDocumentLocations(state: EditorState) {
     const { uri } = location;
     if (!locationMetadata[uri]) {
       locationMetadata[uri] = {
-        ocurrences: 1,
+        location,
+        occurrences: 1,
         distance,
       };
-      locationsDedup.push(location);
     } else {
-      locationMetadata[uri].ocurrences++;
+      locationMetadata[uri].occurrences++;
       if (distance < locationMetadata[uri].distance) {
         locationMetadata[uri].distance = distance;
       }
     }
   }
 
-  locationsDedup.sort(({ uri: uriA }, { uri: uriB }) => {
-    if (
-      locationMetadata[uriA].ocurrences === locationMetadata[uriB].ocurrences
-    ) {
-      return locationMetadata[uriA].distance - locationMetadata[uriB].distance;
-    } else {
-      return (
-        locationMetadata[uriB].ocurrences - locationMetadata[uriA].ocurrences
-      );
-    }
+  const maxOccurence = Object.values(locationMetadata).reduce(
+    (acc, { occurrences: ocurrences }) =>
+      acc >= ocurrences ? acc : ocurrences,
+    1,
+  );
+
+  const scoredLocations = Object.values(locationMetadata).map(
+    ({ location, occurrences, distance }) => ({
+      location,
+      score: getSuggestionScore(occurrences, maxOccurence, distance),
+      occurrences,
+      distance,
+    }),
+  );
+
+  scoredLocations.sort(({ score: scoreA }, { score: scoreB }) => {
+    return scoreB - scoreA;
   });
 
-  return locationsDedup;
+  return scoredLocations.map(({ location }) => location);
 }

--- a/addon/plugins/location-plugin/utils/replace-location.ts
+++ b/addon/plugins/location-plugin/utils/replace-location.ts
@@ -1,12 +1,40 @@
 import { ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
 import { Address } from './address-helpers';
 import { Area, Place } from './geo-helpers';
-import { EditorState, Transaction } from '@lblod/ember-rdfa-editor';
+import {
+  EditorState,
+  Transaction,
+  NodeSelection,
+  TextSelection,
+  PNode,
+  Selection,
+} from '@lblod/ember-rdfa-editor';
 import type { FullTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import { PROV } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
 import { updateSubject } from '@lblod/ember-rdfa-editor/plugins/rdfa-info/utils';
+
+function moveNodeSelectionForward(selection: Selection, doc: PNode) {
+  if (!(selection instanceof NodeSelection)) {
+    return selection;
+  }
+
+  const $from = selection.$from;
+
+  const index = $from.index();
+  const parent = $from.parent;
+
+  if (index + 1 < parent.childCount) {
+    const nextPos = selection.from + selection.node.nodeSize;
+
+    return NodeSelection.create(doc, nextPos);
+  } else {
+    const posAfter = selection.to;
+
+    return TextSelection.create(doc, posAfter);
+  }
+}
 
 export function replaceLocationCommand(
   node: ResolvedPNode,
@@ -29,22 +57,27 @@ export function replaceLocationCommand(
       }
     }); // update the location value and the external triples
     const tr = state.tr;
-    dispatch(
-      transactionCombinator(
-        state,
-        tr
-          .setNodeAttribute(pos, 'value', location)
-          .setNodeAttribute(pos, 'externalTriples', newExternalTriples),
-      )([
-        // Update the subject uri, while keeping backlinks intact
-        updateSubject({
-          pos,
-          targetSubject: location.uri,
-          keepBacklinks: true,
-          keepProperties: false,
-          keepExternalTriples: true,
-        }),
-      ]).transaction,
+    const setLocationTr = transactionCombinator(
+      state,
+      tr
+        .setNodeAttribute(pos, 'value', location)
+        .setNodeAttribute(pos, 'externalTriples', newExternalTriples),
+    )([
+      // Update the subject uri, while keeping backlinks intact
+      updateSubject({
+        pos,
+        targetSubject: location.uri,
+        keepBacklinks: true,
+        keepProperties: false,
+        keepExternalTriples: true,
+      }),
+    ]).transaction;
+
+    const newSelection = moveNodeSelectionForward(
+      state.selection.map(setLocationTr.doc, setLocationTr.mapping),
+      setLocationTr.doc,
     );
+    setLocationTr.setSelection(newSelection);
+    dispatch(setLocationTr);
   };
 }

--- a/addon/plugins/location-plugin/utils/replace-location.ts
+++ b/addon/plugins/location-plugin/utils/replace-location.ts
@@ -1,0 +1,50 @@
+import { ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
+import { Address } from './address-helpers';
+import { Area, Place } from './geo-helpers';
+import { EditorState, Transaction } from '@lblod/ember-rdfa-editor';
+import type { FullTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
+import { PROV } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { SayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
+import { transactionCombinator } from '@lblod/ember-rdfa-editor/utils/transaction-utils';
+import { updateSubject } from '@lblod/ember-rdfa-editor/plugins/rdfa-info/utils';
+
+export function replaceLocationCommand(
+  node: ResolvedPNode,
+  location: Address | Place | Area,
+) {
+  return function (state: EditorState, dispatch: (tr: Transaction) => void) {
+    const df = new SayDataFactory();
+    const { pos, value: locNode } = node;
+    // The location's subject has likely changed, so we should update the external links too
+    // if they exist
+    // NOTE: It's VERY important that this is done without mutating the triple objects
+    // otherwise the attributes will not update as expected when undo-ing
+    const newExternalTriples: FullTriple[] = (
+      locNode.attrs.externalTriples as FullTriple[]
+    ).map((tr) => {
+      if (PROV('atLocation').matches(tr.predicate)) {
+        return { ...tr, object: df.namedNode(location.uri) };
+      } else {
+        return tr;
+      }
+    }); // update the location value and the external triples
+    const tr = state.tr;
+    dispatch(
+      transactionCombinator(
+        state,
+        tr
+          .setNodeAttribute(pos, 'value', location)
+          .setNodeAttribute(pos, 'externalTriples', newExternalTriples),
+      )([
+        // Update the subject uri, while keeping backlinks intact
+        updateSubject({
+          pos,
+          targetSubject: location.uri,
+          keepBacklinks: true,
+          keepProperties: false,
+          keepExternalTriples: true,
+        }),
+      ]).transaction,
+    );
+  };
+}

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "@appuniversum/ember-appuniversum": "^3.12.0",
     "@ember/string": "3.x",
     "@glint/template": "^1.4.0",
-    "@lblod/ember-rdfa-editor": "^13.8.0",
+    "@lblod/ember-rdfa-editor": "^13.10.0",
     "ember-concurrency": "^4.0.2",
     "ember-element-helper": "^0.8.6",
     "ember-intl": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@glint/ember-tsc": "^1.5.0",
     "@glint/environment-ember-loose": "^1.5.0",
     "@glint/environment-ember-template-imports": "^1.5.0",
-    "@lblod/ember-rdfa-editor": "13.8.0-dev.ad210396007a6015c72e1dd3643855f78dddbd2c",
+    "@lblod/ember-rdfa-editor": "13.10.0",
     "@glint/template": "^1.7.7",
     "@rdfjs/to-ntriples": "^3.0.1",
     "@rdfjs/types": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@glint/ember-tsc": "^1.5.0",
     "@glint/environment-ember-loose": "^1.5.0",
     "@glint/environment-ember-template-imports": "^1.5.0",
-    "@lblod/ember-rdfa-editor": "13.8.0",
+    "@lblod/ember-rdfa-editor": "13.8.0-dev.ad210396007a6015c72e1dd3643855f78dddbd2c",
     "@glint/template": "^1.7.7",
     "@rdfjs/to-ntriples": "^3.0.1",
     "@rdfjs/types": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,8 +189,8 @@ importers:
         specifier: ^1.7.7
         version: 1.7.7
       '@lblod/ember-rdfa-editor':
-        specifier: 13.8.0
-        version: 13.8.0(eaaf812331dec1c55ca86d1378863615)
+        specifier: 13.8.0-dev.ad210396007a6015c72e1dd3643855f78dddbd2c
+        version: 13.8.0-dev.ad210396007a6015c72e1dd3643855f78dddbd2c(eaaf812331dec1c55ca86d1378863615)
       '@rdfjs/to-ntriples':
         specifier: ^3.0.1
         version: 3.0.1
@@ -1928,8 +1928,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lblod/ember-rdfa-editor@13.8.0':
-    resolution: {integrity: sha512-32EDfk8Jnf8U2CgNgIuKqModx7bLtdwF+XF8wydG1yQr3cx6uIIds2XLwH5u+BGDxWeYkcZcSW5fMVD+mJouHw==}
+  '@lblod/ember-rdfa-editor@13.8.0-dev.ad210396007a6015c72e1dd3643855f78dddbd2c':
+    resolution: {integrity: sha512-YtXar8I9gH+6XKsQdujOZ4Y7ueFJoxFzt/VZ8/QMlu1P4fQasPN9md7jr95EqDh2czZ6w7e/ob+FbCoQTu0QBA==}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.11.0 || ^4.2.1
       '@ember/test-helpers': ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
@@ -13121,7 +13121,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lblod/ember-rdfa-editor@13.8.0(eaaf812331dec1c55ca86d1378863615)':
+  '@lblod/ember-rdfa-editor@13.8.0-dev.ad210396007a6015c72e1dd3643855f78dddbd2c(eaaf812331dec1c55ca86d1378863615)':
     dependencies:
       '@appuniversum/ember-appuniversum': 4.2.2(@babel/core@7.26.0)(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@4.1.0(@babel/core@7.26.0))
       '@codemirror/commands': 6.10.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,8 +189,8 @@ importers:
         specifier: ^1.7.7
         version: 1.7.7
       '@lblod/ember-rdfa-editor':
-        specifier: 13.8.0-dev.ad210396007a6015c72e1dd3643855f78dddbd2c
-        version: 13.8.0-dev.ad210396007a6015c72e1dd3643855f78dddbd2c(eaaf812331dec1c55ca86d1378863615)
+        specifier: 13.10.0
+        version: 13.10.0(eaaf812331dec1c55ca86d1378863615)
       '@rdfjs/to-ntriples':
         specifier: ^3.0.1
         version: 3.0.1
@@ -1928,8 +1928,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lblod/ember-rdfa-editor@13.8.0-dev.ad210396007a6015c72e1dd3643855f78dddbd2c':
-    resolution: {integrity: sha512-YtXar8I9gH+6XKsQdujOZ4Y7ueFJoxFzt/VZ8/QMlu1P4fQasPN9md7jr95EqDh2czZ6w7e/ob+FbCoQTu0QBA==}
+  '@lblod/ember-rdfa-editor@13.10.0':
+    resolution: {integrity: sha512-t+v+YZLpj7roh9rQmDa752Tpcep59101VbaB9Bkg4FPjLqBJgIEiTw64eWkiG2+BVJOf2iaC+yKaFtJEj2hlJw==}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.11.0 || ^4.2.1
       '@ember/test-helpers': ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
@@ -13121,7 +13121,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lblod/ember-rdfa-editor@13.8.0-dev.ad210396007a6015c72e1dd3643855f78dddbd2c(eaaf812331dec1c55ca86d1378863615)':
+  '@lblod/ember-rdfa-editor@13.10.0(eaaf812331dec1c55ca86d1378863615)':
     dependencies:
       '@appuniversum/ember-appuniversum': 4.2.2(@babel/core@7.26.0)(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@4.1.0(@babel/core@7.26.0))
       '@codemirror/commands': 6.10.3
@@ -13755,27 +13755,6 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
-  '@types/ember@4.0.11':
-    dependencies:
-      '@types/ember__application': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__array': 4.0.10(@babel/core@7.26.0)
-      '@types/ember__component': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__controller': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__debug': 4.0.8(@babel/core@7.26.0)
-      '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
-      '@types/ember__error': 4.0.6
-      '@types/ember__object': 4.0.12(@babel/core@7.26.0)
-      '@types/ember__polyfills': 4.0.6
-      '@types/ember__routing': 4.0.22(@babel/core@7.26.0)
-      '@types/ember__runloop': 4.0.10
-      '@types/ember__service': 4.0.9(@babel/core@7.26.0)
-      '@types/ember__string': 3.0.15
-      '@types/ember__template': 4.0.7
-      '@types/ember__test': 4.0.6(@babel/core@7.26.0)
-      '@types/ember__utils': 4.0.7
-      '@types/rsvp': 4.0.9
-    optional: true
-
   '@types/ember@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@types/ember__application': 4.0.11(@babel/core@7.26.0)
@@ -13803,7 +13782,7 @@ snapshots:
   '@types/ember__application@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
-      '@types/ember': 4.0.11
+      '@types/ember': 4.0.11(@babel/core@7.26.0)
       '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
       '@types/ember__object': 4.0.12(@babel/core@7.26.0)
       '@types/ember__owner': 4.0.9
@@ -13905,11 +13884,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@types/ember__runloop@4.0.10':
-    dependencies:
-      '@types/ember': 4.0.11
-    optional: true
-
   '@types/ember__runloop@4.0.10(@babel/core@7.26.0)':
     dependencies:
       '@types/ember': 4.0.11(@babel/core@7.26.0)
@@ -13938,11 +13912,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    optional: true
-
-  '@types/ember__utils@4.0.7':
-    dependencies:
-      '@types/ember': 4.0.11
     optional: true
 
   '@types/ember__utils@4.0.7(@babel/core@7.26.0)':

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -452,6 +452,7 @@ location-plugin:
     insert-point-on-map: Insert a point on the map
     insert-area: Insert area
     other-elements: Other elements
+    location-suggestions: Location suggestions
   types:
     address: Address
     place: Place

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -449,6 +449,7 @@ location-plugin:
     insert-point-on-map: Punt op de kaart invoegen
     insert-area: Gebied invoegen
     other-elements: Andere elementen
+    location-suggestions: Locatiesuggesties
   types:
     address: Adres
     place: Plaats


### PR DESCRIPTION
### Overview
Integrates the location suggestions described in https://www.figma.com/design/PbSOBtGdYHBArIjVMEIApP/GN_location-plugin?node-id=46-3621

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6164
https://binnenland.atlassian.net/browse/GN-6003


### Setup
Needs https://github.com/lblod/ember-rdfa-editor/pull/1377

### How to test/reproduce
Add some locations to the document. The contextual actions when clicking on a location should now also suggest other locations in the document. Clicking a suggestion should change the content of the highlighted location node and move the selection forward by one position.

### Checks PR readiness
- [x] changelog
- [x] npm lint
