### PR TITLE
Make codelist show up in editable nodes node attributes inspector

### DIFF
--- a/.changeset/fair-mangos-study.md
+++ b/.changeset/fair-mangos-study.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+make codelist editable for it to show up in the editable nodes node inspector

--- a/addon/plugins/variable-plugin/variables/codelist.ts
+++ b/addon/plugins/variable-plugin/variables/codelist.ts
@@ -159,7 +159,7 @@ const emberNodeConfig: EmberNodeConfig = {
   group: 'inline variable',
   content: 'codelist_option*',
   atom: true,
-  editable: false,
+  editable: true,
   recreateUriFunction: recreateVariableUris,
   draggable: false,
   needsFFKludge: true,


### PR DESCRIPTION
### Overview
Rdfa id was not showing up for marcodes in de editable nodes node inspector. This PR fixes that by making the node `editable` which causes it to be detected by the `getActiveEditableNode` function.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6223


### How to test/reproduce
Create a marcode and select it. The node information should show up in the editable nodes node attributes panel

