### PR TITLE
Add contextual actions for codelist variables

### DIFF
--- a/.changeset/four-kiwis-smash.md
+++ b/.changeset/four-kiwis-smash.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Fix bug in location description context actions where one cache was used for both zonal and non-zonal options

--- a/.changeset/khaki-poets-remain.md
+++ b/.changeset/khaki-poets-remain.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+Keep context menu open after selecting codelist options

--- a/.changeset/soft-rabbits-jump.md
+++ b/.changeset/soft-rabbits-jump.md
@@ -1,0 +1,8 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': minor
+---
+
+Add contextual actions for filling in codelist values. This introduces new contextual actions for
+the variable-plugin, so the import for place description actions has moved to
+`@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions/place-description`.
+The old import location remains for backwards compatibility.

--- a/.changeset/warm-toys-visit.md
+++ b/.changeset/warm-toys-visit.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor-lblod-plugins': patch
+---
+
+bump editor to [@lblod](https://github.com/lblod/ember-rdfa-editor/releases/tag/@lblod/ember-rdfa-editor@13.16.0)

--- a/addon/plugins/variable-plugin/contextual-actions/codelist.ts
+++ b/addon/plugins/variable-plugin/contextual-actions/codelist.ts
@@ -9,6 +9,7 @@ import { updateCodelistVariableCommand } from '../utils/codelist-utils';
 import {
   type CodeListOptions,
   fetchCodeListOptions,
+  CodeListOption,
 } from '../utils/fetch-data';
 import { CodelistAttrs } from '../variables';
 
@@ -67,6 +68,15 @@ export function getContextualActions(attrs: GetContextualActionsAttrs) {
     const activeNode = getActiveEditableNode(state);
     if (!activeNode) return [];
     const result = await getCodelistOptionsCached(activeNode, attrs);
+    const isMultiSelect = activeNode.value.attrs['selectionStyle'] === 'multi';
+    const selectedOptions: CodeListOption[] = [];
+    activeNode.value.content.forEach((contentNode) => {
+      selectedOptions.push({
+        uri: contentNode.attrs.subject,
+        label: contentNode.textContent,
+      });
+    });
+
     return result.options
       .filter(
         (option) =>
@@ -74,11 +84,20 @@ export function getContextualActions(attrs: GetContextualActionsAttrs) {
           option.label.toLowerCase().includes(searchQuery.toLowerCase()),
       )
       .map((option) => {
+        const selected = selectedOptions.some(
+          (selOption) => selOption.uri === option.uri,
+        );
+        const newOptions = selected
+          ? selectedOptions.filter((selOption) => selOption.uri !== option.uri)
+          : isMultiSelect
+            ? [...selectedOptions, option]
+            : option;
         return {
           id: uuidv4(),
           label: humanReadableLabel(option.label),
           group: codelistGroupId,
-          command: updateCodelistVariableCommand(activeNode, option),
+          command: updateCodelistVariableCommand(activeNode, newOptions),
+          selected,
         };
       });
   };
@@ -104,6 +123,7 @@ export function getCodelistActionGroups(attrs: GetContextualActionsAttrs) {
               'variable.codelist.label',
               'Codelijst',
             ),
+            keepOpen: true,
             getActions: getContextualActions(attrs),
           },
         ]

