### PR TITLE
Use node v22 and pnpm v11.10 for build process

### DIFF
--- a/.changeset/young-parents-explode.md
+++ b/.changeset/young-parents-explode.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Use node v22 for build process and pnpm v11.10

--- a/.woodpecker/.changeset.yml
+++ b/.woodpecker/.changeset.yml
@@ -1,6 +1,6 @@
 steps:
   changelog:
-    image: danlynn/ember-cli:4.8.0
+    image: danlynn/ember-cli:5.12.0-node_22.9
     commands:
       - git fetch origin master
       - git diff -wb --name-only origin/master..HEAD | grep "\.changeset/.*\.md"

--- a/.woodpecker/.release-commit.yml
+++ b/.woodpecker/.release-commit.yml
@@ -1,11 +1,13 @@
 steps:
   install:
-    image: node:20-slim
+    image: node:22-slim
     commands:
+      - npm config set ignore-scripts true
+      - npm i -g corepack@0.35
       - corepack enable
       - pnpm i --frozen-lockfile
   version:
-    image: node:20-slim
+    image: node:22-slim
     commands:
       - npm version --no-git-tag-version $(npm pkg get version | sed 's/"//g')-dev.${CI_COMMIT_SHA}
   release:

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,7 +1,9 @@
 steps:
   install:
-    image: node:20-slim
+    image: node:22-slim
     commands:
+      - npm config set ignore-scripts true
+      - npm i -g corepack@0.35
       - corepack enable
       - pnpm i --frozen-lockfile
   release:

--- a/.woodpecker/.verify-pr.yml
+++ b/.woodpecker/.verify-pr.yml
@@ -1,34 +1,38 @@
 steps:
   install:
-    image: node:20-slim
+    image: node:22-slim
     commands:
+      - npm config set ignore-scripts true
+      - npm i -g corepack@0.35
       - corepack enable
       - pnpm i --frozen-lockfile
   lint-js:
-    image: node:20-slim
+    image: node:22-slim
     group: lint
     commands:
       - corepack enable
       - pnpm lint:js
   lint-hbs:
-    image: node:20-slim
+    image: node:22-slim
     group: lint
     commands:
       - corepack enable
       - pnpm lint:hbs
   lint-prettier:
-    image: node:20-slim
+    image: node:22-slim
     group: lint
     commands:
       - corepack enable
       - pnpm lint:prettier
   test:
-    image: danlynn/ember-cli:4.12.1
+    image: danlynn/ember-cli:5.12.0-node_22.9
     commands:
+      - npm config set ignore-scripts true
+      - npm i -g corepack@0.35
       - corepack enable
       - pnpm test:ember
   precompile:
-    image: node:20-slim
+    image: node:22-slim
     commands:
       - corepack enable
       - pnpm prepack

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,22 +4,22 @@
 
 * `git clone https://github.com/lblod/ember-rdfa-editor-lblod-plugins`
 * `cd ember-rdfa-editor-lblod-plugins`
-* `npm install`
+* `pnpm install`
 
 ## Linting
 
-* `npm run lint`
-* `npm run lint:fix`
+* `pnpm lint`
+* `pnpm lint:fix`
 
 ## Running tests
-* `npm run test` – Runs the test suite on the current Ember version
+* `pnpm test` – Runs the test suite on the current Ember version
 
 ## Running the test application
 
-* `npm start`
+* `pnpm start`
 * Visit the test application at [http://localhost:4200](http://localhost:4200).
 
 For more information on using ember-cli, visit [https://cli.emberjs.com/release/](https://cli.emberjs.com/release/).
 
 ## Changelog
-It is mandatory that every PR has an entry added to the changelog. Do this by running `npx changeset` and following the instructions, which will add a changelog entry to `.changeset` folder.
+It is mandatory that every PR has an entry added to the changelog. Do this by running `pnpm changeset` and following the instructions, which will add a changelog entry to `.changeset` folder.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ related to the LBLOD Project.
   4.12 is no longer tested and not officially supported, but should still work for now.
 
 - Embroider or ember-auto-import v2
-- Node 18 or above (20+ recommended)
+- Node 18 or above (22+ recommended)
 
 ## Installation
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,7 +31,7 @@ Once the prep work is completed, the actual release is straight forward:
 * First, ensure that you have installed your projects dependencies:
 
 ```sh
-npm install
+pnpm install
 ```
 
 * Second, ensure that you have obtained a
@@ -50,7 +50,7 @@ npm install
 * And last (but not least 😁) do your release.
 
 ```sh
-npx release-it
+pnpm release
 ```
 
 [release-it](https://github.com/release-it/release-it/) manages the actual

--- a/package.json
+++ b/package.json
@@ -216,5 +216,5 @@
   "ember-addon": {
     "configPath": "tests/dummy/config"
   },
-  "packageManager": "pnpm@10.28.2"
+  "packageManager": "pnpm@11.10.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
+allowBuilds:
+  core-js: true
 overrides:
   'prosemirror-model': '^1.25.9'


### PR DESCRIPTION
### Overview
We should use a node version that is supported for builds...

It seems `danlynn/ember-cli` doesn't exist in an ember/node version combination for this to work, so we'll either need to get a new combo from them (or our own) or upgrade ember. Made into a draft until one of those happens.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Build woodpecker steps should work.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
