### PR TITLE
Use parse slice to not include unneeded paragraphs on the inline locked placeholders parse

### DIFF
--- a/.changeset/rude-pets-double.md
+++ b/.changeset/rude-pets-double.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Use parse slice to not include unneeded paragraphs on the inline locked placeholders parse

--- a/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
+++ b/addon/plugins/locked-placeholder-plugin/utils/replace-content-function.ts
@@ -67,7 +67,7 @@ function replacePlaceholderWithHtml(
 ) {
   return (state: EditorState) => {
     const domParser = new DOMParser();
-    const contentFragment = ProseParser.fromSchema(state.schema).parse(
+    const contentFragment = ProseParser.fromSchema(state.schema).parseSlice(
       domParser.parseFromString(value, 'text/html'),
     ).content;
     const tr = state.tr;


### PR DESCRIPTION
### Overview
When parsing html to replace inline placeholders the parse function was including unneeded paragraphs, using parseSlice instead fixes this 

##### connected issues and PRs:
https://github.com/lblod/frontend-embeddable-notule-editor/pull/290


### Setup
None

### How to test/reproduce
Check that you can replace inline placeholders and the final content is still inline

### Challenges/uncertainties
May be that we need to force a fragment for blocks? but I think if they want the final content to be inline it should be like that



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check if dummy app is correctly updated
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