--- a/addon/plugins/variable-plugin/contextual-actions/codelist.ts
+++ b/addon/plugins/variable-plugin/contextual-actions/codelist.ts
@@ -1,0 +1,112 @@
+import { v4 as uuidv4 } from 'uuid';
+import { EditorState } from '@lblod/ember-rdfa-editor';
+import { getActiveEditableNode } from '@lblod/ember-rdfa-editor/plugins/editable-node';
+import { isRdfaAttrs } from '@lblod/ember-rdfa-editor/core/rdfa-types';
+import { ContextualActionGroup } from '@lblod/ember-rdfa-editor/plugins/contextual-actions';
+import { ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
+import { getTranslationFunction } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/translation';
+import { updateCodelistVariableCommand } from '../utils/codelist-utils';
+import {
+  type CodeListOptions,
+  fetchCodeListOptions,
+} from '../utils/fetch-data';
+import { CodelistAttrs } from '../variables';
+
+const codelistGroupId = 'codelist-db36f85d-edbf-45dc-85fc-9fb67649fe00';
+
+const codelistOptionsCache: Map<string, CodeListOptions> = new Map();
+
+function getSource(codelistAttrs: CodelistAttrs, fallback?: string) {
+  if (codelistAttrs) {
+    const source = codelistAttrs['source'];
+    if (source && source !== 'UNKNOWN') {
+      return source;
+    }
+  }
+  return fallback;
+}
+
+type GetContextualActionsAttrs = {
+  endpoint?: string;
+};
+
+function humanReadableLabel(label: string) {
+  return label.replace(/\$\{[^}]+\}/g, '…');
+}
+
+async function getCodelistOptionsCached(
+  activeNode: ResolvedPNode,
+  { endpoint }: GetContextualActionsAttrs,
+) {
+  const codelistAttrs = activeNode.value.attrs as CodelistAttrs | undefined;
+  const source = codelistAttrs && getSource(codelistAttrs, endpoint);
+  const codelistUri = codelistAttrs?.codelist;
+
+  let result = codelistUri && codelistOptionsCache.get(codelistUri);
+  if (!result && codelistAttrs?.hardcodedOptionList) {
+    result = {
+      type: '',
+      options: codelistAttrs.hardcodedOptionList,
+    } as CodeListOptions;
+  }
+  if (!result && source && codelistUri) {
+    result = await fetchCodeListOptions(source, codelistUri);
+    codelistOptionsCache.set(codelistUri, result);
+    if (!result) {
+      console.warn(
+        `Failed to fetch codelist options for ${codelistUri} from ${source}`,
+      );
+    }
+  }
+
+  return result || { type: '', options: [] };
+}
+
+export function getContextualActions(attrs: GetContextualActionsAttrs) {
+  return async function (state: EditorState, searchQuery?: string) {
+    const activeNode = getActiveEditableNode(state);
+    if (!activeNode) return [];
+    const result = await getCodelistOptionsCached(activeNode, attrs);
+    return result.options
+      .filter(
+        (option) =>
+          !searchQuery ||
+          option.label.toLowerCase().includes(searchQuery.toLowerCase()),
+      )
+      .map((option) => {
+        return {
+          id: uuidv4(),
+          label: humanReadableLabel(option.label),
+          group: codelistGroupId,
+          command: updateCodelistVariableCommand(activeNode, option),
+        };
+      });
+  };
+}
+
+function contextualGroupIsVisible(state: EditorState) {
+  const activeNode = getActiveEditableNode(state);
+  const isCodelist =
+    activeNode &&
+    isRdfaAttrs(activeNode.value.attrs) &&
+    activeNode?.value.type.name === 'codelist';
+
+  return isCodelist;
+}
+
+export function getCodelistActionGroups(attrs: GetContextualActionsAttrs) {
+  return function (state: EditorState): ContextualActionGroup[] {
+    return contextualGroupIsVisible(state)
+      ? [
+          {
+            id: codelistGroupId,
+            label: getTranslationFunction(state)(
+              'variable.codelist.label',
+              'Codelijst',
+            ),
+            getActions: getContextualActions(attrs),
+          },
+        ]
+      : [];
+  };
+}

--- a/addon/plugins/variable-plugin/contextual-actions/index.ts
+++ b/addon/plugins/variable-plugin/contextual-actions/index.ts
@@ -1,0 +1,6 @@
+export {
+  /** @deprecated these imports have been moved to contextual-actions/place-description.ts */
+  getContextualActions,
+  /** @deprecated these imports have been moved to contextual-actions/place-description.ts */
+  getPlaceDescriptionActionGroups as getContextualActionGroups,
+} from './place-description';

