### PR TITLE
Make endpoint arg to location variable options required in types

### DIFF
--- a/.changeset/kind-humans-allow.md
+++ b/.changeset/kind-humans-allow.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Make endpoint arg for location variable config required in the typescript type, which matches the documentation, and the reality of handling locations without a source attribute

--- a/addon/plugins/variable-plugin/contextual-actions/index.ts
+++ b/addon/plugins/variable-plugin/contextual-actions/index.ts
@@ -51,11 +51,11 @@ function getSelectedLocation(state: EditorState) {
   }
 }
 
-function getSource(state: EditorState, fallback?: string) {
+function getSource(state: EditorState, fallback: string) {
   const selectedLocation = getSelectedLocation(state);
   if (selectedLocation) {
     const { node } = selectedLocation;
-    const source = node.attrs.source;
+    const source = node.attrs.source as string | undefined;
     if (source) {
       return source;
     }
@@ -92,7 +92,7 @@ function getIsZonal(state: EditorState) {
 type GetContextualActionsAttrs = {
   zonalLocationCodelistUri: string;
   nonZonalLocationCodelistUri: string;
-  endpoint?: string;
+  endpoint: string;
 };
 
 function humanReadableLabel(label: string) {


### PR DESCRIPTION
### Overview
Not considered a major as the documentation already specifies that it is required, only the types said it was optional.

##### connected issues and PRs:
Discovered in https://github.com/lblod/frontend-embeddable-notule-editor/pull/293

### Setup
N/A

### How to test/reproduce
No change, just types

### Challenges/uncertainties
Unsure if this should technically be a major, but since it's in the docs, I think we're okay.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
