### PR TITLE
feat: add option to insert location as placeholder

### DIFF
--- a/.changeset/hip-rocks-burn.md
+++ b/.changeset/hip-rocks-burn.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add option to make location-insert insert a placeholder instead

--- a/addon/components/location-plugin/insert.gts
+++ b/addon/components/location-plugin/insert.gts
@@ -7,6 +7,7 @@ import not from 'ember-truth-helpers/helpers/not';
 import IntlService from 'ember-intl/services/intl';
 import t from 'ember-intl/helpers/t';
 import { trackedReset } from 'tracked-toolbox';
+import { v4 as uuidv4 } from 'uuid';
 import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
 import AuModal from '@appuniversum/ember-appuniversum/components/au-modal';
 import AuLoader from '@appuniversum/ember-appuniversum/components/au-loader';
@@ -66,6 +67,11 @@ interface Signature {
     defaultMunicipality?: Option<string>;
     templateMode?: boolean;
     locationTypes?: LocationType[];
+    /**
+     * TODO: remove this option once the modal has been reworked and the UX of the button
+     * has settled
+     */
+    insertPlaceholder?: boolean;
   };
   Element: HTMLLIElement;
 }
@@ -219,9 +225,26 @@ export default class LocationPluginInsertComponent extends Component<Signature> 
     closeLocationModal(this.controller.activeEditorView);
   }
 
+  get insertPlaceholder() {
+    return this.args.insertPlaceholder ?? false;
+  }
   @action
   insertOrEditAddress() {
-    openLocationModal(this.controller.activeEditorView, 'address');
+    // TODO: remove this logic once the whole modal redesign is through and we settled on
+    // the UX of this button
+    if (this.selectedLocationNode ?? !this.insertPlaceholder) {
+      openLocationModal(this.controller.activeEditorView, 'address');
+    } else {
+      const uri = `http://data.lblod.info/variables/${
+        this.args.templateMode ? '--ref-uuid4-' : ''
+      }${uuidv4()}`;
+      replaceSelectionWithLocation({
+        controller: this.controller,
+        subject: uri,
+        subjectTypes: this.args.config.subjectTypesToLinkTo,
+        explicitSubjectToLinkTo: this.args.config.explicitSubjectToLinkTo,
+      });
+    }
   }
 
   @action

--- a/tests/dummy/app/templates/besluit-sample.hbs
+++ b/tests/dummy/app/templates/besluit-sample.hbs
@@ -129,6 +129,7 @@
                 @config={{this.config.location}}
                 @locationTypes={{array 'place' 'address' 'area'}}
                 @defaultMunicipality='Gent'
+                @insertPlaceholder={{true}}
               />
               <LocationPlugin::InsertLocationPlaceholder
                 @controller={{container.controller}}


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

This is a temporary solution to make the UI transition to the newer location nodes a bit smoother. 
Before, clicking "insert location" would first insert a pill in the document, and then require you to click "edit" in the sidebar.
With the rework, the "insert" button would always immediately open the modal. This is likely a good thing, but since the modal is currently a bit lacking compared to the contextual actions (it doesn't have the location suggestions yet), we're actually making the UX a bit worse by doing this, and hiding our recent nice work.

Additionally, it is an extra UX change for a GN user to get used to. 
So this pr adds an option to make that transition more gradual, by restoring the insert-first-then-edit behavior (but of course now with the context menu)

This highlights the location suggestions nicely as the newly inserted pill is immediately selected and thus has its contextual actions shown.

This is intended to be a stopgap solution, until we come to a final UX for this insert button.

The default is left as-is, opening the modal.

Due to the upcoming demo by MOW, this has been fast-tracked.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness

- [x] changelog
- [x] npm lint
- [x] no new deprecations