--- a/addon/plugins/variable-plugin/contextual-actions/index.ts
+++ b/addon/plugins/variable-plugin/contextual-actions/index.ts
@@ -31,9 +31,11 @@ const plaatsbepalingGroupId =
   'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5';
 
 const placeDescriptionCodelistCache: {
-  placeDescriptions: CodeListOptions | null;
+  zonal: CodeListOptions | null;
+  nonZonal: CodeListOptions | null;
 } = {
-  placeDescriptions: null,
+  zonal: null,
+  nonZonal: null,
 };
 
 function getSelectedLocation(state: EditorState) {
@@ -149,15 +151,16 @@ async function getPlaceDescriptionsCached(
 ) {
   const source = getSource(state, endpoint);
   const isZonal = getIsZonal(state);
+  const zonality = isZonal ? 'zonal' : 'nonZonal';
   let options;
-  if (!placeDescriptionCodelistCache.placeDescriptions) {
+  if (!placeDescriptionCodelistCache[zonality]) {
     options = await fetchCodeListOptions(
       source,
       isZonal ? zonalLocationCodelistUri : nonZonalLocationCodelistUri,
     );
-    placeDescriptionCodelistCache.placeDescriptions = options;
+    placeDescriptionCodelistCache[zonality] = options;
   } else {
-    options = placeDescriptionCodelistCache.placeDescriptions;
+    options = placeDescriptionCodelistCache[zonality];
   }
 
   return options;

--- a/addon/plugins/variable-plugin/contextual-actions/place-description.ts
+++ b/addon/plugins/variable-plugin/contextual-actions/place-description.ts
@@ -202,7 +202,9 @@ function contextualGroupIsVisible(state: EditorState) {
   );
 }
 
-export function getContextualActionGroups(attrs: GetContextualActionsAttrs) {
+export function getPlaceDescriptionActionGroups(
+  attrs: GetContextualActionsAttrs,
+) {
   return function (state: EditorState): ContextualActionGroup[] {
     return contextualGroupIsVisible(state)
       ? [

--- a/addon/plugins/variable-plugin/utils/codelist-utils.ts
+++ b/addon/plugins/variable-plugin/utils/codelist-utils.ts
@@ -1,7 +1,14 @@
 // This file contains helpers for both the codelist and location variable types
 
+import {
+  EditorState,
+  PNode,
+  ProseParser,
+  SayController,
+  Transaction,
+} from '@lblod/ember-rdfa-editor';
+import { ResolvedPNode } from '@lblod/ember-rdfa-editor/utils/_private/types';
 import { CodeListOption } from './fetch-data';
-import { PNode, ProseParser, SayController } from '@lblod/ember-rdfa-editor';
 import { createCodelistOptionNode } from '../actions/create-codelist-variable';
 import { unwrap } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/option';
 
@@ -21,6 +28,40 @@ export function wrapVariableInHighlight(text: string) {
   );
 }
 
+export function updateCodelistVariableCommand(
+  selectedCodelist: ResolvedPNode,
+  selectedOption: CodeListOption | CodeListOption[],
+) {
+  return (state: EditorState, dispatch?: (tr: Transaction) => void) => {
+    const selectedOptions = Array.isArray(selectedOption)
+      ? selectedOption
+      : [selectedOption];
+    const variableInstance = selectedCodelist.value.attrs[
+      'variableInstance'
+    ] as string | undefined;
+    const pointerTarget = selectedCodelist.value.attrs['__rdfaId'] as
+      | string
+      | undefined;
+    const codelistOptionNodes = selectedOptions.map((option) =>
+      createCodelistOptionNode({
+        schema: state.schema,
+        text: option.label,
+        subject: option.uri,
+        variableInstance,
+        pointsToNode: pointerTarget,
+      }),
+    );
+    const range = {
+      from: selectedCodelist.pos + 1,
+      to: selectedCodelist.pos + selectedCodelist.value.nodeSize - 1,
+    };
+    if (dispatch) {
+      dispatch(state.tr.replaceWith(range.from, range.to, codelistOptionNodes));
+    }
+    return true;
+  };
+}
+
 export function updateCodelistVariable(
   selectedCodelist: {
     node: PNode;
@@ -29,31 +70,11 @@ export function updateCodelistVariable(
   selectedOption: CodeListOption | CodeListOption[],
   controller: SayController,
 ) {
-  const selectedOptions = Array.isArray(selectedOption)
-    ? selectedOption
-    : [selectedOption];
-  const variableInstance = selectedCodelist.node.attrs['variableInstance'] as
-    | string
-    | undefined;
-  const pointerTarget = selectedCodelist.node.attrs['__rdfaId'] as
-    | string
-    | undefined;
-  const codelistOptionNodes = selectedOptions.map((option) =>
-    createCodelistOptionNode({
-      schema: controller.schema,
-      text: option.label,
-      subject: option.uri,
-      variableInstance,
-      pointsToNode: pointerTarget,
-    }),
+  const command = updateCodelistVariableCommand(
+    { value: selectedCodelist.node, pos: selectedCodelist.pos },
+    selectedOption,
   );
-  const range = {
-    from: selectedCodelist.pos + 1,
-    to: selectedCodelist.pos + selectedCodelist.node.nodeSize - 1,
-  };
-  controller.withTransaction((tr) => {
-    return tr.replaceWith(range.from, range.to, codelistOptionNodes);
-  });
+  controller.doCommand(command, { view: controller.mainEditorView });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@glint/ember-tsc": "^1.5.0",
     "@glint/environment-ember-loose": "^1.5.0",
     "@glint/environment-ember-template-imports": "^1.5.0",
-    "@lblod/ember-rdfa-editor": "13.12.0",
+    "@lblod/ember-rdfa-editor": "13.15.1-dev.c5cefcf9a50117c08ff14a54a8b585d176b0654c",
     "@glint/template": "^1.7.7",
     "@rdfjs/to-ntriples": "^3.0.1",
     "@rdfjs/types": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@babel/core": "^7.25.2",
     "@codemirror/lang-html": "^6.4.9",
-    "@codemirror/state": "^6.4.1",
+    "@codemirror/state": "^6.7.0",
     "@codemirror/view": "^6.28.3",
     "@curvenote/prosemirror-utils": "^1.0.5",
     "@embroider/macros": "^1.19.7",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@glint/ember-tsc": "^1.5.0",
     "@glint/environment-ember-loose": "^1.5.0",
     "@glint/environment-ember-template-imports": "^1.5.0",
-    "@lblod/ember-rdfa-editor": "13.15.1-dev.c5cefcf9a50117c08ff14a54a8b585d176b0654c",
+    "@lblod/ember-rdfa-editor": "13.16.0",
     "@glint/template": "^1.7.7",
     "@rdfjs/to-ntriples": "^3.0.1",
     "@rdfjs/types": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,8 +185,8 @@ importers:
         specifier: ^1.7.7
         version: 1.7.7
       '@lblod/ember-rdfa-editor':
-        specifier: 13.15.1-dev.c5cefcf9a50117c08ff14a54a8b585d176b0654c
-        version: 13.15.1-dev.c5cefcf9a50117c08ff14a54a8b585d176b0654c(eaaf812331dec1c55ca86d1378863615)
+        specifier: 13.16.0
+        version: 13.16.0(eaaf812331dec1c55ca86d1378863615)
       '@rdfjs/to-ntriples':
         specifier: ^3.0.1
         version: 3.0.1
@@ -1924,8 +1924,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lblod/ember-rdfa-editor@13.15.1-dev.c5cefcf9a50117c08ff14a54a8b585d176b0654c':
-    resolution: {integrity: sha512-uVeueCuJsSWTQxBz2jA62cl75iOZbEjg+lIwLSWEhGgO1rmc+vrwlRZpVfSbQovrFH09LD81Tb50NxE2t+jgWQ==}
+  '@lblod/ember-rdfa-editor@13.16.0':
+    resolution: {integrity: sha512-HT9oF3qv/tyqF9nyGkbjd9UU6eO/Y9QeTNq6TTseK29YZu2D46VYCf1H+SBRr2ektJzBAQlYnaQfEfh3c6DemQ==}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.11.0 || ^4.2.1
       '@ember/test-helpers': ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
@@ -13108,7 +13108,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lblod/ember-rdfa-editor@13.15.1-dev.c5cefcf9a50117c08ff14a54a8b585d176b0654c(eaaf812331dec1c55ca86d1378863615)':
+  '@lblod/ember-rdfa-editor@13.16.0(eaaf812331dec1c55ca86d1378863615)':
     dependencies:
       '@appuniversum/ember-appuniversum': 4.2.2(@babel/core@7.26.0)(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@4.1.0(@babel/core@7.26.0))
       '@codemirror/commands': 6.10.3
@@ -13737,6 +13737,27 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
+  '@types/ember@4.0.11':
+    dependencies:
+      '@types/ember__application': 4.0.11(@babel/core@7.26.0)
+      '@types/ember__array': 4.0.10(@babel/core@7.26.0)
+      '@types/ember__component': 4.0.22(@babel/core@7.26.0)
+      '@types/ember__controller': 4.0.12(@babel/core@7.26.0)
+      '@types/ember__debug': 4.0.8(@babel/core@7.26.0)
+      '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
+      '@types/ember__error': 4.0.6
+      '@types/ember__object': 4.0.12(@babel/core@7.26.0)
+      '@types/ember__polyfills': 4.0.6
+      '@types/ember__routing': 4.0.22(@babel/core@7.26.0)
+      '@types/ember__runloop': 4.0.10
+      '@types/ember__service': 4.0.9(@babel/core@7.26.0)
+      '@types/ember__string': 3.0.15
+      '@types/ember__template': 4.0.7
+      '@types/ember__test': 4.0.6(@babel/core@7.26.0)
+      '@types/ember__utils': 4.0.7
+      '@types/rsvp': 4.0.9
+    optional: true
+
   '@types/ember@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@types/ember__application': 4.0.11(@babel/core@7.26.0)
@@ -13764,7 +13785,7 @@ snapshots:
   '@types/ember__application@4.0.11(@babel/core@7.26.0)':
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.26.0)
-      '@types/ember': 4.0.11(@babel/core@7.26.0)
+      '@types/ember': 4.0.11
       '@types/ember__engine': 4.0.11(@babel/core@7.26.0)
       '@types/ember__object': 4.0.12(@babel/core@7.26.0)
       '@types/ember__owner': 4.0.9
@@ -13866,6 +13887,11 @@ snapshots:
       - supports-color
     optional: true
 
+  '@types/ember__runloop@4.0.10':
+    dependencies:
+      '@types/ember': 4.0.11
+    optional: true
+
   '@types/ember__runloop@4.0.10(@babel/core@7.26.0)':
     dependencies:
       '@types/ember': 4.0.11(@babel/core@7.26.0)
@@ -13894,6 +13920,11 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+    optional: true
+
+  '@types/ember__utils@4.0.7':
+    dependencies:
+      '@types/ember': 4.0.11
     optional: true
 
   '@types/ember__utils@4.0.7(@babel/core@7.26.0)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   prosemirror-model: ^1.25.9
+  '@codemirror/state': ^6.7.0
 
 importers:
 
@@ -18,8 +19,8 @@ importers:
         specifier: ^6.4.9
         version: 6.4.11
       '@codemirror/state':
-        specifier: ^6.4.1
-        version: 6.5.2
+        specifier: ^6.7.0
+        version: 6.7.0
       '@codemirror/view':
         specifier: ^6.28.3
         version: 6.38.6
@@ -1226,7 +1227,7 @@ packages:
     resolution: {integrity: sha512-fdfj6e6ZxZf8yrkMHUSJJir7OJkHkZKaOZGzLWIYp2PZ3jd+d+UjG8zVPqJF6d3bKxkhvXTPan/UZ1t7Bqm0gA==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
-      '@codemirror/state': ^6.0.0
+      '@codemirror/state': ^6.7.0
       '@codemirror/view': ^6.0.0
       '@lezer/common': ^1.0.0
 
@@ -1256,9 +1257,6 @@ packages:
 
   '@codemirror/search@6.5.6':
     resolution: {integrity: sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==}
-
-  '@codemirror/state@6.5.2':
-    resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
 
   '@codemirror/state@6.7.0':
     resolution: {integrity: sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==}
@@ -11826,10 +11824,10 @@ snapshots:
       exec-sh: 0.3.6
       minimist: 1.2.8
 
-  '@codemirror/autocomplete@6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(@lezer/common@1.2.1)':
+  '@codemirror/autocomplete@6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.7.0)(@codemirror/view@6.38.6)(@lezer/common@1.2.1)':
     dependencies:
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.1
 
@@ -11850,15 +11848,15 @@ snapshots:
   '@codemirror/commands@6.9.0':
     dependencies:
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.1
 
   '@codemirror/lang-css@6.2.1(@codemirror/view@6.38.6)':
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.7.0)(@codemirror/view@6.38.6)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.7.0
       '@lezer/common': 1.2.1
       '@lezer/css': 1.1.8
     transitivePeerDependencies:
@@ -11866,11 +11864,11 @@ snapshots:
 
   '@codemirror/lang-html@6.4.11':
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.7.0)(@codemirror/view@6.38.6)(@lezer/common@1.2.1)
       '@codemirror/lang-css': 6.2.1(@codemirror/view@6.38.6)
       '@codemirror/lang-javascript': 6.2.2
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.1
       '@lezer/css': 1.1.8
@@ -11878,10 +11876,10 @@ snapshots:
 
   '@codemirror/lang-javascript@6.2.2':
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.7.0)(@codemirror/view@6.38.6)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.2
       '@codemirror/lint': 6.8.1
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.1
       '@lezer/javascript': 1.4.17
@@ -11897,7 +11895,7 @@ snapshots:
 
   '@codemirror/language@6.10.2':
     dependencies:
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.38.6
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
@@ -11906,19 +11904,15 @@ snapshots:
 
   '@codemirror/lint@6.8.1':
     dependencies:
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.38.6
       crelt: 1.0.6
 
   '@codemirror/search@6.5.6':
     dependencies:
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.38.6
       crelt: 1.0.6
-
-  '@codemirror/state@6.5.2':
-    dependencies:
-      '@marijn/find-cluster-break': 1.0.2
 
   '@codemirror/state@6.7.0':
     dependencies:
@@ -11926,7 +11920,7 @@ snapshots:
 
   '@codemirror/view@6.38.6':
     dependencies:
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.7.0
       crelt: 1.0.6
       style-mod: 4.1.2
       w3c-keyname: 2.2.8
@@ -15898,12 +15892,12 @@ snapshots:
 
   codemirror@6.0.2(@lezer/common@1.2.1):
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.7.0)(@codemirror/view@6.38.6)(@lezer/common@1.2.1)
       '@codemirror/commands': 6.9.0
       '@codemirror/language': 6.10.2
       '@codemirror/lint': 6.8.1
       '@codemirror/search': 6.5.6
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.38.6
     transitivePeerDependencies:
       - '@lezer/common'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,8 +185,8 @@ importers:
         specifier: ^1.7.7
         version: 1.7.7
       '@lblod/ember-rdfa-editor':
-        specifier: 13.12.0
-        version: 13.12.0(eaaf812331dec1c55ca86d1378863615)
+        specifier: 13.15.1-dev.c5cefcf9a50117c08ff14a54a8b585d176b0654c
+        version: 13.15.1-dev.c5cefcf9a50117c08ff14a54a8b585d176b0654c(eaaf812331dec1c55ca86d1378863615)
       '@rdfjs/to-ntriples':
         specifier: ^3.0.1
         version: 3.0.1
@@ -1924,8 +1924,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lblod/ember-rdfa-editor@13.12.0':
-    resolution: {integrity: sha512-lqv46ZibcdV2OVw4fSDIWxtx9qJdxPESdUjvt8FK8oq0dIA597UNCWwkwN0GcuRoBviADjdftJNPoV6h/2jaFQ==}
+  '@lblod/ember-rdfa-editor@13.15.1-dev.c5cefcf9a50117c08ff14a54a8b585d176b0654c':
+    resolution: {integrity: sha512-uVeueCuJsSWTQxBz2jA62cl75iOZbEjg+lIwLSWEhGgO1rmc+vrwlRZpVfSbQovrFH09LD81Tb50NxE2t+jgWQ==}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.11.0 || ^4.2.1
       '@ember/test-helpers': ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
@@ -4679,12 +4679,6 @@ packages:
       miragejs:
         optional: true
 
-  ember-focus-trap@1.1.1:
-    resolution: {integrity: sha512-5tOWu6eV1UoNZE+P9Gl9lJXNrENZVCoOXi52ePb7JOrOZ3ckOk1OkPsFwR4Jym9VJ7vZ6S3Z3D8BrkFa2aCpYw==}
-    engines: {node: 12.* || >= 14}
-    peerDependencies:
-      ember-source: '>= 4.0.0'
-
   ember-focus-trap@2.0.0:
     resolution: {integrity: sha512-zGPvt934h08gxdemIZz29XRn4cdwn51UxlodKtDkiahGrEpiSQ6qH8nvXGwDhQvZsf8zGumnXqcmDYYA5oFomQ==}
     engines: {node: '>= 22.*', pnpm: '>= 10'}
@@ -5434,9 +5428,6 @@ packages:
 
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
-
-  focus-trap@6.9.4:
-    resolution: {integrity: sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==}
 
   focus-trap@8.2.1:
     resolution: {integrity: sha512-6CxwrrFRquH7pDXb1mWxudkU9LSfYBMRZutpgddb2o6iwCk7cIRrBhyY3c8SGKcmIKdeMTrGSNg4Bedh2RSF/w==}
@@ -8988,9 +8979,6 @@ packages:
   synckit@0.9.2:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
     engines: {node: ^14.18.0 || >=16.0.0}
-
-  tabbable@5.3.3:
-    resolution: {integrity: sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
@@ -13120,7 +13108,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lblod/ember-rdfa-editor@13.12.0(eaaf812331dec1c55ca86d1378863615)':
+  '@lblod/ember-rdfa-editor@13.15.1-dev.c5cefcf9a50117c08ff14a54a8b585d176b0654c(eaaf812331dec1c55ca86d1378863615)':
     dependencies:
       '@appuniversum/ember-appuniversum': 4.2.2(@babel/core@7.26.0)(@ember/test-helpers@3.3.1(@babel/core@7.26.0)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(tracked-built-ins@4.1.0(@babel/core@7.26.0))
       '@codemirror/commands': 6.10.3
@@ -13151,7 +13139,7 @@ snapshots:
       ember-cli-babel: 8.3.1(@babel/core@7.26.0)
       ember-cli-htmlbars: 6.3.0
       ember-concurrency: 4.0.3(@babel/core@7.26.0)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))
-      ember-focus-trap: 1.1.1(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))
+      ember-focus-trap: 2.0.0(@babel/core@7.26.0)
       ember-headless-form: 1.1.1(@babel/core@7.26.0)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(eslint@8.57.1)
       ember-headless-form-yup: 1.0.0(ember-headless-form@1.1.1(@babel/core@7.26.0)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(@types/ember__array@4.0.10(@babel/core@7.26.0))(@types/ember__component@4.0.22(@babel/core@7.26.0))(@types/ember__controller@4.0.12(@babel/core@7.26.0))(@types/ember__object@4.0.12(@babel/core@7.26.0))(@types/ember__routing@4.0.22(@babel/core@7.26.0))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))))(@glint/template@1.7.7)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(eslint@8.57.1))(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1))(yup@1.7.1)
       ember-intl: 7.0.3(@glint/template@1.7.7)(typescript@5.7.3)(webpack@5.97.1)
