### PR TITLE
always use text content to avoid parsing problems

### DIFF
--- a/addon/plugins/structure-plugin/node.ts
+++ b/addon/plugins/structure-plugin/node.ts
@@ -211,7 +211,7 @@ export const emberNodeConfig: (
       const hasTitle = node.attrs.hasTitle as boolean;
       const titleHTML = hasTitle
         ? parser.parseFromString(node.attrs.title, 'text/html').body
-            .firstElementChild
+            .firstElementChild?.textContent
         : null;
       const headerFormat = node.attrs.headerFormat as string;
       const romanizeNumber = node.attrs.romanize as boolean;


### PR DESCRIPTION
### Overview
Seems like title parsing on the structures is failing, due to including the whole span in the prosemirror json. I added the text content accessor so it always pass down a string, this works on all the structures I tested, but if you make it break please let me know as this is a risky PR

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6161


### Setup
None

### How to test/reproduce
Check that all the structures are parsed correctly even if they have titles.
If you want to really make it break before the PR link to GN and open the RPR - rechtspositieregeling 2026 template and try to save

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
