### PR TITLE
Wait document content on insert

### DIFF
--- a/.changeset/hot-ducks-sniff.md
+++ b/.changeset/hot-ducks-sniff.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Fetch document content before passing it up on the document template component in order to solve race condition on GN

--- a/addon/components/common/documents/preview.gts
+++ b/addon/components/common/documents/preview.gts
@@ -14,6 +14,7 @@ import t from 'ember-intl/helpers/t';
 import { SayController } from '@lblod/ember-rdfa-editor';
 import { PreviewableDocument } from './types';
 import { VoteStarUnfilledIcon } from '../vote-star-unfilled-icon';
+import perform from 'ember-concurrency/helpers/perform';
 
 interface Signature<Doc extends PreviewableDocument> {
   Args: {
@@ -31,10 +32,10 @@ export default class DocumentPreview<
   @tracked controller?: SayController;
   @tracked isExpanded = false;
 
-  @action
-  onInsert() {
+  onInsert = task(async () => {
+    await this.contentTask.perform();
     this.args.onInsert(this.args.doc);
-  }
+  });
 
   @action
   togglePreview() {
@@ -101,7 +102,7 @@ export default class DocumentPreview<
         <div
           role='button'
           title={{t 'common.preview-list.select-button.title'}}
-          {{on 'click' this.onInsert}}
+          {{on 'click' (perform this.onInsert)}}
           {{! template-lint-disable require-presentational-children}}
         >
           <AuButton class='snippet-preview__insert-button' @skin='naked'>

--- a/addon/plugins/location-plugin/index.ts
+++ b/addon/plugins/location-plugin/index.ts
@@ -3,7 +3,6 @@ import {
   PluginKey,
   EditorState,
   EditorView,
-  Transaction,
   Command,
 } from '@lblod/ember-rdfa-editor';
 import { LocationType } from '@lblod/ember-rdfa-editor-lblod-plugins/components/location-plugin/map';


### PR DESCRIPTION
### Overview
Not waiting on the content for the document when passing it up to the onInsert function was provoking a race condition, this solves that and the problem with the submit function on the document creator of GN getting stuck

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6162


### Setup
None

### How to test/reproduce
This one is tricky to test, first make sure you can reproduce the bug on GN, I managed to do so disabling the cache in the dev-tools and using a local build image of docker on the GN stack.
Then replace the version of the plugins for this one and try again, the bug should be solved

### Challenges/uncertainties
As it was tricky to reproduce for me, it could still be edge cases so please let me know if you get any problem, even if it happens one out of 500



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