@@ -17271,14 +17259,6 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  ember-focus-trap@1.1.1(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1)):
-    dependencies:
-      '@embroider/addon-shim': 1.10.2
-      ember-source: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.97.1)
-      focus-trap: 6.9.4
-    transitivePeerDependencies:
-      - supports-color
-
   ember-focus-trap@2.0.0(@babel/core@7.26.0):
     dependencies:
       '@embroider/addon-shim': 1.10.2
@@ -18553,10 +18533,6 @@ snapshots:
       rimraf: 3.0.2
 
   flatted@3.3.1: {}
-
-  focus-trap@6.9.4:
-    dependencies:
-      tabbable: 5.3.3
 
   focus-trap@8.2.1:
     dependencies:
@@ -22745,8 +22721,6 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.1.1
       tslib: 2.6.3
-
-  tabbable@5.3.3: {}
 
   tabbable@6.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 overrides:
   'prosemirror-model': '^1.25.9'
+  '@codemirror/state': '^6.7.0'

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -169,7 +169,7 @@ import {
   legacyCodelistView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/legacy-codelist';
 import ContextualActionsContainer from '@lblod/ember-rdfa-editor/components/plugins/contextual-actions/container';
-import { getContextualActionGroups as placeDescriptionActionGroups } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions';
+import { getPlaceDescriptionActionGroups } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions/place-description';
 import { getContextualActionGroups as locationActionsGroups } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/contextual-actions';
 import { slashCommandsPlugin } from '@lblod/ember-rdfa-editor/plugins/slash-commands/index';
 import Owner from '@ember/owner';
@@ -246,7 +246,7 @@ export default class BesluitSampleController extends Controller {
   };
 
   contextualGroupGetters = [
-    placeDescriptionActionGroups(this.locationOptions),
+    getPlaceDescriptionActionGroups(this.locationOptions),
     locationActionsGroups(),
   ];
 

--- a/tests/dummy/app/controllers/besluit-sample.ts
+++ b/tests/dummy/app/controllers/besluit-sample.ts
@@ -175,6 +175,7 @@ import { slashCommandsPlugin } from '@lblod/ember-rdfa-editor/plugins/slash-comm
 import Owner from '@ember/owner';
 import { locationModalsPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin';
 import { emptyBlockPlaceholder } from '@lblod/ember-rdfa-editor/plugins/empty-block-placeholder';
+import { getCodelistActionGroups } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions/codelist';
 
 export default class BesluitSampleController extends Controller {
   queryParams = ['editableNodes'];
@@ -248,6 +249,7 @@ export default class BesluitSampleController extends Controller {
   contextualGroupGetters = [
     getPlaceDescriptionActionGroups(this.locationOptions),
     locationActionsGroups(),
+    getCodelistActionGroups(this.codelistOptions),
   ];
 
   get schema() {

--- a/tests/dummy/app/controllers/regulatory-statement-sample.ts
+++ b/tests/dummy/app/controllers/regulatory-statement-sample.ts
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { tracked } from 'tracked-built-ins';
 import { getOwner } from '@ember/owner';
 import { service } from '@ember/service';
+import Owner from '@ember/owner';
 import IntlService from 'ember-intl/services/intl';
 import { ComponentLike } from '@glint/template';
 import { EditorState, PNode, SayController } from '@lblod/ember-rdfa-editor';
@@ -55,6 +56,8 @@ import {
   paragraph as paragraphInvisible,
 } from '@lblod/ember-rdfa-editor/plugins/invisibles';
 import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
+import { slashCommandsPlugin } from '@lblod/ember-rdfa-editor/plugins/slash-commands/index';
+import ContextualActionsContainer from '@lblod/ember-rdfa-editor/components/plugins/contextual-actions/container';
 import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
 import {
   address,
@@ -146,6 +149,9 @@ import {
   legacy_codelist,
   legacyCodelistView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables/legacy-codelist';
+import { getPlaceDescriptionActionGroups } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions/place-description';
+import { getCodelistActionGroups } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/contextual-actions/codelist';
+import { getContextualActionGroups as locationActionsGroups } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/contextual-actions';
 
 export default class RegulatoryStatementSampleController extends Controller {
   queryParams = ['editableNodes'];
@@ -158,10 +164,11 @@ export default class RegulatoryStatementSampleController extends Controller {
   ImportedResourceLinkerCard = ImportedResourceLinkerCard;
   ExternalTripleEditorCard = ExternalTripleEditorCard;
   RelationshipEditorCard = RelationshipEditorCard;
-
   SnippetInsert = SnippetInsertRdfaComponent;
   SnippetListSelect = SnippetListSelect;
   StructureControlCard = StructureControlCardComponent;
+  ContextualActionsContainer = ContextualActionsContainer;
+
   @tracked editableNodes = false;
 
   @action
@@ -173,6 +180,33 @@ export default class RegulatoryStatementSampleController extends Controller {
   @service declare intl: IntlService;
   @tracked controller?: SayController;
   @tracked citationPlugin = citationPlugin(this.config.citation);
+  @tracked plugins: Plugin[];
+
+  constructor(owner: Owner) {
+    super(owner);
+    this.plugins = [
+      firefoxCursorFix(),
+      chromeHacksPlugin(),
+      lastKeyPressedPlugin,
+      tablePlugin,
+      tableKeymap,
+      linkPasteHandler(this.schema.nodes.link),
+      createInvisiblesPlugin(
+        [hardBreak, paragraphInvisible, headingInvisible],
+        {
+          shouldShowInvisibles: false,
+        },
+      ),
+      emberApplication({ application: unwrap(getOwner(this)) }),
+      editableNodePlugin(),
+      recreateUuidsOnPaste,
+      variableAutofillerPlugin(this.config.autofilledVariable),
+      slashCommandsPlugin({
+        intl: this.intl,
+        getGroups: this.contextualGroupGetters,
+      }),
+    ];
+  }
 
   prefixes = {
     ext: 'http://mu.semte.ch/vocabularies/ext/',
@@ -180,6 +214,12 @@ export default class RegulatoryStatementSampleController extends Controller {
     dct: 'http://purl.org/dc/terms/',
     say: 'https://say.data.gift/ns/',
   };
+
+  contextualGroupGetters = [
+    getPlaceDescriptionActionGroups(this.locationOptions),
+    locationActionsGroups(),
+    getCodelistActionGroups(this.codelistOptions),
+  ];
 
   schema = new Schema({
     nodes: {
@@ -399,21 +439,6 @@ export default class RegulatoryStatementSampleController extends Controller {
       address: addressView(controller),
     };
   };
-  @tracked plugins: Plugin[] = [
-    firefoxCursorFix(),
-    chromeHacksPlugin(),
-    lastKeyPressedPlugin,
-    tablePlugin,
-    tableKeymap,
-    linkPasteHandler(this.schema.nodes.link),
-    createInvisiblesPlugin([hardBreak, paragraphInvisible, headingInvisible], {
-      shouldShowInvisibles: false,
-    }),
-    emberApplication({ application: unwrap(getOwner(this)) }),
-    editableNodePlugin(),
-    recreateUuidsOnPaste,
-    variableAutofillerPlugin(this.config.autofilledVariable),
-  ];
 
   @action
   setPrefixes(element: HTMLElement) {

--- a/tests/dummy/app/templates/regulatory-statement-sample.hbs
+++ b/tests/dummy/app/templates/regulatory-statement-sample.hbs
@@ -80,6 +80,13 @@
             @nodeViews={{this.nodeViews}}
             @rdfaEditorInit={{this.rdfaEditorInit}}
           />
+          {{#if this.controller}}
+            <this.ContextualActionsContainer
+              @controller={{this.controller}}
+              @getActions={{this.contextualActionGetters}}
+              @getGroups={{this.contextualGroupGetters}}
+            />
+          {{/if}}
         </:default>
         <:sidebarRight as |container|>
           <Sidebar as |Sidebar|>


### PR DESCRIPTION
### Overview
When properly configured, codelist variables should now have contextual actions available, which support single and multi select variables.

Review of the changes to place description context actions can be reviewed by looking at changes before the commit "Add variable-plugin contextual-actions index for backwards compatibility".

##### connected issues and PRs:

- Part of [binnenland.atlassian.net/browse/GN-6010](https://binnenland.atlassian.net/browse/GN-6010)
- Uses https://github.com/lblod/ember-rdfa-editor/pull/1398
- Design: [figma.com/design/C4QjSLpfzyLhwlQikhMVsW/GN-navigation](https://www.figma.com/design/C4QjSLpfzyLhwlQikhMVsW/GN-navigation)

### Setup
Needs to be linked to the editor PR which adds support for multi-selection.

### How to test/reproduce
- Editing codelist (including marcode) choices should be fully possible using context actions.
- The existing context actions should behave the same as they did previously.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check if dummy app is correctly updated
- [ ] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
